### PR TITLE
update lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@1.26.1":
-  version "1.26.1"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.26.1.tgz#079b0a5a2b3d6a82a17af39cbebb6cdba5dcd41a"
-  integrity sha512-jlM45VxlLZduLqMt96xMPsFB8di5xDkfCTG9fsmYANxANflgGSCpYnC23hMR3BOazR8XkQ0EUca4VEaVcuFQiw==
+"@mitodl/ocw-to-hugo@1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.27.0.tgz#e12355944ffd9b646f08d98b62d11c56acf4b43d"
+  integrity sha512-/BZXGCB1ln1gDP0zohhjUpvUkJNrdw/GaGrar3McOEHXBCfREMxgzLXRyXTXNpBm4OIk23ryC3QuzJpbzd2Lxg==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
This PR updates the Node lockfile.  It was inadvertently not updated when merging https://github.com/mitodl/ocw-hugo-themes/pull/153 because of oversight, but also CI did not fail on the PR branch.  The check only started failing after merging to main.  Looking at the checks from the PR that updated `ocw-to-hugo` to 1.27.0, the CI checks did not run, which is why this wasn't noticed in the PR review: https://github.com/mitodl/ocw-hugo-themes/pull/153/checks.  The CI checks are being run on every other PR, and this PR was created on August 10th 2021 when Github was having some serious outage issues.  I believe this is why the checks did not run.

#### How should this be manually tested?
 - Remove your `node_modules` folder if it exists
 - Run `yarn install --frozen-lockfile --ignore-engines --prefer-offline` and you should see no errors
