### PR TITLE
reorganize webpack output

### DIFF
--- a/base-theme/assets/webpack/webpack.common.js
+++ b/base-theme/assets/webpack/webpack.common.js
@@ -31,7 +31,8 @@ module.exports = {
   },
 
   output: {
-    path: path.join(__dirname, "../../dist")
+    path:     path.join(__dirname, "../../dist/static"),
+    filename: "js/[name].js"
   },
 
   module: {
@@ -77,8 +78,10 @@ module.exports = {
           {
             loader:  MiniCssExtractPlugin.loader,
             options: {
-              publicPath: "./",
-              hmr:        process.env.NODE_ENV !== "production"
+              publicPath:    "./",
+              filename:      "css/[name].css",
+              chunkFilename: "css/[id].css",
+              hmr:           process.env.NODE_ENV !== "production"
             }
           },
           "css-loader",

--- a/base-theme/assets/webpack/webpack.dev.js
+++ b/base-theme/assets/webpack/webpack.dev.js
@@ -1,4 +1,5 @@
 const { merge } = require("webpack-merge")
+const path = require("path")
 const { CleanWebpackPlugin } = require("clean-webpack-plugin")
 const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 
@@ -8,9 +9,9 @@ module.exports = merge(common, {
   mode: "development",
 
   output: {
-    filename:      "[name].js",
-    chunkFilename: "[id].css",
-    publicPath:    "/"
+    path:       path.join(__dirname, "../../dist/static"),
+    publicPath: "/static",
+    filename:   "js/[name].js"
   },
 
   devtool: "eval-source-map",
@@ -41,8 +42,8 @@ module.exports = merge(common, {
     }),
 
     new MiniCssExtractPlugin({
-      filename:      "[name].css",
-      chunkFilename: "[id].css"
+      filename:      "css/[name].css",
+      chunkFilename: "css/[id].css"
     })
   ]
 })

--- a/base-theme/assets/webpack/webpack.prod.js
+++ b/base-theme/assets/webpack/webpack.prod.js
@@ -1,4 +1,5 @@
 const { merge } = require("webpack-merge")
+const path = require("path")
 const TerserPlugin = require("terser-webpack-plugin")
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin")
 const MiniCssExtractPlugin = require("mini-css-extract-plugin")
@@ -9,8 +10,9 @@ module.exports = merge(common, {
   mode: "production",
 
   output: {
-    filename:      "[name].[hash:5].js",
-    chunkFilename: "[id].[hash:5].css"
+    path:       path.join(__dirname, "../../dist/static"),
+    publicPath: "/static",
+    filename:   "js/[name].[hash:5].js"
   },
 
   optimization: {
@@ -26,8 +28,8 @@ module.exports = merge(common, {
 
       new MiniCssExtractPlugin({
         publicPath:    "./",
-        filename:      "[name].[hash:5].css",
-        chunkFilename: "[id].[hash:5].css"
+        filename:      "css/[name].[hash:5].css",
+        chunkFilename: "css/[id].[hash:5].css"
       }),
 
       new OptimizeCSSAssetsPlugin({})

--- a/base-theme/layouts/partials/head.html
+++ b/base-theme/layouts/partials/head.html
@@ -23,9 +23,9 @@
     font-weight: 400;
     src: local('Material Icons'),
       local('MaterialIcons-Regular'),
-      url({{ partial "webpack_url.html" "/fonts/MaterialIcons-Regular.woff2" }}) format('woff2'),
-      url({{ partial "webpack_url.html" "/fonts/MaterialIcons-Regular.woff" }}) format('woff'),
-      url({{ partial "webpack_url.html" "/fonts/MaterialIcons-Regular.ttf" }}) format('truetype');
+      url({{ partial "webpack_url.html" "/static/fonts/MaterialIcons-Regular.woff2" }}) format('woff2'),
+      url({{ partial "webpack_url.html" "/static/fonts/MaterialIcons-Regular.woff" }}) format('woff'),
+      url({{ partial "webpack_url.html" "/static/fonts/MaterialIcons-Regular.ttf" }}) format('truetype');
   }
   </style>
 </head>

--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -15,7 +15,7 @@ else
   # Build the site
   rm -rf $EXTERNAL_SITE_PATH/dist
   GIT_HASH=`git rev-parse HEAD`
-  npm run build:webpack --  --output-path=$EXTERNAL_SITE_PATH/dist
+  npm run build:webpack --  --output-path=$EXTERNAL_SITE_PATH/dist/static
   cd $EXTERNAL_SITE_PATH
   hugo -d dist -v
   mkdir -p dist/static 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/97

#### What's this PR do?
This PR cleans up the output of the webpack build and organizes it into folders.  All assets are placed in a `static` folder, and then organized into folders by file type beyond that.  External dependencies like Mathjax still go into their own folder under `static`.

#### How should this be manually tested?
 - Read the readme if you have never run a site locally before using `ocw-hugo-themes`
 - Clone `ocw-www`
 - Point `EXTERNAL_SITE_PATH` to `ocw-www` and run `npm start` to start `ocw-www`
 - Open the inspector in your browser and verify that all assets load correctly and there are no 404's
 - Verify that the paths to the various assets on the page are prefixed in the manner described above
 - Stop the site and run `npm run build:webpack`
 - Inspect the contents of `base-theme/data/webpack.json` and ensure that the paths are prefixed in the way described above, then look at the contents of `base-theme/dist/` and ensure that the `static` folder under there matches what the `webpack.json` file describes
