### PR TITLE
check if site.BaseURL is set before trying to use it

### DIFF
--- a/base-theme/layouts/partials/site_root_url.html
+++ b/base-theme/layouts/partials/site_root_url.html
@@ -6,5 +6,5 @@
     {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
   {{- end -}}
 {{- else -}}
-  {{- . -}}
+  {{- printf "/%s" . -}}
 {{- end -}}

--- a/base-theme/layouts/partials/site_root_url.html
+++ b/base-theme/layouts/partials/site_root_url.html
@@ -1,4 +1,4 @@
-{{- if isset site "BaseURL" -}}
+{{- if not (eq site.BaseURL "") -}}
   {{- $baseUrl := urls.Parse site.BaseURL -}}
   {{- if or (eq $baseUrl.Scheme nil) (eq $baseUrl.Host nil) -}}
     {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
@@ -6,5 +6,5 @@
     {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
   {{- end -}}
 {{- else -}}
-{{- . -}}
+  {{- . -}}
 {{- end -}}

--- a/base-theme/layouts/partials/site_root_url.html
+++ b/base-theme/layouts/partials/site_root_url.html
@@ -1,6 +1,10 @@
-{{- $baseUrl := urls.Parse site.BaseURL -}}
-{{- if or (eq $baseUrl.Scheme nil) (eq $baseUrl.Host nil) -}}
+{{- if isset site "BaseURL" -}}
+  {{- $baseUrl := urls.Parse site.BaseURL -}}
+  {{- if or (eq $baseUrl.Scheme nil) (eq $baseUrl.Host nil) -}}
     {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
-{{- else -}}
+  {{- else -}}
     {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
+  {{- end -}}
+{{- else -}}
+{{- . -}}
 {{- end -}}

--- a/base-theme/layouts/partials/site_root_url.html
+++ b/base-theme/layouts/partials/site_root_url.html
@@ -1,17 +1,15 @@
-{{- if and (not (eq site.BaseURL "")) (not (hasPrefix site.BaseURL "/")) -}}
-  {{- if hasPrefix site.BaseURL "http" -}}
-    {{/* A fully qualified BaseURL is set, so disassemble it and construct the root URL */}}
-    {{- $baseUrl := urls.Parse site.BaseURL -}}
-    {{- if or (eq $baseUrl.Scheme nil) (eq $baseUrl.Host nil) -}}
-      {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
-    {{- else -}}
-      {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
-    {{- end -}}
-  {{- else -}}
-    {{/* A BaseURL value that doesn't start with "/" or "http" is not valid */}}
-    {{- errorf "Invalid BaseURL: %q" site.BaseURL -}}
-  {{- end -}}
-{{- else -}}
+{{- if or (eq site.BaseURL "") (hasPrefix site.BaseURL "/") -}}
   {{/* No BaseURL is set or it is relative to the root, so simply prefix what's passed in with "/" */}}
   {{- printf "/%s" . -}}
+{{- else if hasPrefix site.BaseURL "http" -}}
+  {{/* A fully qualified BaseURL is set, so disassemble it and construct the root URL */}}
+  {{- $baseUrl := urls.Parse site.BaseURL -}}
+  {{- if or (eq $baseUrl.Scheme nil) (eq $baseUrl.Host nil) -}}
+    {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
+  {{- else -}}
+    {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
+  {{- end -}}
+{{- else -}}
+  {{/* A BaseURL value that doesn't start with "/" or "http" is not valid */}}
+  {{- errorf "Invalid BaseURL: %q" site.BaseURL -}}
 {{- end -}}

--- a/base-theme/layouts/partials/site_root_url.html
+++ b/base-theme/layouts/partials/site_root_url.html
@@ -1,10 +1,17 @@
-{{- if not (eq site.BaseURL "") -}}
-  {{- $baseUrl := urls.Parse site.BaseURL -}}
-  {{- if or (eq $baseUrl.Scheme nil) (eq $baseUrl.Host nil) -}}
-    {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
+{{- if and (not (eq site.BaseURL "")) (not (hasPrefix site.BaseURL "/")) -}}
+  {{- if hasPrefix site.BaseURL "http" -}}
+    {{/* A fully qualified BaseURL is set, so disassemble it and construct the root URL */}}
+    {{- $baseUrl := urls.Parse site.BaseURL -}}
+    {{- if or (eq $baseUrl.Scheme nil) (eq $baseUrl.Host nil) -}}
+      {{- printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) (strings.TrimPrefix "/" .) -}}
+    {{- else -}}
+      {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
+    {{- end -}}
   {{- else -}}
-    {{- printf "%s://%s/%s" $baseUrl.Scheme $baseUrl.Host (strings.TrimPrefix "/" .) -}}
+    {{/* A BaseURL value that doesn't start with "/" or "http" is not valid */}}
+    {{- errorf "Invalid BaseURL: %q" site.BaseURL -}}
   {{- end -}}
 {{- else -}}
+  {{/* No BaseURL is set or it is relative to the root, so simply prefix what's passed in with "/" */}}
   {{- printf "/%s" . -}}
 {{- end -}}

--- a/base-theme/layouts/partials/site_root_url.html
+++ b/base-theme/layouts/partials/site_root_url.html
@@ -1,5 +1,8 @@
-{{- if or (eq site.BaseURL "") (hasPrefix site.BaseURL "/") -}}
-  {{/* No BaseURL is set or it is relative to the root, so simply prefix what's passed in with "/" */}}
+{{- if eq site.BaseURL "" -}}
+  {{/* No BaseURL is defined */}}
+  {{- errorf "No BaseURL has been defined, please check our configuration" -}}
+{{- else if hasPrefix site.BaseURL "/" -}}
+  {{/* BaseURL is relative to the root, so simply prefix what's passed in with "/" */}}
   {{- printf "/%s" (strings.TrimPrefix "/" .) -}}
 {{- else if hasPrefix site.BaseURL "http" -}}
   {{/* A fully qualified BaseURL is set, so disassemble it and construct the root URL */}}

--- a/base-theme/layouts/partials/site_root_url.html
+++ b/base-theme/layouts/partials/site_root_url.html
@@ -1,6 +1,6 @@
 {{- if or (eq site.BaseURL "") (hasPrefix site.BaseURL "/") -}}
   {{/* No BaseURL is set or it is relative to the root, so simply prefix what's passed in with "/" */}}
-  {{- printf "/%s" . -}}
+  {{- printf "/%s" (strings.TrimPrefix "/" .) -}}
 {{- else if hasPrefix site.BaseURL "http" -}}
   {{/* A fully qualified BaseURL is set, so disassemble it and construct the root URL */}}
   {{- $baseUrl := urls.Parse site.BaseURL -}}

--- a/base-theme/layouts/partials/webpack_url.html
+++ b/base-theme/layouts/partials/webpack_url.html
@@ -1,4 +1,4 @@
-{{- if or site.IsServer (isset site "BaseURL") -}}
+{{- if or site.IsServer (not (eq site.BaseURL "")) -}}
   {{- if or site.IsServer (in site.BaseURL ":3000") -}}
     {{- if hasPrefix . "/" -}}
       {{- print "http://localhost:3001" . -}}

--- a/base-theme/layouts/partials/webpack_url.html
+++ b/base-theme/layouts/partials/webpack_url.html
@@ -1,9 +1,13 @@
-{{- if or site.IsServer (in site.BaseURL ":3000") -}}
+{{- if or site.IsServer (isset site "BaseURL") -}}
+  {{- if or site.IsServer (in site.BaseURL ":3000") -}}
     {{- if hasPrefix . "/" -}}
-        {{- print "http://localhost:3001" . -}}
+      {{- print "http://localhost:3001" . -}}
     {{- else -}}
-        {{- print "http://localhost:3001/" . -}}
+      {{- print "http://localhost:3001/" . -}}
     {{- end -}}
-{{- else -}}
+  {{- else -}}
     {{- partial "site_root_url.html" . -}}
+  {{- end -}}
+{{- else -}}
+  {{- partial "site_root_url.html" . -}}
 {{- end -}}

--- a/example_configs/example.base.config.toml
+++ b/example_configs/example.base.config.toml
@@ -1,2 +1,3 @@
+baseUrl = "/"
 languageCode = "en-us"
 title = "MIT OpenCourseWare"

--- a/example_configs/example.base.config.toml
+++ b/example_configs/example.base.config.toml
@@ -1,3 +1,2 @@
-baseURL = "http://localhost:3000/"
 languageCode = "en-us"
 title = "MIT OpenCourseWare"

--- a/example_configs/example.course.config.toml
+++ b/example_configs/example.course.config.toml
@@ -1,3 +1,4 @@
+baseUrl = "/"
 languageCode = "en-us"
 title = "MIT OpenCourseWare"
 

--- a/example_configs/example.course.config.toml
+++ b/example_configs/example.course.config.toml
@@ -1,4 +1,3 @@
-baseURL = "http://localhost:3000/"
 languageCode = "en-us"
 title = "MIT OpenCourseWare"
 

--- a/example_configs/example.www.config.toml
+++ b/example_configs/example.www.config.toml
@@ -1,3 +1,4 @@
+baseUrl = "/"
 languageCode = "en-us"
 title = "MIT OpenCourseWare"
 

--- a/example_configs/example.www.config.toml
+++ b/example_configs/example.www.config.toml
@@ -1,4 +1,3 @@
-baseURL = "http://localhost:3000/"
 languageCode = "en-us"
 title = "MIT OpenCourseWare"
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/17

#### What's this PR do?
This is related to the recent work we have done to separate "theme" and "content."  A default `baseUrl` of `http://localhost:3000` was inadvertently set in the default config for `ocw-www`, causing all builds with `baseUrl` unset to assume this was the value. 
 If you remove this value, links to webpack resources do not render properly at all.  This PR adds some conditional checks to the `webpack_url.html` and `site_root_url.html` to make sure that `site.BaseURL` is set before using it.

#### How should this be manually tested?
 - Clone `ocw-www` and check out the `cg/remove-dev-baseurl` branch
 - Configure `ocw-hugo-themes` to point at your local copy of `ocw-www` by setting the path to it in `EXTERNAL_SITE_PATH`
 - Run `npm run build` and inspect the output (`ocw-www/dist`)
 - Ensure that Webpack CSS / JS in `index.html` is properly linked

### Additional info
This `ocw-www` PR is related and defaults the `baseUrl` to `/`: https://github.com/mitodl/ocw-www/pull/112
