### PR TITLE
Accessibility changes for carousel

### DIFF
--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -458,7 +458,24 @@ $promo-carousel-height: 200px;
 
 .promo-carousel {
   max-height: $promo-carousel-height;
+  margin: 0 auto;
   margin-bottom: 30px;
+  max-width: $max-content-width;
+
+  a {
+    cursor: pointer;
+    .material-icons {
+      font-size: 60px;
+      font-weight: 200;
+      color: $text_gray;
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    .carousel-item {
+      transition-property: none !important;
+    }
+  }
 
   .carousel-indicators {
     margin-bottom: 0;

--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -12,7 +12,7 @@
     {{ $isMobile := (eq $itemsInCarousel 1) }}
     {{ $carouselId := (printf "new-course-carousel-%v" $breakpoint) }}
     <div class="{{ $breakpointVisibilityClass }}">
-      <div id="{{ $carouselId }}" class="carousel slide">
+      <div id="{{ $carouselId }}" class="carousel slide" data-interval="false">
         <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
           <h3>New Courses</h3>
           {{ partial "carousel_controls.html" $carouselId }}

--- a/www/layouts/partials/promo-carousel.html
+++ b/www/layouts/partials/promo-carousel.html
@@ -1,27 +1,38 @@
 {{ $pages := .Site.RegularPages }}
 {{ $promos := where $pages "Type" "==" "promos" }}
-<div id="carouselExampleIndicators" class="promo-carousel pt-2 carousel slide" data-ride="carousel">
+{{ $carouselId := "promo-carousel" }}
+<div id="{{ $carouselId }}" class="promo-carousel pt-2 carousel carousel-fade slide" data-interval="false">
   <ol class="carousel-indicators">
     {{ range $index, $promo := $promos }}
-    <li data-target="#carouselExampleIndicators" data-slide-to="{{ $index }}" class="{{ if eq $index 0}}active{{ end }}"></li>
+    <li data-target="#{{ $carouselId }}" data-slide-to="{{ $index }}" class="{{ if eq $index 0}}active{{ end }}" />
     {{ end }}
   </ol>
-  <div class="carousel-inner h-100">
-    {{ range $index, $promo := $promos }}
-    <div class="carousel-item {{ if eq $index 0}}active{{ end }}">
-      <div class="carousel-content d-flex m-auto align-items-center">
-        <div class="img-container p-2">
-        <img class="promo-image img-fluid" src="{{ $promo.Params.image }}" />
-        </div>
-        <div class="promo-info d-flex flex-column px-2 px-md-4 align-items-start h-100">
-          <h2>{{ $promo.Params.title }}</h2>
-          <h3>{{ $promo.Params.subtitle }}</h3>
-          <a class="btn px-3 orange-link font-weight-bold" href="{{ $promo.Params.link_url }}">
-            {{ $promo.Params.link_title }}
-          </a>
+  <div class="d-flex flex-direction-row align-items-center">
+    <a href="#{{ $carouselId }}" role="button" data-slide="prev" class="bg-white prev">
+      <span class="material-icons" aria-hidden="true">keyboard_arrow_left</span>
+      <span class="sr-only">Previous</span>
+    </a>
+    <div class="carousel-inner h-100">
+      {{ range $index, $promo := $promos }}
+      <div class="carousel-item {{ if eq $index 0}}active{{ end }}">
+        <div class="carousel-content d-flex m-auto align-items-center bg-white">
+          <div class="img-container p-2">
+            <img class="promo-image img-fluid" src="{{ $promo.Params.image }}" alt="{{ $promo.Params.image_alt }}" />
+          </div>
+          <div class="promo-info d-flex flex-column px-2 px-md-4 align-items-start h-100">
+            <h2>{{ $promo.Params.title }}</h2>
+            <h3>{{ $promo.Params.subtitle }}</h3>
+            <a class="btn px-3 orange-link font-weight-bold" href="{{ $promo.Params.link_url }}">
+              {{ $promo.Params.link_title }}
+            </a>
+          </div>
         </div>
       </div>
+      {{ end }}
     </div>
-    {{ end }}
+    <a href="#{{ $carouselId }}" role="button" data-slide="next" class="bg-white next">
+      <span class="material-icons" aria-hidden="true">keyboard_arrow_right</span>
+      <span class="sr-only">Next</span>
+    </a>
   </div>
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-www/issues/100

#### What's this PR do?
Makes some accessibility changes to the carousel:
 - fade in and out instead of scroll
 - left and right buttons at the side
 - no autoscrolling

#### How should this be manually tested?
Try out the promo carousel on the homepage. You may want to checkout https://github.com/mitodl/ocw-www/pull/115 for ocw-www first to have alt text for the images. 
 - Nothing should animate automatically. When you trigger an animation, it should end after a couple seconds and stay inanimate until you trigger it explicitly again. 
 - You should see a fade transition effect instead of seeing cards animate to the side.
 - You should be able to tab between the left and right buttons and press enter to activate them. You should not be able to activate the carousel indicator buttons at the bottom with a keyboard. I wasn't able to get this to work effectively, and the bootstrap example code does not do so either.
 - On mobile, you should be able to swipe the carousel and see a similar fade transition. It is awkward but you can do this in the responsive view in Firefox, and there's likely a similar feature in Chrome.
 - Mobile transitions are turned off so you should not see a fade at all. It should just instantly switch to the next or previous card.

#### Screenshots
Desktop:
![Screenshot from 2021-05-11 09-25-35](https://user-images.githubusercontent.com/863262/117880881-99229e80-b276-11eb-8aa6-df5961d8ee1f.png)

Mobile:
![Screenshot from 2021-05-11 09-25-19](https://user-images.githubusercontent.com/863262/117880904-a049ac80-b276-11eb-8af0-a5f3610e846f.png)

