### PR TITLE
course description from data template

### DIFF
--- a/course/layouts/course/course_home.html
+++ b/course/layouts/course/course_home.html
@@ -26,7 +26,7 @@
       {{ partial "mobile_nav_toggle.html" . }}
       <div class="col-lg-8 course-description expand-container {{ if $shouldCollapseContent }}collapsed{{ end }}">
         <h4 class="font-weight-bold course-description-title">Course Description</h4>
-        <div class="mb-1 description">{{- .Content -}}</div>
+        <div class="mb-1 description">{{- $courseData.course_description | markdownify -}}</div>
         <div class="mb-3">
           {{ if $shouldCollapseContent }}
             <button class="expand-link" aria-expanded="false">

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "1.25.1",
+    "@mitodl/ocw-to-hugo": "1.26.1",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@1.25.1":
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.25.1.tgz#45096150c0fdabb343203e272f750e75c11dd861"
-  integrity sha512-kZFqm+BivIVVu6XhKL+j0meXH2XAjIoVQK2iRE6vX3XXU7q3uCiF63U2rC8SBZZZ5fn/dKzgGMUkIsEHerUN/A==
+"@mitodl/ocw-to-hugo@1.26.1":
+  version "1.26.1"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.26.1.tgz#079b0a5a2b3d6a82a17af39cbebb6cdba5dcd41a"
+  integrity sha512-jlM45VxlLZduLqMt96xMPsFB8di5xDkfCTG9fsmYANxANflgGSCpYnC23hMR3BOazR8XkQ0EUca4VEaVcuFQiw==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/150

#### What's this PR do?
In mitodl/ocw-to-hugo#323, we moved the course description from the course home page's markdown body to the course data template under the course_description property. This PR adjusts the course home template to source the course description from the new `course_description` property in the data template, passing it through `markdownify` as it is expected that it will be a markdown string.

#### How should this be manually tested?
 - Read the readme if you have never run a course site locally before
 - Make sure `OCW_TO_HUGO_PATH` and `OCW_TO_HUGO_OUTPUT_DIR` are blank in your `.env`, and `OCW_TEST_COURSE` is set to any course ID
 - Run `yarn install`
 - Run `npm run start:course`
 - Verify that the course site is available at http://localhost:3000 and that the course description is present on the home page
