### PR TITLE
update ocw-to-hugo to 1.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "1.24.3",
+    "@mitodl/ocw-to-hugo": "1.25.0",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@1.24.3":
-  version "1.24.3"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.24.3.tgz#ebace14e4be35a5a902cc6805fc008d0e91d04e3"
-  integrity sha512-egbp7LC3DQdrec+FQNzO3OJD5NMTXQBz5xAB4d8lucWAuemr62lpesP7y3WxV+hIka9j/LV/fmEXZJLrWDpLaQ==
+"@mitodl/ocw-to-hugo@1.25.0":
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.25.0.tgz#50f3a5c1f9997b4479fec434dcc4a2dc8a9ca6d5"
+  integrity sha512-XRKsQSU0PIn+BOqWSCbJ95ZkwJZ/HWYlSAyjziz3uWzrVapm++jqxe7QNp020VnSvG1ESfsFMf7BYyWM3yfZhA==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-to-hugo/issues/309 and https://github.com/mitodl/ocw-studio/issues/382

#### What's this PR do?
This PR updates the `ocw-to-hugo` version to 1.25.0 and releases code related to the two above issues

#### How should this be manually tested?
 - If you've never used `ocw-hugo-themes` before, read the readme about how to start up a course site
 - Make sure `OCW_TO_HUGO` path is not set, but configure AWS access and set `OCW_TEST_COURSE` to any course
 - Run `yarn install` and then spin up any course using `npm run start:course`
 - Ensure there are no errors and the course site spins up at http://localhost:3000
