### PR TITLE
other versions to data template

### DIFF
--- a/course/layouts/course/course_home.html
+++ b/course/layouts/course/course_home.html
@@ -42,7 +42,7 @@
         {{ partial "course_features.html" (dict "context" . "inPanel" false) }}
       </div>
     </div>
-    {{ if not (eq .Params.other_versions_text "")  }}
+    {{ if gt (len $courseData.other_versions) 0}}
     <div class="row px-lg-3 pb-lg-2 p-0">
       <div class="col-12 p-0">
         {{ partial "other_versions.html" . }}

--- a/course/layouts/partials/other_versions.html
+++ b/course/layouts/partials/other_versions.html
@@ -1,6 +1,6 @@
 {{ $courseId := .Params.course_id }}
 {{ $courseData := .Site.Data.course }}
-{{ $otherVersions := .Params.other_versions }}
+{{ $otherVersions := $courseData.other_versions }}
 {{ if gt (len $otherVersions) 0}}
 <div class="course-home-section w-100">
   <div class="container px-0 mx-0">

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.2.1",
-    "@mitodl/ocw-to-hugo": "^1.20.0",
+    "@mitodl/ocw-to-hugo": "^1.21.0",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@^1.20.0":
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.20.0.tgz#31a8a9a941e54bff7ea539034c4cd0f80ed5d5cd"
-  integrity sha512-2eRgr5tgCr5osfVsFxIgFWgrjrKEnvTPIOjW7col6xMTeLVo4cs4e/l/FA+34Vdx17XB3O+3YJaXokmSVHkUGA==
+"@mitodl/ocw-to-hugo@^1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.21.0.tgz#a70951c2b4115ecad85d0070fffed0769dd7b50b"
+  integrity sha512-Yhx3G7TpIPBZZYWBHdJdPY9EONl4wJwKXoTxWS5u/9gSCeOsk0DWIKvsvgtXmlkr4GNx+6C5KAjuX3/tNKqQnw==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-to-hugo/issues/291

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/292, `other_versions` was moved into the course data template, `course.json`.  This PR updates `ocw-hugo-themes` to reflect that change and updates the version of `ocw-to-hugo` used.

#### How should this be manually tested?
 - Make sure your `OCW_TO_HUGO_PATH` variable is blank so `ocw-hugo-themes` uses the version from NPM
 - Run `yarn install` to install the latest version
 - Spin up a course with other versions, like `8-01sc-classical-mechanics-fall-2016`
 - Ensure that the site spins up without errors and that the other versions are listed on the course home page.
