### PR TITLE
fix responsive tables

### DIFF
--- a/course/assets/css/tables.scss
+++ b/course/assets/css/tables.scss
@@ -40,7 +40,7 @@
   }
 }
 
-#main-content .table {
+#main-content table {
   thead th,
   td {
     vertical-align: middle !important;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/38

#### What's this PR do?
At some point, our responsive table styling was broken. Previously, it had been applied to elements with a class of table using `.table`, which should be applied by bootstrap. This doesn't seem to work anymore, and it makes more sense to apply to all table elements anyway by specifying `table`

#### How should this be manually tested?
 - Spin up any course with a table, like `18-s191-introduction-to-computational-thinking-fall-2020`'s course materials section
 - View the table and reduce the size of your browser window to mobile size, verify that the mobile style is applied.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/118157784-fc344280-b3e8-11eb-9315-a88636c51365.png)
![image](https://user-images.githubusercontent.com/12089658/118157854-0f471280-b3e9-11eb-95aa-5b666cb5eed2.png)

