### PR TITLE
add search placeholder

### DIFF
--- a/www/content/search/_index.md
+++ b/www/content/search/_index.md
@@ -1,0 +1,4 @@
+---
+title: Search
+type: search
+---


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/95

#### What's this PR do?
In `ocw-www`, we currently have a file at `content/search/_index.md` with the following contents:

```
---
title: Search
type: search
---
```

Its purpose is to tell Hugo to render a page at `/search/index.html` using the layout at `layouts/search/section.html`.  This PR moves this file into the theme, so the search page is rendered at `/search/index.html` by default.

#### How should this be manually tested?
 - Read the readme if you've never used this project before
 - Clone `ocw-www` on the `cg/remove-search-placeholder` branch and point at it using `EXTERNAL_SITE_PATH`
 - Start the site with `npm start`
 - View the search page at `http://localhost:3000/search.  You will not see any search results unless you've configured `ocw-studio` to return them, but the goal here is to verify that the page renders at all and is not just a blank page.

