### PR TITLE
Add padding to search textbox

### DIFF
--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -92,6 +92,10 @@ $searchbox-height: 50px;
 
         .home-search-box {
           flex-grow: 2;
+
+          input {
+            padding-left: 12px;
+          }
         }
 
         input {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-www/issues/102

#### What's this PR do?
Adds 12px padding to the left of search box

#### How should this be manually tested?
Look at home page and enter some text in the search textbox

#### Screenshots (if appropriate)
![Screenshot from 2021-05-20 16-53-15](https://user-images.githubusercontent.com/863262/119047510-024b9580-b98c-11eb-9cde-0dee160d239c.png)
