### PR TITLE
Add search role and mark search area with aria-live

### DIFF
--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -346,14 +346,14 @@ $searchbox-height: 50px;
 
     .course-level {
       text-transform: uppercase;
-      color: $medium-gray;
+      color: $dark-gray;
     }
 
     .course-card-content {
       font-size: 12px;
 
       .card-label {
-        color: $medium-gray;
+        color: $dark-gray;
       }
     }
   }

--- a/www/assets/css/learning-resource-card.scss
+++ b/www/assets/css/learning-resource-card.scss
@@ -128,7 +128,7 @@
           }
 
           .gray {
-            color: $medium-gray;
+            color: $dark-gray;
             padding-right: 10px;
             min-width: fit-content;
           }
@@ -143,7 +143,7 @@
     &.resource-type-audience-certificates {
       .resource-type {
         font-size: 14px;
-        color: $medium-gray;
+        color: $dark-gray;
         text-transform: uppercase;
         font-weight: 400;
       }

--- a/www/assets/js/components/SearchPage.js
+++ b/www/assets/js/components/SearchPage.js
@@ -165,7 +165,7 @@ export default function SearchPage() {
           </div>
           <div className="col-lg-3" />
         </div>
-        <div className="row">
+        <div className="row" role="search" aria-live="polite">
           <SearchFilterDrawer
             facetMap={facetMap}
             facetOptions={facetOptions}

--- a/www/assets/js/components/SearchResult.js
+++ b/www/assets/js/components/SearchResult.js
@@ -84,7 +84,7 @@ export function LearningResourceDisplay(props) {
             </div>
           ) : null}
         </div>
-        <div className="lr-row course-title" tabIndex="0">
+        <div className="lr-row course-title">
           {isResource ? (
             <i className="material-icons md-24 align-bottom pr-2">
               {getContentIcon(object.content_type)}
@@ -103,7 +103,7 @@ export function LearningResourceDisplay(props) {
           )}
         </div>
         {object.run_title ? (
-          <div className="lr-row subtitles lr-subheader" tabIndex="0">
+          <div className="lr-row subtitles lr-subheader">
             <a href={`/courses/${object.run_slug}`}>
               <Dotdotdot clamp={3}>
                 {object.coursenum ? `${object.coursenum} ` : ""}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-www/issues/107

#### What's this PR do?
Mark search section as search landmark and set aria-live=polite so screenreaders notice changes to the feed

#### How should this be manually tested?
I'm not sure how to test the accessibility changes since I don't have a screenreader except the plugin for Chrome which seems low quality. When the page refreshes it only reads off the number of search results. Getting to scroll through the search results is also difficult. But you can look at the source and verify that the HTML has been changed, and read the accessibility docs on the aria [search](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role) role and [aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) regions.

The color in search result cards has been changed to make greys darker for better contrast, and I also made a similar change to home page course cards.

#### Screenshots

![Screenshot from 2021-05-28 11-38-05](https://user-images.githubusercontent.com/863262/120008787-51f01980-bfa9-11eb-9b9a-f3917aa1635e.png)

![Screenshot from 2021-05-28 11-26-00](https://user-images.githubusercontent.com/863262/120007057-8236b880-bfa7-11eb-8f9d-8d4d7795b33f.png)

