### PR TITLE
Add captions location as an argument to youtube shortcode

### DIFF
--- a/course/layouts/partials/youtube_player.html
+++ b/course/layouts/partials/youtube_player.html
@@ -9,6 +9,8 @@
     "techOrder": ["youtube"],
     "sources": [{"type": "video/youtube", "src": "https://www.youtube.com/embed/{{ .youtubeKey }}"}]}'
   >
-      <track kind="captions" src="{{ .captionsLocation }}" srclang="en" label="English" default>
+      {{ if .captionsLocation }}
+        <track kind="captions" src="{{ .captionsLocation }}" srclang="en" label="English" default>
+      {{ end }}
   </video>
 </div>

--- a/course/layouts/shortcodes/youtube.html
+++ b/course/layouts/shortcodes/youtube.html
@@ -1,2 +1,3 @@
-{{ $youtubeId := index .Params 0 }}
-{{ partial "youtube_player.html" $youtubeId }}
+{{ $youtubeId := index .Params "youtubeId" }}
+{{ $captionsLocation := index .Params "captionsLocation"}}
+{{ partial "youtube_player.html" (dict "youtubeKey" $youtubeId "captionsLocation" $captionsLocation) }}

--- a/course/layouts/shortcodes/youtube.html
+++ b/course/layouts/shortcodes/youtube.html
@@ -1,3 +1,3 @@
-{{ $youtubeId := index .Params "youtubeId" }}
-{{ $captionsLocation := index .Params "captionsLocation"}}
+{{ $youtubeId := index .Params 0 }}
+{{ $captionsLocation := index .Params 1}}
 {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeId "captionsLocation" $captionsLocation) }}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "1.24.0",
+    "@mitodl/ocw-to-hugo": "1.24.3",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.24.0.tgz#25375ae4de95d1cb9920974941e04c8e2fe89645"
-  integrity sha512-SvdE3WsNaPhMJyYeyVt1JDlgBU5VikHlVIQkX3o6fOL8uKiKJWqbJ6hUd/30/c+PL/Ejlqn7JhLK48mXCg8tTQ==
+"@mitodl/ocw-to-hugo@1.24.3":
+  version "1.24.3"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.24.3.tgz#ebace14e4be35a5a902cc6805fc008d0e91d04e3"
+  integrity sha512-egbp7LC3DQdrec+FQNzO3OJD5NMTXQBz5xAB4d8lucWAuemr62lpesP7y3WxV+hIka9j/LV/fmEXZJLrWDpLaQ==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fix error where a course, for example, "1-050-solid-mechanics-fall-2004", has youtube video as an introduction to the course, and using youtube shortcode. 

#### What's this PR do?
This PR updates `shortcodes/youtube.html` to pass an extra parameter the captions location.

#### How should this be manually tested?

Set the course id in the env file `OCW_TEST_COURSE=`, and run the course you are testing `npm run start:course`
There should be no errors.
