### PR TITLE
remove default salutation from search

### DIFF
--- a/www/assets/js/components/SearchResult.js
+++ b/www/assets/js/components/SearchResult.js
@@ -117,7 +117,7 @@ export function LearningResourceDisplay(props) {
                     text: `"${instructor}"`
                   })}`}
                 >
-                  {`Prof. ${instructor}`}{" "}
+                  {instructor}{" "}
                 </a>
               ))}
             </Subtitle>

--- a/www/assets/js/components/SearchResult.test.js
+++ b/www/assets/js/components/SearchResult.test.js
@@ -42,7 +42,7 @@ describe("SearchResult component", () => {
         .find(".subtitles")
         .first()
         .text()
-    ).toContain(`Prof. ${object.instructors[0]}`)
+    ).toContain(object.instructors[0])
     expect(
       wrapper
         .find(".cover-image")


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/8

#### What's this PR do?
This pr removes the default Prof. salutation

#### How should this be manually tested?
Run the search. You should no longer see salutations for instructors.

Checkout `ab/fix-salutation` in open and run

```
from course_catalog.api import *

sync_ocw_courses(course_prefixes=["PROD/8/8.01/Fall_2016/8-01sc-classical-mechanics-fall-2016/"], blocklist=[], force_overwrite=True, upload_to_s3=False)
```
in open

Go to the search and search for "Classical Mechanics"

Verify that the instructors are
```
Prof. Deepto Chakrabarty, Dr. Peter Dourmashkin, Prof. Anna Frebel, Dr. Michelle Tomasik, Prof. Vladan Vuletic
```

Alternatively if you set `SEARCH_API_URL=https://discussions-rc.odl.mit.edu/api/v0/search/` you should see salutations for only "Classical Mechanics"
