### PR TITLE
update ocw-to-hugo to 1.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "1.26.1",
+    "@mitodl/ocw-to-hugo": "1.27.0",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Releases https://github.com/mitodl/ocw-to-hugo/issues/325

#### What's this PR do?
This PR updates `ocw-to-hugo` to 1.27.0, which includes fixes for unrendered shortcodes appearing in the course description after the transition to storing it in the course data template.

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-hugo-themes` to spin up a course site locally before and make sure you have AWS S3 access configured
 - Make sure `OCW_TO_HUGO_PATH` is blank in your `.env` file, and set `OCW_TEST_COURSE` to `12-000-solving-complex-problems-fall-2003`
 - Run `yarn install` to install the latest `ocw-to-hugo`
 - Run `npm run start:course` and ensure that the site builds without error
 - Visit http://localhost:3000 and ensure that the course site renders and you can click the links in the course description
