### PR TITLE
output all build artifacts to external site path's dist folder

### DIFF
--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -6,7 +6,6 @@ if test -f ".env"; then
   export $(cat .env | xargs)
 fi
 
-npm run build:webpack
 if [[ -z "${EXTERNAL_SITE_PATH}" ]]; then
   echo "EXTERNAL_SITE_PATH not set"
   exit 1
@@ -14,6 +13,11 @@ else
   # Prep our external site to use this theme
   /bin/bash build_scripts/prep_external_site.sh
   # Build the site
+  rm -rf $EXTERNAL_SITE_PATH/dist
+  GIT_HASH=`git rev-parse HEAD`
+  npm run build:webpack --  --output-path=$EXTERNAL_SITE_PATH/dist
   cd $EXTERNAL_SITE_PATH
-  hugo -d $PWD/dist -v
+  hugo -d dist -v
+  mkdir -p dist/static 
+  printf $GIT_HASH >> dist/static/hash.txt
 fi

--- a/build_scripts/prep_external_site.sh
+++ b/build_scripts/prep_external_site.sh
@@ -16,7 +16,7 @@ else
     mv go.mod go.mod.bak
   fi
   touch go.mod
-  printf "module github.com/mitodl/ocw-website\n\n" >> go.mod
+  printf "module github.com/mitodl/ocw-www\n\n" >> go.mod
   printf "go 1.16\n\n" >> go.mod
   printf "replace github.com/mitodl/ocw-hugo-themes/base-theme => $THEME_DIR/base-theme\n\n" >> go.mod
   printf "replace github.com/mitodl/ocw-hugo-themes/www => $THEME_DIR/www\n\n" >> go.mod

--- a/build_scripts/prep_external_site.sh
+++ b/build_scripts/prep_external_site.sh
@@ -10,8 +10,17 @@ if [[ -z "${EXTERNAL_SITE_PATH}" ]]; then
   echo "EXTERNAL_SITE_PATH not set"
   exit 1
 else
+  THEME_DIR=$(pwd)
   cd $EXTERNAL_SITE_PATH
-  hugo mod tidy
+  if test -f "go.mod"; then
+    mv go.mod go.mod.bak
+  fi
+  touch go.mod
+  printf "module github.com/mitodl/ocw-website\n\n" >> go.mod
+  printf "go 1.16\n\n" >> go.mod
+  printf "replace github.com/mitodl/ocw-hugo-themes/base-theme => $THEME_DIR/base-theme\n\n" >> go.mod
+  printf "replace github.com/mitodl/ocw-hugo-themes/www => $THEME_DIR/www\n\n" >> go.mod
+  printf "replace github.com/mitodl/ocw-hugo-themes/course => $THEME_DIR/course\n\n" >> go.mod
   hugo mod clean
   hugo mod get -u
 fi

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start:course:hugo": "./build_scripts/start_course.sh",
     "start:course:webpack": "webpack-dev-server --config base-theme/assets/webpack/webpack.dev.js --hot --host 0.0.0.0",
     "prebuild": "rimraf dist",
-    "build": "./build_scripts/build.sh && npm run build:githash",
+    "build": "./build_scripts/build.sh",
     "build:githash": "mkdir -p dist/static && git rev-parse HEAD > dist/static/hash.txt",
     "build:hugo": "hugo -d ../dist -v",
     "build:hugo:debug": "hugo -d ../dist -v --templateMetrics --debug",


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/4

#### What's this PR do?
Currently, the `build.sh` script deposits webpack artifacts at `base-theme/assets/dist` relative to `ocw-hugo-themes`, the git hash text file to `dist/static/` relative to `ocw-hugo-themes` which is not ideal.  These artifacts should all be deposited in the `dist` folder of the site being built.  This PR modifies the `build.sh` build script to output all build artifacts to the `dist` folder relative to the `EXTERNAL_SITE_PATH` variable.

There has also been some confusion surrounding linking Hugo sites to a local copy of the `ocw-hugo-themes` repo, so `prep_external_sites.sh` was modified to simplify this by simply backing up the `go.mod` file if it exists and then write one in that links the site to the local copy of your theme repo.

#### How should this be manually tested?
 - Clone [`ocw-www`](https://github.com/mitodl/ocw-www) on the `cg/content-only` branch and configure the `go.mod` file to point at the `ocw-hugo-themes` repo by adding the following lines:
 ```
replace github.com/mitodl/ocw-hugo-themes/base-theme => /path/to/ocw-hugo-themes/base-theme

replace github.com/mitodl/ocw-hugo-themes/www => /path/to/Code/ocw-hugo-themes/www
 ```
  - In your `.env` file in `ocw-hugo-themes`, set `EXTERNAL_SITE_PATH` to your path to `ocw-www`
  - Run `npm run build`
  - Verify that you have a `dist` folder under `ocw-www` containing:
    - Webpack build artifacts
    - Hugo build artifacts
    - Git hash text file

