### PR TITLE
use primary_course_number on home_course_cards partial

### DIFF
--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -34,7 +34,7 @@
                     </a>
                     <div class="course-card-content pt-1 px-3 pb-3">
                       <div class="course-level">
-                        {{ index $courseData.course_numbers 0 }} | {{ $courseData.level }}
+                        {{ $courseData.primary_course_number }} | {{ $courseData.level }}
                       </div>
                       <div class="pt-1">
                         <div class="h5">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/147

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/423, we updated `ocw-studio` to use `primary_course_number` and `extra_course_numbers` instead of `course_numbers`.  The `course_numbers` array was separated out into primary and extra course numbers in https://github.com/mitodl/ocw-to-hugo/pull/318.  This PR adjusts the `home_course_cards.html` partial template to adjust for the `ocw-studio` API returning the new structure.

#### How should this be manually tested?
 - Clone https://github.com/mitodl/ocw-www
 - Set up `ocw-hugo-themes` to run locally (read the readme) and point `EXTERNAL_SITE_PATH` at your locally cloned `ocw-www`
 - Set `OCW_STUDIO_BASE_URL=http://ocw-studio-rc.odl.mit.edu`
 - Run the site with `npm start`
 - Visit the site at http://localhost:3000 and verify that the "new courses" section renders.  Note that the images will not load because of the `coursemedia` prefix used on the live site.  This is expected.
