### PR TITLE
separate primary course number and extra course numbers

### DIFF
--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -23,7 +23,7 @@
       </tr>
       <tr>
         <td class="pl-0">Course Number:</td>
-        <td>{{ partial "partial_collapse_list.html" (dict "list" $courseData.course_numbers "id" "course_numbers" "useLinks" false) }}</td>
+        <td>{{ partial "partial_collapse_list.html" (dict "list" ((slice $courseData.primary_course_number) | append $courseData.extra_course_numbers) "id" "course_numbers" "useLinks" false) }}</td>
       </tr>
       <tr>
         <td class="pl-0">Departments:</td>

--- a/course/layouts/partials/course_instructor_number.html
+++ b/course/layouts/partials/course_instructor_number.html
@@ -16,7 +16,8 @@
     <tr>
       <td class="px-2 py-2">Course No.</td>
       <td class="px-2 py-2">
-        {{- range $index, $course_number := $courseData.course_numbers -}}
+        {{- $courseData.primary_course_number -}},&nbsp;
+        {{- range $index, $course_number := $courseData.extra_course_numbers -}}
         {{- if $index -}},&nbsp;{{- end -}}
         {{- $course_number -}}
         {{- end -}}

--- a/course/layouts/partials/other_versions.html
+++ b/course/layouts/partials/other_versions.html
@@ -4,7 +4,7 @@
 {{ if gt (len $otherVersions) 0}}
 <div class="course-home-section w-100">
   <div class="container px-0 mx-0">
-    <h4 class="course-info-title font-weight-bold">OTHER {{ index $courseData.course_numbers 0  }} OFFERINGS ON OPENCOURSEWARE</h4>
+    <h4 class="course-info-title font-weight-bold">OTHER {{ index $courseData.primary_course_number  }} OFFERINGS ON OPENCOURSEWARE</h4>
     <p>OCW has multiple versions of this course as taught in different terms by different faculty, with distinct materials and pedagogy.</p>
     <ul class="other-version-list list-unstyled">
     {{ range $otherVersions }}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "1.25.0",
+    "@mitodl/ocw-to-hugo": "1.25.1",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.25.0.tgz#50f3a5c1f9997b4479fec434dcc4a2dc8a9ca6d5"
-  integrity sha512-XRKsQSU0PIn+BOqWSCbJ95ZkwJZ/HWYlSAyjziz3uWzrVapm++jqxe7QNp020VnSvG1ESfsFMf7BYyWM3yfZhA==
+"@mitodl/ocw-to-hugo@1.25.1":
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.25.1.tgz#45096150c0fdabb343203e272f750e75c11dd861"
+  integrity sha512-kZFqm+BivIVVu6XhKL+j0meXH2XAjIoVQK2iRE6vX3XXU7q3uCiF63U2rC8SBZZZ5fn/dKzgGMUkIsEHerUN/A==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to:
 - https://github.com/mitodl/ocw-to-hugo/issues/317
 - https://github.com/mitodl/ocw-hugo-projects/issues/25

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/318, we changed the way `ocw-to-hugo` renders course numbers in the data template.  Instead of being in one `course_numbers` array, the numbers were broken out into `primary_course_number` and `extra_course_numbers`.  This PR adjusts the theme templates to account for that change and updates the version of `ocw-to-hugo` to match.

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-hugo-themes` to spin up a course site locally before and make sure you have AWS S3 access configured
 - Make sure `OCW_TO_HUGO_PATH` is blank in your `.env` file, and set `OCW_TEST_COURSE` to `2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009`
 - Run `yarn install` to install the latest `ocw-to-hugo`
 - Run `npm run start:course` and ensure that the site builds without error
 - Visit http://localhost:3000 and ensure that the course site renders and you see both course numbers in the course info section
