### PR TITLE
Tweaks to search accessibility page

### DIFF
--- a/www/assets/js/components/SearchPage.js
+++ b/www/assets/js/components/SearchPage.js
@@ -254,7 +254,7 @@ export default function SearchPage() {
                     results.map((hit, idx) => (
                       <SearchResult
                         key={`${hit._source.title}_${idx}`}
-                        id={`${hit._source.title}_${idx}`}
+                        id={`search-result-${idx}`}
                         index={idx}
                         object={searchResultToLearningResource(hit._source)}
                         searchResultLayout={SEARCH_LIST_UI}

--- a/www/assets/js/components/SearchResult.js
+++ b/www/assets/js/components/SearchResult.js
@@ -54,7 +54,8 @@ export default function SearchResult(props) {
     <article
       aria-labelledby={makeIdTitle(id)}
       aria-setsize="-1"
-      aria-posinset={index}
+      aria-posinset={index + 1}
+      tabIndex={0}
     >
       <Card
         className={getClassName(searchResultLayout)}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-www/issues/107

#### What's this PR do?
Some small tweaks to fix lighthouse warnings:
 - Adjust `aria-posinet` to start at `1`, not `0`
 - Add `tabIndex={0}` to allow selecting the card
 - Simplify id and remove spaces so it can be used in `aria-labelledby`

The keyboard navigation implemented in [this example](https://w3c.github.io/aria-practices/examples/feed/feedDisplay.html) seems to be implemented via javascript so I'm not sure what we can or should do here
