### PR TITLE
Disable collapse for instructors list

### DIFF
--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -18,7 +18,7 @@
       <tr>
         <td class="pl-0">{{ if eq (len $courseData.instructors) 1 }}Instructor{{ else }}Instructors{{ end }}:</td>
         <td>
-          {{ partial "partial_collapse_list.html" (dict "list" $courseData.instructors "id" "instructors" "key" "instructor" "klass" "course-info-instructor") }}
+          {{ partial "partial_collapse_list.html" (dict "list" $courseData.instructors "id" "instructors" "key" "instructor" "klass" "course-info-instructor" "showCollapse" .inPanel) }}
         </td>
       </tr>
       <tr>

--- a/course/layouts/partials/partial_collapse_list.html
+++ b/course/layouts/partials/partial_collapse_list.html
@@ -1,7 +1,8 @@
 {{ $params := . }}
 {{ $className := .klass | default "coming-soon" }}
 {{ $useLinks := .useLinks | default true }}
-{{ if gt (len .list) 4 }}
+{{ $showCollapse := .showCollapse | default true }}
+{{ if and (gt (len .list) 4) $showCollapse }}
 <div class="position-relative pr-3">
   <a class="partial-collapse-toggle-link" href="#partial-collapse-container_{{ .id }}" data-toggle="collapse"
     aria-controls="partial-collapse-container_{{ .id }}" aria-expanded="false">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-course-hugo-theme/issues/60

#### What's this PR do?
Disables collapse for instructors list when viewing course info on course home page

#### How should this be manually tested?
View `8-01sc-classical-mechanics-fall-2016` by setting the course id in `.env` and running `npm run start:course`. Look at the instructors list. It should show 5 instructors without an option to toggle. Click on "Assignments" on the sidebar to go to the assignments page. You should see the course info on the right side, and the instructors list should show an option to expand there.

The changes should look roughly the same on mobile as they do on desktop: no expander for instructors on the course home page, expander for instructors elsewhere.