### PR TITLE
Accessibility improvements for search

### DIFF
--- a/course/layouts/course/baseof.html
+++ b/course/layouts/course/baseof.html
@@ -28,7 +28,7 @@
         {{ partialCached "desktop_nav.html" . .Params.course_id }}
         <div class="left-col-bg"></div>
         <div id="main-content-wrapper" class="col-lg-9 p-0 bg-white">
-          <main aria-role="main">
+          <main>
             <div class="container-fluid p-0">
               <div class="row m-0">
                 <div id="main-content" class="col-12 col-lg-{{ if $isCourseHomePage }}12{{ else }}8{{ end }} col-xl-{{ if $isCourseHomePage }}12{{ else }}8{{ end }} px-3 pl-md-5 pr-md-8 mt-3 mt-lg-6">

--- a/www/assets/css/search-filter.scss
+++ b/www/assets/css/search-filter.scss
@@ -81,6 +81,11 @@
       flex-direction: row;
       justify-content: space-between;
       width: 100%;
+
+      label {
+        cursor: pointer;
+        margin-bottom: 0;
+      }
     }
 
     .facet-key {

--- a/www/assets/js/components/SearchBox.js
+++ b/www/assets/js/components/SearchBox.js
@@ -11,6 +11,7 @@ export default function SearchBox(props) {
         onChange={onChange}
         value={value ?? ""}
         placeholder="Enter Course Name, Department, Course Number..."
+        aria-label="Enter Course Name, Department, Course Number"
       />
       <button type="submit" className="py-2 px-3">
         Search

--- a/www/assets/js/components/SearchFacetItem.js
+++ b/www/assets/js/components/SearchFacetItem.js
@@ -4,41 +4,25 @@ import Dotdotdot from "react-dotdotdot"
 
 const featuredFacetNames = ["audience", "certification"]
 
-function updateFacetCheckbox(props) {
-  const { facet, isChecked, name, onUpdate } = props
-  onUpdate({
-    target: {
-      name,
-      value:   facet.key,
-      checked: !isChecked
-    }
-  })
-}
-
 export default function SearchFacetItem(props) {
   const { facet, isChecked, onUpdate, labelFunction, name } = props
 
   const labelText = labelFunction ? labelFunction(facet.key) : facet.key
 
+  const facetId = `${name}-${facet.key}`
   return (
-    <div
-      className={isChecked ? "facet-visible checked" : "facet-visible"}
-      onClick={() => updateFacetCheckbox(props)}
-      onKeyPress={e => {
-        if (e.key === "Space") {
-          updateFacetCheckbox(props)
-        }
-      }}
-    >
+    <div className={isChecked ? "facet-visible checked" : "facet-visible"}>
       <input
         type="checkbox"
+        id={facetId}
         name={name}
         value={facet.key}
         checked={isChecked}
         onChange={onUpdate}
       />
       <div className="facet-label-div">
-        <div
+        <label
+          htmlFor={facetId}
           className={
             featuredFacetNames.includes(name) ?
               "facet-key facet-key-large" :
@@ -46,7 +30,7 @@ export default function SearchFacetItem(props) {
           }
         >
           <Dotdotdot clamp={1}>{labelText}</Dotdotdot>
-        </div>
+        </label>
         <div className="facet-count">{facet.doc_count}</div>
       </div>
     </div>

--- a/www/assets/js/components/SearchResult.js
+++ b/www/assets/js/components/SearchResult.js
@@ -46,21 +46,28 @@ const CoverImage = ({ object }) => (
   </div>
 )
 
+const makeIdTitle = id => `${id}-title`
 export default function SearchResult(props) {
-  const { searchResultLayout, object } = props
+  const { searchResultLayout, object, id, index } = props
 
   return object.url ? (
-    <Card
-      className={getClassName(searchResultLayout)}
-      borderless={searchResultLayout === SEARCH_GRID_UI}
+    <article
+      aria-labelledby={makeIdTitle(id)}
+      aria-setsize="-1"
+      aria-posinset={index}
     >
-      <LearningResourceDisplay {...props} />
-    </Card>
+      <Card
+        className={getClassName(searchResultLayout)}
+        borderless={searchResultLayout === SEARCH_GRID_UI}
+      >
+        <LearningResourceDisplay {...props} />
+      </Card>
+    </article>
   ) : null
 }
 
 export function LearningResourceDisplay(props) {
-  const { object, searchResultLayout } = props
+  const { object, searchResultLayout, id } = props
   const isResource = object.object_type === LR_TYPE_RESOURCEFILE
 
   return (
@@ -85,7 +92,9 @@ export function LearningResourceDisplay(props) {
           {object.url ? (
             <a href={object.url} className="w-100">
               <Dotdotdot clamp={3}>
-                {object.content_title || object.title}
+                <span id={makeIdTitle(id)}>
+                  {object.content_title || object.title}
+                </span>
               </Dotdotdot>
             </a>
           ) : (

--- a/www/layouts/search/section.html
+++ b/www/layouts/search/section.html
@@ -4,7 +4,7 @@
   {{ partialCached "header" . }}
   {{end}}
   <div class="container-fluid">
-    <main aria-role="main">
+    <main>
       <div class="container-fluid p-0">
         <div class="row m-0">
           <div id="search-page" class="w-100"></div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-www/issues/107

#### What's this PR do?
 - Wrap search cards in `article` for `aria-feed` compatibility
 - Add `aria-busy` attribute to communicate when loading happens
 - Add `label` to facets and handle link clicks there instead of the surrounding div
 - Remove incorrect aria roles

#### How should this be manually tested?
Nothing should appear to function differently. In particular you should be able to click the facet labels and also tab between facet checkboxes and trigger them with your spacebar.

I tried these changes using the ScreenReader plugin for Chrome and it didn't appear to make things function better. The aria-feed related changes described in the linked issue might be unimplemented in that screenreader.