### PR TITLE
Don't initialize the video player setup

### DIFF
--- a/course/assets/course.js
+++ b/course/assets/course.js
@@ -4,7 +4,6 @@ import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
 import "nanogallery2/src/jquery.nanogallery2.core.js"
 
 import "./css/course.scss"
-import videojs from "video.js"
 import "videojs-youtube"
 
 import { initPdfViewers } from "./js/pdf_viewer"
@@ -15,20 +14,4 @@ $(document).ready(() => {
   initPdfViewers()
   initDesktopCourseInfoToggle()
   initCourseInfoExpander(document)
-  videojs("vid1", {
-    controlBar: {
-      children: [
-        "playToggle",
-        "volumePanel",
-        "progressControl",
-        "currentTimeDisplay",
-        "timeDivider",
-        "durationDisplay",
-        "playbackRateMenuButton",
-        "subsCapsButton",
-        "qualitySelector",
-        "fullscreenToggle"
-      ]
-    }
-  })
 })

--- a/course/layouts/partials/youtube_player.html
+++ b/course/layouts/partials/youtube_player.html
@@ -1,6 +1,6 @@
 <div class="video-container">
   <video
-    id="vid1"
+    id="video-player"
     class="video-js vjs-default-skin vjs-big-play-centered vjs-ocw"
     autoplay
     controls


### PR DESCRIPTION

#### What are the relevant tickets?
Fix #142 

#### What's this PR do?
There are three ways to pass options to Video.js.  We are using the data-setup attribute to trigger the player setup, so no need to pass it to videojs function.

#### How should this be manually tested?
There should be no errors

