### PR TITLE
restore search icon

### DIFF
--- a/base-theme/assets/css/header.scss
+++ b/base-theme/assets/css/header.scss
@@ -47,6 +47,16 @@
     .right {
       justify-content: flex-end;
 
+      .search-icon {
+        display: flex;
+        text-decoration: none;
+        color: $orange;
+
+        .material-icons {
+          font-size: 1.75rem;
+        }
+      }
+
       a {
         font-size: 14px;
         text-transform: uppercase;

--- a/base-theme/layouts/partials/header.html
+++ b/base-theme/layouts/partials/header.html
@@ -22,6 +22,7 @@
       </div>
     </div>
     <div class="right">
+      {{ block "extraheader" . }}{{ end }}
       <a class="btn orange-link py-2 px-3" href="https://giving.mit.edu/give/to/ocw/?utm_source=ocw&utm_medium=homepage_banner&utm_campaign=nextgen_home">
         <div class="text-white font-weight-bold w-100">Give now</div>
       </a>

--- a/course/layouts/partials/extraheader.html
+++ b/course/layouts/partials/extraheader.html
@@ -1,0 +1,5 @@
+{{ define "extraheader" }}
+<a class="search-icon pr-6" href="/search">
+  <i class="material-icons">search</i>
+</a>
+{{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/32

#### What's this PR do?
In porting over `ocw-www` and `ocw-course-hugo-theme` into this repo, the search icon at the top of course pages was lost.  This PR adds it back in.

#### How should this be manually tested?
 - Spin up any course using `npm run start:course` (if you're unsure how to do this, check out the readme)
 - Verify that the search icon appears in the header and the link points to `/search` (it will not work when you click it locally)
 - Start up the OCW home page using `npm start` and verify that the search icon does not appear on the home page or the search page

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/117874266-bf444080-b26e-11eb-908a-311e070ceee9.png)

