### PR TITLE
fix title tag generation

### DIFF
--- a/base-theme/layouts/partials/head.html
+++ b/base-theme/layouts/partials/head.html
@@ -12,7 +12,7 @@
   {{ end }}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  {{ partial "title.html" . }}
+  {{ block "title" . }}{{ end }}
   {{ $theme := .Site.Data.webpack.main }}
   <link href="{{ partial "webpack_url.html" $theme.css }}" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">

--- a/course/layouts/course/baseof.html
+++ b/course/layouts/course/baseof.html
@@ -1,7 +1,7 @@
 {{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
 <!doctype html>
 <html lang="{{ $.Site.Language.Lang }}">
-  {{ partial "head.html" . }}
+{{ partial "head.html" . }}
 <body class="course-home-page">
   {{ if $gtmId }}
     <!-- Google Tag Manager (noscript) -->

--- a/course/layouts/partials/extrahead.html
+++ b/course/layouts/partials/extrahead.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ partial "title.html" . }}{{ end }}
 {{ define "extrahead" }}
 {{ $courseTheme := .Site.Data.webpack.course }}
 <link href="{{ partial "webpack_url.html" $courseTheme.css }}" rel="stylesheet">

--- a/course/layouts/partials/title.html
+++ b/course/layouts/partials/title.html
@@ -6,7 +6,7 @@
 {{- if $courseData.course_title -}}
   {{- $titleArray = $titleArray | append $courseData.course_title -}}
   {{- if $courseData.departments -}}
-    {{- $titleArray = $titleArray | append (index $courseData.departments 0) -}}
+    {{- $titleArray = $titleArray | append (index $courseData.departments 0).department -}}
   {{- end -}}
 {{- end -}}
 {{- $titleArray = $titleArray | append $.Site.Title -}}

--- a/www/layouts/partials/extrahead.html
+++ b/www/layouts/partials/extrahead.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ partial "title.html" . }}{{ end }}
 {{ define "extrahead" }}
 {{ $wwwTheme := .Site.Data.webpack.www }}
 <link href="{{ partial "webpack_url.html" $wwwTheme.css }}" rel="stylesheet">

--- a/www/layouts/partials/title.html
+++ b/www/layouts/partials/title.html
@@ -1,6 +1,8 @@
 <title>
 {{- $titleArray := (slice) -}}
-{{- $titleArray = $titleArray | append .Title -}}
+{{- if .Params.Title -}}
+  {{- $titleArray = $titleArray | append .Params.Title -}}
+{{- end -}}
 {{- $titleArray = $titleArray | append $.Site.Title -}}
 {{- if lt (len $titleArray) 3 -}}
   {{- $titleArray = $titleArray | append "Free Online Course Materials" -}}

--- a/www/layouts/partials/title.html
+++ b/www/layouts/partials/title.html
@@ -1,5 +1,6 @@
 <title>
 {{- $titleArray := (slice) -}}
+{{- $titleArray = $titleArray | append .Title -}}
 {{- $titleArray = $titleArray | append $.Site.Title -}}
 {{- if lt (len $titleArray) 3 -}}
   {{- $titleArray = $titleArray | append "Free Online Course Materials" -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/40

#### What's this PR do?
In the transition to `ocw-hugo-themes`, page titles were broken.  This PR introduces some changes that fix rendering of titles on a number of pages listed in the issue attached to this PR.  The title was being sourced from `title.html` in `base-theme`.  The reason this was happening was because `head.html` directly calls it, which is directly called by `baseof.html` all in the `base-theme`.  When you include a partial of the same name in two themes, the first one found is used.  Instead of calling the partial directly, head.html now has a block called `title` that is implemented in `extrahead.html` in both `www` and `course`.

#### How should this be manually tested?
 - Read the readme to learn how to setup this project to run `ocw-www` with the `EXTERNAL_SITE_PATH` environment variable, as well as course sites using `ocw-to-hugo`
 - Spin up the OCW home page with `npm start` and browse to http://localhost:3000
 - Ensure that the title is `MIT OpenCourseWare | Free Online Course Materials`
 - Browse to the search page at http://localhost:3000/search
 - Ensure that the title is `Search | MIT OpenCourseWare | Free Online Course Materials`
 - Close down `ocw-www`
 - Spin up a course site with `npm run start:course` (any one with at least one section will work)
 - Browse to the course home page at http://localhost:3000
 - Ensure that the title is the title of the course, followed by the boilerplate title like: `Classical Mechanics | Physics | MIT OpenCourseWare`
 - Browse to one of the sections and ensure that the title of the section is prepended to the beginning of the title, like: `Readings | Classical Mechanics | Physics | MIT OpenCourseWare`

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/118714777-c8925780-b7f0-11eb-96a2-a8ff2af7ee8e.png)
![image](https://user-images.githubusercontent.com/12089658/118711673-d98d9980-b7ed-11eb-8a6f-3fd08c366426.png)
![image](https://user-images.githubusercontent.com/12089658/118713054-84eb1e00-b7ef-11eb-92a4-e2773e9ded0b.png)
![image](https://user-images.githubusercontent.com/12089658/118713593-1d819e00-b7f0-11eb-8007-043c577aaabf.png)

