### PR TITLE
fix course info table

### DIFF
--- a/course/assets/css/tables.scss
+++ b/course/assets/css/tables.scss
@@ -40,7 +40,7 @@
   }
 }
 
-#main-content table {
+#main-content table:not(#course-info-table) {
   thead th,
   td {
     vertical-align: middle !important;

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -14,7 +14,7 @@
   </div>
   <div class="position-relative">
     <div class="opaque-layer"></div>
-    <table class="table table-borderless {{ if $inPanel }}border-bottom-light{{ end }} mb-2">
+    <table id="course-info-table" class="table table-borderless {{ if $inPanel }}border-bottom-light{{ end }} mb-2">
       <tr>
         <td class="pl-0">{{ if eq (len $courseData.instructors) 1 }}Instructor{{ else }}Instructors{{ end }}:</td>
         <td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/43

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/24, some CSS / JS was added to force the mobile table style on tables that exceed the width of the main content area.  I mistakenly thought that https://github.com/mitodl/ocw-hugo-themes/issues/43 would be fixed by this because of another bug that was present.  This PR forces the course info table to never have the `mobile-table` class applied to it.

#### How should this be manually tested?
 - Spin up any course by reading the readme and using `npm run start:course`
 - Visit the course home page and expand the course info drawer, ensure that there are no borders on the table
 - Reduce your browser to mobile width and ensure that the course info table does not have any borders on it

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/118333271-688e6f00-b4d9-11eb-93f3-b47c66955224.png)
![chrome_2021-05-14_17-26-06](https://user-images.githubusercontent.com/12089658/118333360-92e02c80-b4d9-11eb-8d0f-dcaf610b67da.png)

