### PR TITLE
check length before rendering

### DIFF
--- a/course/layouts/partials/other_versions.html
+++ b/course/layouts/partials/other_versions.html
@@ -1,6 +1,7 @@
 {{ $courseId := .Params.course_id }}
 {{ $courseData := .Site.Data.course }}
 {{ $otherVersions := .Params.other_versions }}
+{{ if gt (len $otherVersions) 0}}
 <div class="course-home-section w-100">
   <div class="container px-0 mx-0">
     <h4 class="course-info-title font-weight-bold">OTHER {{ index $courseData.course_numbers 0  }} OFFERINGS ON OPENCOURSEWARE</h4>
@@ -12,3 +13,4 @@
     </ul>
   </div>
 </div>
+{{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/57

#### What's this PR do?
Recently, support for "other OCW versions" was added.  Something was missed and a course not having any other versions is resulting in just the title for that section being rendered.  This PR checks the length of the `other_versions` param before rendering the section.

#### How should this be manually tested?
 - Clone `ocw-to-hugo` and read the readme if you haven't used it before
 - Place the following in `private/courses.json` in `ocw-to-hugo`:
```
{
    "courses": [
        "8-01sc-classical-mechanics-fall-2016",
        "8-01l-physics-i-classical-mechanics-fall-2005",
        "8-01x-physics-i-classical-mechanics-with-an-experimental-focus-fall-2002",
        "21h-244j-imperial-and-revolutionary-russia-culture-and-politics-1700-1917-fall-2019"
    ]
}
```
- Back over in `ocw-course-hugo-themes`, make sure you read the readme and set `OCW_TO_HUGO_PATH` and `OCW_TO_HUGO_OUTPUT_DIR` to your paths as well as `DOWNLOAD=0`
- Set `OCW_TEST_COURSE=21h-244j-imperial-and-revolutionary-russia-culture-and-politics-1700-1917-fall-2019`
- Spin up the course site with `npm run start:course`
- Verify that the "other versions" section is not rendered
- Set `OCW_TEST_COURSE=8-01sc-classical-mechanics-fall-2016`
- Spin up the course site with `npm run start:course`
- Verify that the "other versions" section is rendered with links to the other two 8.01 courses (note that these links won't work locally)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/119045897-07a7e080-b98a-11eb-9512-8921d1f4d378.png)
![chrome_2021-05-20_16-40-26](https://user-images.githubusercontent.com/12089658/119045994-2908cc80-b98a-11eb-8590-a34b55bdf28b.png)

