### PR TITLE
adapt to use ocw-studio generated ocw-www content

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-engines --prefer-offline
 
+      - name: Clear ocw-www directory
+        run: (cd ..; rm -rf ocw-www) 
+
       - name: Clone ocw-www for content
         run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/ocw-www_eb8b70174c714752a91dbe730af76769.git ocw-www)
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm run build:webpack
 
       - name: Run hugo build
-        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes)
+        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes; ls -lah public)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm run build:webpack
 
       - name: Run hugo build
-        run: (ls -lah; cd ../ocw-www; ls -lah; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
+        run: (ls -lah; cd ../ocw-www; ls -lah; cat ../ocw-hugo-projects/ocw-www/config.yaml; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-engines --prefer-offline
 
-      - name: Clear ocw-www directory
-        run: (cd ..; rm -rf ocw-www) 
-
       - name: Clone ocw-www for content
         run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/ocw-www_eb8b70174c714752a91dbe730af76769.git ocw-www)
 
@@ -56,7 +53,7 @@ jobs:
         run: npm run build:webpack
 
       - name: Run hugo build
-        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
+        run: (ls -lah; cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,21 +29,26 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-engines --prefer-offline
 
-      - name: Clone ocw-www for config
-        run: (cd ..; git clone https://github.com/mitodl/ocw-www)
+      - name: Clone ocw-www for content
+        run: (cd ..; git clone https://github.mit.edu/ocw-content-rc/ocw-www_eb8b70174c714752a91dbe730af76769)
 
-      - name: build site
-        run: npm run build
+      - name: Clone ocw-hugo-projects for config
+        run: (cd ..; git clone https://github.com/mitodl/ocw-hugo-projects)
+
+      - name: run webpack build
+        run: npm run build:webpack
+
+      - name: run hugo build
+        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}
-          EXTERNAL_SITE_PATH: "../ocw-www"
 
       - name: Deploy PR Preview to Netlify
         uses: nwtgck/actions-netlify@v1.1
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          publish-dir: '../ocw-www/dist'
+          publish-dir: '../ocw-www/public'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: true
@@ -58,7 +63,7 @@ jobs:
         uses: nwtgck/actions-netlify@v1.1
         if: ${{ github.event_name == 'push' }}
         with:
-          publish-dir: '../ocw-www/dist'
+          publish-dir: '../ocw-www/public'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-engines --prefer-offline
 
       - name: Clone ocw-www for content
-        run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/ocw-www_eb8b70174c714752a91dbe730af76769.git)
+        run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/ocw-www_eb8b70174c714752a91dbe730af76769.git ocw-www)
 
       - name: Clone ocw-hugo-projects for config
         run: (cd ..; git clone https://github.com/mitodl/ocw-hugo-projects)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,10 +50,10 @@ jobs:
         run: (cd ..; git clone https://github.com/mitodl/ocw-hugo-projects)
 
       - name: Run webpack build
-        run: npm run build:webpack -- --output-path=../ocw-www/public/static
+        run: npm run build:webpack -- --output-path=../ocw-www/public/static/
 
       - name: Run hugo build
-        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes; cat ../ocw-hugo-themes/base-theme/data/webpack.json; ls -lah ../ocw-hugo-themes/base-theme/static/)
+        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
         run: (cd ..; git clone https://github.com/mitodl/ocw-hugo-projects)
 
       - name: Run webpack build
-        run: npm run build:webpack
+        run: npm run build:webpack -- --output-path=../ocw-www/public/static
 
       - name: Run hugo build
         run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes; cat ../ocw-hugo-themes/base-theme/data/webpack.json; ls -lah ../ocw-hugo-themes/base-theme/static/)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Clone ocw-hugo-projects for config
         run: (cd ..; git clone https://github.com/mitodl/ocw-hugo-projects)
 
-      - name: run webpack build
+      - name: Run webpack build
         run: npm run build:webpack
 
-      - name: run hugo build
+      - name: Run hugo build
         run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          if_key_exists: replace
       - uses: actions/checkout@v2
       - name: Set up node.js
         uses: actions/setup-node@v2-beta

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm run build:webpack
 
       - name: Run hugo build
-        run: (ls -lah; cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
+        run: (ls -lah; cd ../ocw-www; ls -lah; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm run build:webpack
 
       - name: Run hugo build
-        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes; cat ../ocw-hugo-themes/base-theme/data/webpack.json; ls -lah public)
+        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes; cat ../ocw-hugo-themes/base-theme/data/webpack.json; ls -lah ../ocw-hugo-themes/base-theme/static/)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm run build:webpack
 
       - name: Run hugo build
-        run: (ls -lah; cd ../ocw-www; ls -lah; cat ../ocw-hugo-projects/ocw-www/config.yaml; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
+        run: (ls -lah ../; cd ../ocw-www; ls -lah; cat ../ocw-hugo-projects/ocw-www/config.yaml; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,19 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
           if_key_exists: replace
+
       - uses: actions/checkout@v2
+
       - name: Set up node.js
         uses: actions/setup-node@v2-beta
         with:
           node-version: 12.13.1
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm run build:webpack
 
       - name: Run hugo build
-        run: (ls -lah ../; cd ../ocw-www; ls -lah; cat ../ocw-hugo-projects/ocw-www/config.yaml; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../)
+        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-engines --prefer-offline
 
       - name: Clone ocw-www for content
-        run: (cd ..; git clone https://github.mit.edu/ocw-content-rc/ocw-www_eb8b70174c714752a91dbe730af76769)
+        run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/ocw-www_eb8b70174c714752a91dbe730af76769.git)
 
       - name: Clone ocw-hugo-projects for config
         run: (cd ..; git clone https://github.com/mitodl/ocw-hugo-projects)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ jobs:
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
           if_key_exists: replace
       - uses: actions/checkout@v2
       - name: Set up node.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm run build:webpack
 
       - name: Run hugo build
-        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes; ls -lah public)
+        run: (cd ../ocw-www; hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes; cat ../ocw-hugo-themes/base-theme/data/webpack.json; ls -lah public)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}

--- a/www/layouts/partials/home_testimonials.html
+++ b/www/layouts/partials/home_testimonials.html
@@ -1,6 +1,5 @@
-{{ $pages := .Site.RegularPages }}
-{{ $testimonials := where $pages "Type" "==" "testimonials" }}
-{{ $testimonialSection := .Site.GetPage "section" "testimonials" }}
+{{- $testimonials := where .Site.RegularPages "Type" "==" "testimonials" -}}
+{{- $testimonialSection := .Site.GetPage "section" "testimonials" -}}
 <div class="home-testimonials standard-width container mx-auto my-3">
   <h2 class="branded mb-3">
     <span>OpenCourseWare</span> Testimonies
@@ -11,7 +10,7 @@
     {{ end }}
   </div>
   <div class="d-flex d-md-none">
-    {{ $carouselId := "testimonial-carousel-xs-sm" }}
+    {{- $carouselId := "testimonial-carousel-xs-sm" -}}
     <div id="{{ $carouselId }}" class="carousel slide">
       <div class="carousel-header d-flex flex-row justify-content-end font-weight-bold text-uppercase">
         {{ partial "carousel_controls.html" $carouselId }}
@@ -28,7 +27,7 @@
     </div>
   </div>
   <div class="d-none d-md-flex d-lg-none">
-    {{ $carouselId := "testimonial-carousel-md" }}
+    {{- $carouselId := "testimonial-carousel-md" -}}
     <div id="{{ $carouselId }}" class="carousel slide">
       <div class="carousel-header d-flex flex-row justify-content-end font-weight-bold text-uppercase">
         {{ partial "carousel_controls.html" $carouselId }}
@@ -49,7 +48,7 @@
     </div>
   </div>
   <div class="d-none d-lg-flex d-xl-none">
-    {{ $carouselId := "testimonial-carousel-lg" }}
+    {{- $carouselId := "testimonial-carousel-lg" -}}
     <div id="{{ $carouselId }}" class="carousel slide">
       <div class="carousel-header d-flex flex-row justify-content-end font-weight-bold text-uppercase">
         {{ partial "carousel_controls.html" $carouselId }}

--- a/www/layouts/partials/promo-carousel.html
+++ b/www/layouts/partials/promo-carousel.html
@@ -1,6 +1,6 @@
-{{ $pages := .Site.RegularPages }}
-{{ $promos := where $pages "Type" "==" "promos" }}
-{{ $carouselId := "promo-carousel" }}
+{{- $pages := .Site.RegularPages -}}
+{{- $promos := where $pages "Type" "==" "promos" -}}
+{{- $carouselId := "promo-carousel" -}}
 <div id="{{ $carouselId }}" class="promo-carousel pt-2 carousel carousel-fade slide" data-interval="false">
   <ol class="carousel-indicators">
     {{ range $index, $promo := $promos }}
@@ -17,7 +17,7 @@
       <div class="carousel-item {{ if eq $index 0}}active{{ end }}">
         <div class="carousel-content d-flex m-auto align-items-center bg-white">
           <div class="img-container p-2">
-            <img class="promo-image img-fluid" src="{{ $promo.Params.image }}" alt="{{ $promo.Params.image_alt }}" />
+            <img class="promo-image img-fluid" src="{{ partial "resource_url" (dict "filetype" "Image" "uid" $promo.Params.image.content) }}" alt="{{ $promo.Params.image_alt }}" />
           </div>
           <div class="promo-info d-flex flex-column px-2 px-md-4 align-items-start h-100">
             <h2>{{ $promo.Params.title }}</h2>

--- a/www/layouts/partials/resource_url.html
+++ b/www/layouts/partials/resource_url.html
@@ -1,0 +1,4 @@
+{{- $resources := where (where site.RegularPages "Type" "==" "resource") ".Params.filetype" "==" .filetype -}}
+{{- $resource := index (where $resources ".Params.uid" "==" .uid) 0 -}}
+{{- $resourceUrl := urls.Parse $resource.Params.file -}}
+{{- return printf $resourceUrl.Path -}}

--- a/www/layouts/partials/resource_url.html
+++ b/www/layouts/partials/resource_url.html
@@ -3,7 +3,7 @@
 {{/* 
   Here we are disassembling the URL and returning it without the host and schema.  This is done because 
   it is expected that ocw-studio currently returns fully qualified S3 URLs, and when deployed these will 
-  need to be transformed into CDN URLs.
+  need to be behind CDN.
 */}}
 {{- $resourceUrl := urls.Parse $resource.Params.file -}}
 {{- return printf $resourceUrl.Path -}}

--- a/www/layouts/partials/resource_url.html
+++ b/www/layouts/partials/resource_url.html
@@ -1,9 +1,9 @@
 {{- $resources := where (where site.RegularPages "Type" "==" "resource") ".Params.filetype" "==" .filetype -}}
 {{- $resource := index (where $resources ".Params.uid" "==" .uid) 0 -}}
 {{/* 
-  Here we are disassembling the URL and returning it without the host and schema.  This is done because 
-  it is expected that ocw-studio currently returns fully qualified S3 URLs, and when deployed these will 
-  need to be behind CDN.
+  Here we are disassembling the URL and returning it without the host and schema.
+  This is done because it is expected that ocw-studio currently returns fully 
+  qualified S3 URLs, and when deployed these will need to be behind CDN.
 */}}
 {{- $resourceUrl := urls.Parse $resource.Params.file -}}
 {{- return printf $resourceUrl.Path -}}

--- a/www/layouts/partials/resource_url.html
+++ b/www/layouts/partials/resource_url.html
@@ -1,4 +1,9 @@
 {{- $resources := where (where site.RegularPages "Type" "==" "resource") ".Params.filetype" "==" .filetype -}}
 {{- $resource := index (where $resources ".Params.uid" "==" .uid) 0 -}}
+{{/* 
+  Here we are disassembling the URL and returning it without the host and schema.  This is done because 
+  it is expected that ocw-studio currently returns fully qualified S3 URLs, and when deployed these will 
+  need to be transformed into CDN URLs.
+*/}}
 {{- $resourceUrl := urls.Parse $resource.Params.file -}}
 {{- return printf $resourceUrl.Path -}}

--- a/www/layouts/partials/testimonial_card.html
+++ b/www/layouts/partials/testimonial_card.html
@@ -2,7 +2,7 @@
 <a href="{{ $testimonial.RelPermalink }}" class="testimonial-link">
   <div
     class="testimonial d-flex flex-column justify-content-end rounded"
-    style="background-image: linear-gradient(180deg, rgba(0,0,0,0) 0%, #000000 100%), url({{ $testimonial.Params.image }});"
+    style="background-image: linear-gradient(180deg, rgba(0,0,0,0) 0%, #000000 100%), url({{ partial "resource_url" (dict "filetype" "Image" "uid" $testimonial.Params.image.content) }});"
   >
     <div class="name font-weight-bold pl-3">
       {{ $testimonial.Title }}

--- a/www/layouts/testimonials/list.html
+++ b/www/layouts/testimonials/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
-{{ $pages := .Site.RegularPages }}
-{{ $testimonials := where $pages "Type" "==" "testimonials" }}
+{{- $pages := .Site.RegularPages -}}
+{{- $testimonials := where $pages "Type" "==" "testimonials" -}}
 <div>
   {{ block "header" . }}
   {{ partialCached "header" . }}
@@ -15,7 +15,7 @@
       {{ range $testimonial := $testimonials }}
       <div class="testimonial d-flex flex-wrap flex-sm-nowrap">
         <div class="img-container">
-          <img src="{{ $testimonial.Params.image }}" alt="{{ $testimonial.Title }}" />
+          <img src="{{ partial "resource_url" (dict "filetype" "Image" "uid" $testimonial.Params.image.content) }}" alt="{{ $testimonial.Title }}" />
         </div>
         <div class="detail d-flex flex-column flex-nowrap justify-content-between p-0 ml-sm-5">
           <div class="text">

--- a/www/layouts/testimonials/single.html
+++ b/www/layouts/testimonials/single.html
@@ -3,13 +3,13 @@
 <div>
   {{ block "header" . }}
   {{ partialCached "header" . }}
-  {{end}}
+  {{ end }}
   <div class="testimonial-single container standard-width mx-auto mt-5">
     <h1>OCW Testimonies</h1>
     <div class="testimonials">
       <div class="testimonial d-flex flex-wrap flex-sm-nowrap">
         <div class="img-container">
-          <img src="{{ $testimonial.Params.image }}" alt="{{ $testimonial.Title }}" />
+          <img src="{{ partial "resource_url" (dict "filetype" "Image" "uid" $testimonial.Params.image.content) }}" alt="{{ $testimonial.Title }}" />
         </div>
         <div class="detail d-flex flex-column flex-nowrap justify-content-between p-0 ml-sm-5">
           <div class="text">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/125

#### What's this PR do?
In mitodl/ocw-hugo-projects#8, we set up the `ocw-www` studio config to have a collection of resources with uploaded files and metadata. Now that we are moving to source `ocw-www` content from `ocw-studio`, we will need to update the way we source image URLs for promos and testimonials to reflect this change. Currently, in the static version of `ocw-www` at https://github.com/mitodl/ocw-www we simply store the image URL under the image front matter property and the alt text in image_alt.

This PR adds the `resource_url.html` partial to the `www` theme.  It takes two arguments, the first being `filetype` and second being `uid`.  The partial retrieves a resource by first filtering the resources by `filetype` and then matching on `uid`.  It then returns the URL for the image minus the hostname and schema, leaving a relative URL.  `ocw-studio` currently writes in fully qualified S3 URLs into the `file` field, and these need to be stripped down to just be a relative URL in the final output as it will be served from a CDN.  This partial is then used in the various locations that promo and testimonial images are displayed throughout our templates.

#### How should this be manually tested?
 - If you have never run this project before, run `yarn install`
 - Run `npm run start:site:webpack`
 - Clone https://github.com/mitodl/ocw-hugo-projects locally
 - Clone https://github.mit.edu/ocw-content-rc/ocw-www_eb8b70174c714752a91dbe730af76769 locally and open a terminal there
 - Run `hugo server --config /path/to/ocw-hugo-projects/ocw-www/config.yaml --themesDir /path/to/ocw-hugo-themes`, replacing `/path/to` with your path to these respective repos
 - Browse to http://localhost:1313 and check the URLs on the images for promos and testimonials at:
   - http://localhost:1313
   - http://localhost:1313/testimonials/
   - http://localhost:1313/testimonials/clinton-blackburn/
 - Note that the images won't load locally as they are being stripped of their hostname down to relative URLs for use behind the CDN.  What you should expect to see for each URL is a pattern of `/ocw-www/filename`.  Check the markdown source for any given testimonial or promo and make sure that the URL written into the outputted HTML is essentially the `file` property from the markdown minus the schema and domain (https://ol-ocw-studio-app-qa.s3.amazonaws.com/)

