### PR TITLE
use uid instead of id for notifications

### DIFF
--- a/base-theme/layouts/partials/notification.html
+++ b/base-theme/layouts/partials/notification.html
@@ -1,6 +1,6 @@
 {{- range ( where site.RegularPages "Section" "notifications" | first 1 ) -}}
-{{- if isset .Params "id" -}}
-<div id="notification_{{ .Params.id }}" class="notification d-none">
+{{- if isset .Params "uid" -}}
+<div id="notification_{{ .Params.uid }}" class="notification d-none">
   <div class="notification-message">
     {{ .Content }}
   </div>

--- a/www/archetypes/notifications.md
+++ b/www/archetypes/notifications.md
@@ -1,6 +1,6 @@
 {{- $name := replaceRE "-" " " .Name | replaceRE "_" " " | title -}}
 ---
-id: "{{ now.UnixNano }}"
+uid: "{{ now.UnixNano }}"
 title: "{{ $name }}"
 date: {{ .Date }}
 headless: true


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/121

#### What's this PR do?
In an effort to build `ocw-www` content generated by `ocw-studio`, it was noticed that the partial for `notification` in the `www` theme looks for an identifier in the `id` property of the front matter of the notification.  This `id` is currently a Unix timestamp generated at the time of the creation of the file if you are using the `hugo new` syntax as defined in the archetype in the `www` theme for `notification`. `ocw-studio` doesn't use `hugo new` to create content and instead generates content based the `WebsiteStarter` config used to generate the site.  `ocw-studio` however does generate a UUID for each piece of content it creates, and this is deposited in the front matter of any given piece of content under the `uid` key.  This PR moves the theme to look at the `uid` property and uses that to key  to generate the `id` property in HTML and manage dismissal.

#### How should this be manually tested?
 - Read the readme if you have never spun up a site with `ocw-hugo-themes` before
 - Clone the repo at https://github.mit.edu/ocw-content-rc/the-ocw-www-rc_2b7b49fc4f784ca293edee4368e35a88
 - Clone `ocw-hugo-projects`: https://github.com/mitodl/ocw-hugo-projects
 - Start the webpack dev server in `ocw-hugo-themes` with `npm run start:site:webpack`
 - Start the hugo server in the cloned content repo directory by running `hugo server --config /path/to/ocw-hugo-projects/ocw-www/config.yaml --themesDir /path/to/ocw-hugo-themes`
 - Browse to http://localhost:1313 in an incognito window
 - Verify you see a beta notification at the top of the screen
 - Dismiss the notification and refresh the page.  It should not re-appear
