### PR TITLE
Implement sort

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
-    "@mitodl/course-search-utils": "1.2.1",
+    "@mitodl/course-search-utils": "1.3.0",
     "@mitodl/ocw-to-hugo": "1.24.0",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",

--- a/www/assets/js/components/SearchPage.js
+++ b/www/assets/js/components/SearchPage.js
@@ -233,6 +233,9 @@ export default function SearchPage() {
                     Resources
                   </button>
                 </li>
+                <li className="nav-item flex-grow-1 d-flex align-items-center justify-content-center results-total">
+                  {completedInitialLoad ? `${total} Results` : null}
+                </li>
                 {!isResourceSearch ? (
                   <li className="sort-nav-item nav-item flex-grow-1 d-flex align-items-center justify-content-end">
                     Sort By:{" "}

--- a/www/assets/js/components/SearchPage.js
+++ b/www/assets/js/components/SearchPage.js
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from "react"
 import InfiniteScroll from "react-infinite-scroller"
 import { useCourseSearch } from "@mitodl/course-search-utils"
+import { serializeSort } from "@mitodl/course-search-utils/dist/url_utils"
 import {
   LR_TYPE_COURSE,
   LR_TYPE_RESOURCEFILE
@@ -36,7 +37,7 @@ export default function SearchPage() {
   const [busy, setBusy] = useState(false)
 
   const runSearch = useCallback(
-    async (text, activeFacets, from) => {
+    async (text, activeFacets, from, sort) => {
       if (activeFacets && activeFacets.type.length > 1) {
         // Default is LR_TYPE_ALL, don't want that here. course or resourcefile only
         activeFacets["type"] = [LR_TYPE_COURSE]
@@ -47,7 +48,8 @@ export default function SearchPage() {
         text,
         from,
         activeFacets,
-        size: SEARCH_PAGE_SIZE
+        size: SEARCH_PAGE_SIZE,
+        sort: sort
       })
       setBusy(false)
 
@@ -102,8 +104,10 @@ export default function SearchPage() {
     facetOptions,
     onUpdateFacets,
     updateText,
+    updateSort,
     loadMore,
     text,
+    sort,
     activeFacets,
     onSubmit,
     from,
@@ -229,9 +233,19 @@ export default function SearchPage() {
                     Resources
                   </button>
                 </li>
-                <li className="nav-item flex-grow-1 d-flex align-items-center justify-content-center results-total">
-                  {completedInitialLoad ? `${total} Results` : null}
-                </li>
+                {!isResourceSearch ? (
+                  <li className="sort-nav-item nav-item flex-grow-1 d-flex align-items-center justify-content-end">
+                    Sort By:{" "}
+                    <select
+                      value={serializeSort(sort)}
+                      onChange={updateSort}
+                      className="ml-2"
+                    >
+                      <option value="">Relevance</option>
+                      <option value="coursenum">MIT course nr</option>
+                    </select>
+                  </li>
+                ) : null}
               </ul>
             </div>
             <InfiniteScroll

--- a/www/assets/js/components/SearchPage.test.js
+++ b/www/assets/js/components/SearchPage.test.js
@@ -30,8 +30,9 @@ jest.mock("../lib/api", () => ({
   search:     jest.fn(async () => {
     return new Promise(resolve => {
       resolver = (extraData = {}) => {
+        const results = mockGetResults()
         resolve({
-          hits: { hits: mockGetResults() },
+          hits: { hits: results, total: results.length },
           ...extraData
         })
       }
@@ -227,6 +228,13 @@ describe("SearchPage component", () => {
       field:  differentSortParam,
       option: "asc"
     })
+  })
+
+  it("should display the number of results", async () => {
+    const wrapper = await render()
+    await resolveSearch()
+    const resultsText = wrapper.find(".results-total").text()
+    expect(resultsText).toBe("10 Results")
   })
 
   //

--- a/www/assets/js/components/SearchPage.test.js
+++ b/www/assets/js/components/SearchPage.test.js
@@ -96,7 +96,8 @@ describe("SearchPage component", () => {
           activeFacets: {
             ...defaultCourseFacets,
             ...params.activeFacets
-          }
+          },
+          sort: null
         }
       ])
     })
@@ -118,7 +119,8 @@ describe("SearchPage component", () => {
           text:         "",
           from:         0,
           size:         SEARCH_PAGE_SIZE,
-          activeFacets: defaultCourseFacets
+          activeFacets: defaultCourseFacets,
+          sort:         null
         }
       ],
       [
@@ -126,7 +128,8 @@ describe("SearchPage component", () => {
           text:         "New Search Text",
           from:         0,
           size:         SEARCH_PAGE_SIZE,
-          activeFacets: defaultCourseFacets
+          activeFacets: defaultCourseFacets,
+          sort:         null
         }
       ]
     ])
@@ -157,7 +160,8 @@ describe("SearchPage component", () => {
           text:         parameters.text,
           from:         0,
           size:         SEARCH_PAGE_SIZE,
-          activeFacets: { ...defaultCourseFacets, ...parameters.activeFacets }
+          activeFacets: { ...defaultCourseFacets, ...parameters.activeFacets },
+          sort:         null
         }
       ],
       [
@@ -165,7 +169,8 @@ describe("SearchPage component", () => {
           text:         parameters.text,
           from:         0,
           size:         SEARCH_PAGE_SIZE,
-          activeFacets: defaultResourceFacets
+          activeFacets: defaultResourceFacets,
+          sort:         null
         }
       ]
     ])
@@ -205,6 +210,44 @@ describe("SearchPage component", () => {
     expect(!wrapper.find(".suggestions").exists())
   })
 
+  it("should allow the user to toggle sort", async () => {
+    const sortParam = "-sortablefieldname",
+      differentSortParam = "differentsortparam"
+    const parameters = {
+      sort: { field: sortParam, option: "asc" }
+    }
+    const searchString = serializeSearchParams(parameters)
+    const wrapper = await render(searchString)
+    const select = wrapper.find(".sort-nav-item select")
+    expect(select.prop("value")).toBe(sortParam)
+    act(() => {
+      select.prop("onChange")({ target: { value: differentSortParam } })
+    })
+    expect(search.mock.calls[1][0].sort).toEqual({
+      field:  differentSortParam,
+      option: "asc"
+    })
+  })
+
+  //
+  ;[
+    [LR_TYPE_COURSE, true],
+    [LR_TYPE_RESOURCEFILE, false]
+  ].forEach(([type, sortExists]) => {
+    it(`${
+      sortExists ? "should" : "shouldn't"
+    } show the sort option if the user is on the ${type} page`, async () => {
+      const parameters = {
+        activeFacets: {
+          type: [type]
+        }
+      }
+      const searchString = serializeSearchParams(parameters)
+      const wrapper = await render(searchString)
+      expect(wrapper.find(".sort-nav-item").exists()).toBe(sortExists)
+    })
+  })
+
   it("should show spinner when searching", async () => {
     const wrapper = await render()
     await resolveSearch()
@@ -239,7 +282,8 @@ describe("SearchPage component", () => {
           text:         "",
           from:         0,
           size:         SEARCH_PAGE_SIZE,
-          activeFacets: defaultCourseFacets
+          activeFacets: defaultCourseFacets,
+          sort:         null
         }
       ],
       [
@@ -247,7 +291,8 @@ describe("SearchPage component", () => {
           text:         "",
           from:         SEARCH_PAGE_SIZE,
           size:         SEARCH_PAGE_SIZE,
-          activeFacets: defaultCourseFacets
+          activeFacets: defaultCourseFacets,
+          sort:         null
         }
       ],
       [
@@ -255,7 +300,8 @@ describe("SearchPage component", () => {
           text:         "",
           from:         2 * SEARCH_PAGE_SIZE,
           size:         SEARCH_PAGE_SIZE,
-          activeFacets: defaultCourseFacets
+          activeFacets: defaultCourseFacets,
+          sort:         null
         }
       ]
     ])

--- a/www/assets/js/lib/search.js
+++ b/www/assets/js/lib/search.js
@@ -107,7 +107,7 @@ export const buildSearchQuery = ({ text, from, size, sort, activeFacets }) => {
   if (size !== undefined) {
     builder = builder.size(size)
   }
-  if (sort !== undefined) {
+  if (sort && !activeFacets.type.includes(LR_TYPE_RESOURCEFILE)) {
     const { field, option } = sort
     builder.sort(field, option)
   }

--- a/www/assets/js/lib/search.test.js
+++ b/www/assets/js/lib/search.test.js
@@ -23,13 +23,16 @@ import {
 } from "./search"
 import { makeLearningResourceResult } from "../factories/search"
 
-const activeFacets = {
-  ...INITIAL_FACET_STATE,
-  type: [LR_TYPE_COURSE]
-}
-
 describe("search library", () => {
   const sandbox = sinon.createSandbox()
+  let activeFacets
+
+  beforeEach(() => {
+    activeFacets = {
+      ...INITIAL_FACET_STATE,
+      type: [LR_TYPE_COURSE]
+    }
+  })
 
   afterEach(() => {
     sandbox.restore()
@@ -303,6 +306,26 @@ describe("search library", () => {
     const query = buildSearchQuery({ from: 10, size: 100, activeFacets })
     expect(query.from).toBe(10)
     expect(query.size).toBe(100)
+  })
+
+  //
+  ;[
+    [
+      { field: "field", option: "asc" },
+      LR_TYPE_COURSE,
+      [{ field: { order: "asc" } }]
+    ],
+    [{ field: "field", option: "asc" }, LR_TYPE_RESOURCEFILE, undefined],
+    [null, LR_TYPE_COURSE, undefined],
+    [undefined, LR_TYPE_COURSE, undefined]
+  ].forEach(([sortField, type, expectedSort]) => {
+    it(`should add a sort option if field is ${JSON.stringify(
+      sortField
+    )} and type is ${type}`, () => {
+      activeFacets["type"] = [type]
+      const query = buildSearchQuery({ sort: sortField, activeFacets })
+      expect(query.sort).toStrictEqual(expectedSort)
+    })
   })
 
   //

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,10 +1189,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@mitodl/course-search-utils@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.2.1.tgz#d230f9c9755f291408084e453f404f2c5240fdf0"
-  integrity sha512-Mnsnn5BtuXSREB4B2nq14aPIsVDvP+1QjdtOox3wdt2XJZ3jlQYamvi4rsan2Mpta8E21oj0mNJ7CsYHCl3XCA==
+"@mitodl/course-search-utils@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.3.0.tgz#6da8701536c2a3f733eb37367d9bd444ec4e9c9f"
+  integrity sha512-HEbxFN+F9T7JEBPHH13Ud04IGRkgBW/7AcF2/3m6kDh/f1JWLZyPQFrvqyAdWi4Ja0yZi7uVe4iDGOh5nLOKtA==
   dependencies:
     history "^5.0.0"
     query-string "^6.13.1"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/course-search-utils/issues/21

#### What's this PR do?
Implements sort for courses. There are two options at the moment: "Relevance" and "MIT course nr"

#### How should this be manually tested?
 - Make sure you have the course index updated. If you haven't, you will need to rebuild the docker container on open-discussions to get the latest version of `ocw-data-parser`, then run `./manage.py recreate_index --course`. 
 - Go to `/search` and click the sort dropdown, then change to "MIT course nr". When you switch to "MIT course nr" you should see a `s=coursenum` parameter appear in the URL. The search results should appear to sort by course number.
 - You should be able to switch back and forth between "MIT course nr" and "Relevance" and see expected results. The text and facets should remain when you switch sorting.
 - If you refresh the browser you should see the same sort items, as well as the same facets and text as before
 - You should be able to click the back and forward buttons and not see any inconsistencies. The browser history stack should not change as a result of clicking either the back or forward buttons

#### Screenshots
![Screenshot from 2021-06-11 14-32-37](https://user-images.githubusercontent.com/863262/121915972-b6c5a680-cd01-11eb-8548-9db9044305f7.png)
![screencapture-localhost-3000-search-2021-06-14-11_24_25](https://user-images.githubusercontent.com/863262/121917466-2720f780-cd03-11eb-818b-60e445e6bcfd.png)
