### PR TITLE
Show archived versions on course home page

### DIFF
--- a/course/layouts/course/course_home.html
+++ b/course/layouts/course/course_home.html
@@ -49,6 +49,13 @@
       </div>
     </div>
     {{ end }}
+    {{ if gt (len $courseData.archived_versions) 0}}
+    <div class="row px-lg-3 pb-lg-2 p-0">
+      <div class="col-12 p-0">
+        {{ partial "archived_versions.html" . }}
+      </div>
+    </div>
+    {{ end }}
     {{ if gt (len $courseData.open_learning_library_versions) 0}}
     <div class="row px-lg-3 pb-lg-2 p-0">
       <div class="col-12 p-0">

--- a/course/layouts/partials/archived_versions.html
+++ b/course/layouts/partials/archived_versions.html
@@ -1,0 +1,15 @@
+{{ $courseId := .Params.course_id }}
+{{ $courseData := .Site.Data.course }}
+{{ $archivedVersions := $courseData.archived_versions }}
+{{ if gt (len $archivedVersions) 0}}
+<div class="course-home-section w-100">
+  <div class="container px-0 mx-0">
+    <h4 class="course-info-title font-weight-bold">ARCHIVED OCW VERSIONS</h4>
+    <ul class="other-version-list list-unstyled">
+    {{ range $archivedVersions }}
+    <li>{{ . | markdownify }}</li>
+    {{ end }}
+    </ul>
+  </div>
+</div>
+{{ end }}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.2.1",
-    "@mitodl/ocw-to-hugo": "^1.22.0",
+    "@mitodl/ocw-to-hugo": "1.24.0",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@^1.22.0":
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.22.0.tgz#94fd7bbd906a63d2e2aba44abf12a77e265cada6"
-  integrity sha512-+ONaEfsFHbqGLSehQNfMKGMFHxEJP95NFRdTOR5yHStzztkQQ4N7wr5dB/EHkP2033l1ITMeExhOYgZYtXU2qA==
+"@mitodl/ocw-to-hugo@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.24.0.tgz#25375ae4de95d1cb9920974941e04c8e2fe89645"
+  integrity sha512-SvdE3WsNaPhMJyYeyVt1JDlgBU5VikHlVIQkX3o6fOL8uKiKJWqbJ6hUd/30/c+PL/Ejlqn7JhLK48mXCg8tTQ==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-to-hugo/issues/274

#### What's this PR do?
Shows archived courses on the home page. You will need to run this using ocw-to-hugo data from https://github.com/mitodl/ocw-to-hugo/pull/301, which itself relies on ocw-data-parser output from https://github.com/mitodl/ocw-data-parser/pull/145 (both have been merged to master).

#### How should this be manually tested?
After generating fresh data via ocw-data-parser and ocw-to-hugo for all courses, view the course home page for `17-40-american-foreign-policy-past-present-and-future-fall-2017`.

#### Screenshots
![Screenshot from 2021-06-09 13-13-08](https://user-images.githubusercontent.com/863262/121399621-9920c780-c924-11eb-96f1-64d3e1b86300.png)

![Screenshot from 2021-06-09 13-14-38](https://user-images.githubusercontent.com/863262/121399771-c3728500-c924-11eb-901a-06ce472bb35e.png)
