### PR TITLE
Fix course info expander

### DIFF
--- a/course/assets/course.js
+++ b/course/assets/course.js
@@ -12,5 +12,5 @@ import { initCourseInfoExpander } from "./js/course_expander"
 $(document).ready(() => {
   initPdfViewers()
   initDesktopCourseInfoToggle()
-  initCourseInfoExpander()
+  initCourseInfoExpander(document)
 })

--- a/course/assets/js/course_expander.js
+++ b/course/assets/js/course_expander.js
@@ -1,7 +1,7 @@
 const toggleExpand = (button, container) => {
   const expanded = button.classList.contains("expanded")
-  const text = button.querySelector(".text")
-  const arrow = button.querySelector(".material-icons")
+  const readmoreText = button.querySelector(".read-more-text")
+  const arrow = button.querySelector(".expander-arrow")
   if (expanded) {
     button.classList.remove("expanded")
     button.setAttribute("aria-expanded", "false")
@@ -18,42 +18,24 @@ const toggleExpand = (button, container) => {
     }
   }
 
-  if (text) {
-    text.innerText = expanded ? "Read More" : "Show Less"
+  if (readmoreText) {
+    readmoreText.textContent = expanded ? "Read More" : "Show Less"
   }
 }
 
-const initCourseInfoExpander = () => {
-  for (const container of document.querySelectorAll(".course-info")) {
-    const expanderButton = container.querySelector(".expand-link")
-    if (expanderButton) {
-      expanderButton.addEventListener("click", event => {
+const initCourseInfoExpander = document => {
+  for (const expanderButton of document.querySelectorAll(".expand-link")) {
+    const container = expanderButton.closest(".expand-container")
+    expanderButton.addEventListener("click", event => {
+      event.preventDefault()
+      toggleExpand(expanderButton, container)
+    })
+    expanderButton.addEventListener("keypress", event => {
+      if (event.key === "Enter") {
         event.preventDefault()
         toggleExpand(expanderButton, container)
-      })
-      expanderButton.addEventListener("keypress", event => {
-        if (event.key === "Enter") {
-          event.preventDefault()
-          toggleExpand(expanderButton, container)
-        }
-      })
-    }
-  }
-
-  for (const container of document.querySelectorAll(".course-description")) {
-    const expanderButton = container.querySelector(".expand-link")
-    if (expanderButton) {
-      expanderButton.addEventListener("click", event => {
-        event.preventDefault()
-        toggleExpand(expanderButton, container)
-      })
-      expanderButton.addEventListener("keypress", event => {
-        if (event.key === "Enter") {
-          event.preventDefault()
-          toggleExpand(expanderButton, container)
-        }
-      })
-    }
+      }
+    })
   }
 }
 

--- a/course/assets/js/course_expander.test.js
+++ b/course/assets/js/course_expander.test.js
@@ -1,0 +1,79 @@
+import { JSDOM } from "jsdom"
+
+import { initCourseInfoExpander } from "./course_expander"
+
+describe("initCourseInfoExpander", () => {
+  let html
+
+  beforeEach(() => {
+    html = `<body>
+    <div class="course-description expand-container collapsed">
+      <div class="course-info expand-container collapsed">
+        <a class="expand-link course-info-link" aria-expanded="false">
+          <h4>Course Info</h4>
+          <span class="expander-arrow material-icons">keyboard_arrow_right</span>
+        </a>
+      </div>
+      <button class="expand-link read-more" aria-expanded="false">
+        <span class="read-more-text">Read More</span>
+      </button>
+    </div>
+    </body>`
+  })
+
+  const assertExpanded = (button, expanded) => {
+    const container = button.closest(".expand-container")
+    expect(button.getAttribute("aria-expanded")).toBe(String(expanded))
+    expect(button.classList.contains("expanded")).toBe(expanded)
+    expect(container.classList.contains("collapsed")).toBe(!expanded)
+    const readmore = button.querySelector(".read-more-text")
+    if (readmore) {
+      expect(readmore.textContent).toBe(expanded ? "Show Less" : "Read More")
+    }
+    const arrow = button.querySelector(".expander-arrow")
+    if (arrow) {
+      expect(arrow.textContent).toBe(
+        expanded ? "keyboard_arrow_down" : "keyboard_arrow_right"
+      )
+    }
+  }
+
+  const toggleButton = (button, isMouseClick, window) => {
+    if (isMouseClick) {
+      button.click()
+    } else {
+      const event = new window.KeyboardEvent("keypress", {
+        key:     "Enter",
+        bubbles: true
+      })
+      button.dispatchEvent(event)
+    }
+  }
+
+  //
+  ;[true, false].forEach(isReadMore => {
+    [true, false].forEach(isMouseClick => {
+      it(`toggles the ${isReadMore ? "read more" : "course info"} link by ${
+        isMouseClick ? "click" : "enter"
+      }`, () => {
+        const { window } = new JSDOM(html)
+        const document = window.document
+        initCourseInfoExpander(document)
+        const buttonSelectors = [".read-more", ".course-info-link"]
+        const selector = isReadMore ? ".read-more" : ".course-info-link"
+        const button = document.querySelector(selector)
+        const otherButton = document.querySelector(
+          buttonSelectors.find(_selector => _selector !== selector)
+        )
+        assertExpanded(button, false)
+        assertExpanded(otherButton, false)
+        toggleButton(button, isMouseClick, window)
+        assertExpanded(button, true)
+        assertExpanded(otherButton, false)
+        toggleButton(button, isMouseClick, window)
+        assertExpanded(button, false)
+        assertExpanded(otherButton, false)
+      })
+    })
+  })
+})

--- a/course/layouts/course/course_home.html
+++ b/course/layouts/course/course_home.html
@@ -24,13 +24,13 @@
         </div>
       </div>
       {{ partial "mobile_nav_toggle.html" . }}
-      <div class="col-lg-8 course-description {{ if $shouldCollapseContent }}collapsed{{ end }}">
+      <div class="col-lg-8 course-description expand-container {{ if $shouldCollapseContent }}collapsed{{ end }}">
         <h4 class="font-weight-bold course-description-title">Course Description</h4>
         <div class="mb-1 description">{{- .Content -}}</div>
         <div class="mb-3">
           {{ if $shouldCollapseContent }}
             <button class="expand-link" aria-expanded="false">
-              <span class="text">Read More</span>
+              <span class="read-more-text">Read More</span>
             </button>
           {{ end }}
         </div>

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -1,12 +1,12 @@
 {{ $courseId := .context.Params.course_id }}
 {{ $courseData := .context.Site.Data.course }}
 {{ $inPanel := .inPanel }}
-<div class="table-responsive course-info {{ if not $inPanel }}collapsed{{ end }}">
+<div class="table-responsive course-info expand-container {{ if not $inPanel }}collapsed{{ end }}">
   <div class="course-info-expander">
     {{ if not $inPanel }}
     <a class="expand-link d-flex align-items-center text-decoration-none" aria-expanded="false" href="#">
       <h4 class="course-info-title font-weight-bold d-inline m-0">Course Info</h4>
-      <span class="material-icons">keyboard_arrow_right</span>
+      <span class="expander-arrow material-icons">keyboard_arrow_right</span>
     </a>
     {{ else }}
     <h4 class="course-info-title font-weight-bold">Course Info</h4>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #104 

#### What's this PR do?
Fixes the course info expander

#### How should this be manually tested?
Start the server on course `6-00sc-introduction-to-computer-science-and-programming-spring-2011`. You should be able to toggle the "Course info >" link and also the "Read More" link. Both links should toggle correctly to expand the course info or course description sections.
