### PR TITLE
open learning library

### DIFF
--- a/course/assets/css/course-home.scss
+++ b/course/assets/css/course-home.scss
@@ -35,7 +35,7 @@
   }
 
   .course-home-section {
-    padding: 40px;
+    padding: 20px 40px 0px 40px;
 
     @include media-breakpoint-down(md) {
       padding: 30px;

--- a/course/assets/css/course-home.scss
+++ b/course/assets/css/course-home.scss
@@ -58,6 +58,10 @@
         text-decoration: underline;
         color: $blue;
       }
+
+      li {
+        padding-bottom: 4px;
+      }
     }
   }
 }

--- a/course/layouts/course/course_home.html
+++ b/course/layouts/course/course_home.html
@@ -49,6 +49,13 @@
       </div>
     </div>
     {{ end }}
+    {{ if gt (len $courseData.open_learning_library_versions) 0}}
+    <div class="row px-lg-3 pb-lg-2 p-0">
+      <div class="col-12 p-0">
+        {{ partial "open_learning_library_versions.html" . }}
+      </div>
+    </div>
+    {{ end }}
   </div>
 </div>
 {{ end }}

--- a/course/layouts/partials/open_learning_library_versions.html
+++ b/course/layouts/partials/open_learning_library_versions.html
@@ -1,0 +1,16 @@
+{{ $courseId := .Params.course_id }}
+{{ $courseData := .Site.Data.course }}
+{{ $openLearningLibraryVersions := $courseData.open_learning_library_versions }}
+{{ if gt (len $openLearningLibraryVersions) 0}}
+<div class="course-home-section w-100">
+  <div class="container px-0 mx-0">
+    <h4 class="course-info-title font-weight-bold">INTERACTIVE ASSESSMENTS WITH OPEN LEARNING LIBRARY</h4>
+    <p>Other versions of this course on MIT Open Learning Library have interactive assessments and progress tracking to better support independent learning.</p>
+    <ul class="other-version-list list-unstyled">
+    {{ range $openLearningLibraryVersions }}
+    <li>{{ . | markdownify }}</li>
+    {{ end }}
+    </ul>
+  </div>
+</div>
+{{ end }}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.2.1",
-    "@mitodl/ocw-to-hugo": "^1.21.0",
+    "@mitodl/ocw-to-hugo": "^1.22.0",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@^1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.21.0.tgz#a70951c2b4115ecad85d0070fffed0769dd7b50b"
-  integrity sha512-Yhx3G7TpIPBZZYWBHdJdPY9EONl4wJwKXoTxWS5u/9gSCeOsk0DWIKvsvgtXmlkr4GNx+6C5KAjuX3/tNKqQnw==
+"@mitodl/ocw-to-hugo@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.22.0.tgz#94fd7bbd906a63d2e2aba44abf12a77e265cada6"
+  integrity sha512-+ONaEfsFHbqGLSehQNfMKGMFHxEJP95NFRdTOR5yHStzztkQQ4N7wr5dB/EHkP2033l1ITMeExhOYgZYtXU2qA==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-data-parser/issues/53

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/296, we added `open_learning_library_versions` to the course data template.  This PR adds a partial template for rendering them and implements it on the course home page.

#### How should this be manually tested?
 - Clone `ocw-to-hugo` and read the readme for it and `ocw-hugo-themes` if you have not used these repos before
 - In the `ocw-to-hugo` directory, put the following in `private/courses.json`:
```
{
    "courses": [
        "8-01sc-classical-mechanics-fall-2016",
        "8-01l-physics-i-classical-mechanics-fall-2005",
        "8-01x-physics-i-classical-mechanics-with-an-experimental-focus-fall-2002"
    ]
}
```
 - Convert the courses using: `node . -i private/input -o private/output --courses private/courses.json --download --rm`
 - Back in `ocw-hugo-themes`, make sure the following environment variables are set, replacing paths with your own:
```
OCW_TEST_COURSE=8-01sc-classical-mechanics-fall-2016
OCW_TO_HUGO_PATH=/path/to/Code/ocw-to-hugo
OCW_TO_HUGO_OUTPUT_DIR=/path/to/ocw-to-hugo/private/output
DOWNLOAD=0
```
 - Start the site with `npm run start:course`
 - Browse to http://localhost:3000/
 - Ensure that both the "other versions" and "open learning library" sections are rendered and that they look like the design

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/120392282-4466c680-c2fe-11eb-9830-707324729685.png)
![image](https://user-images.githubusercontent.com/12089658/120392336-58122d00-c2fe-11eb-8c48-22e045e0c45a.png)

