### PR TITLE
Add sorting by date

### DIFF
--- a/www/assets/js/components/SearchPage.js
+++ b/www/assets/js/components/SearchPage.js
@@ -246,6 +246,7 @@ export default function SearchPage() {
                     >
                       <option value="">Relevance</option>
                       <option value="coursenum">MIT course nr</option>
+                      <option value="-runs.best_start_date">Date</option>
                     </select>
                   </li>
                 ) : null}

--- a/www/assets/js/lib/search.js
+++ b/www/assets/js/lib/search.js
@@ -109,7 +109,17 @@ export const buildSearchQuery = ({ text, from, size, sort, activeFacets }) => {
   }
   if (sort && !activeFacets.type.includes(LR_TYPE_RESOURCEFILE)) {
     const { field, option } = sort
-    builder.sort(field, option)
+    if (field.includes(".")) {
+      const fieldPieces = field.split(".")
+      builder.sort(field, {
+        order:  option,
+        nested: {
+          path: fieldPieces[0]
+        }
+      })
+    } else {
+      builder.sort(field, option)
+    }
   }
 
   for (const type of activeFacets.type) {

--- a/www/assets/js/lib/search.test.js
+++ b/www/assets/js/lib/search.test.js
@@ -317,7 +317,17 @@ describe("search library", () => {
     ],
     [{ field: "field", option: "asc" }, LR_TYPE_RESOURCEFILE, undefined],
     [null, LR_TYPE_COURSE, undefined],
-    [undefined, LR_TYPE_COURSE, undefined]
+    [undefined, LR_TYPE_COURSE, undefined],
+    [
+      { field: "nested.field", option: "desc" },
+      LR_TYPE_RESOURCEFILE,
+      undefined
+    ],
+    [
+      { field: "nested.field", option: "desc" },
+      LR_TYPE_COURSE,
+      [{ "nested.field": { order: "desc", nested: { path: "nested" } } }]
+    ]
   ].forEach(([sortField, type, expectedSort]) => {
     it(`should add a sort option if field is ${JSON.stringify(
       sortField


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #111

#### What's this PR do?
Adds an option to sort by best_start_date, descending

#### How should this be manually tested?
Go to `/search` and switch between different sort options. For `Date` it may or may not be obvious that earlier courses are first but you can see the dates in the network tab in the API response, or hover over the URL and look at the semester in the URL. The dates should be in descending order.

#### Screenshots (if appropriate)
![Screenshot from 2021-06-17 09-35-07](https://user-images.githubusercontent.com/863262/122407168-6c396980-cf4f-11eb-85e5-86c9dc75b0c7.png)
![Screenshot from 2021-06-17 09-35-33](https://user-images.githubusercontent.com/863262/122407170-6cd20000-cf4f-11eb-9a3a-2c3fbc4ea8ce.png)
