### PR TITLE
remove references to course_id in front matter and the data template

### DIFF
--- a/course/layouts/course/baseof.html
+++ b/course/layouts/course/baseof.html
@@ -10,8 +10,8 @@
     <!-- End Google Tag Manager (noscript) -->
   {{ end }}
   <div class="overflow-auto">
-    {{ partialCached "mobile_course_nav.html" . .Params.course_id }}
-    {{ partialCached "mobile_course_info.html" . .Params.course_id }}
+    {{ partialCached "mobile_course_nav.html" . }}
+    {{ partialCached "mobile_course_info.html" . }}
     {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
     {{ $isCourseHomePage := (eq .Params.layout "course_home") }}
     {{ if not $isCourseHomePage }}
@@ -22,10 +22,10 @@
       </div>
     </div>
     {{ end }}
-    {{ block "subheader" . }}{{ partialCached "course_banner.html" . .Params.course_id }}{{ end }}
+    {{ block "subheader" . }}{{ partialCached "course_banner.html" . }}{{ end }}
     <div class="container-fluid">
       <div class="row outer-wrapper">
-        {{ partialCached "desktop_nav.html" . .Params.course_id }}
+        {{ partialCached "desktop_nav.html" . }}
         <div class="left-col-bg"></div>
         <div id="main-content-wrapper" class="col-lg-9 p-0 bg-white">
           <main>
@@ -43,7 +43,7 @@
                   {{ block "main" . }}{{ end }}
                 </div>
                 {{ if not $isCourseHomePage }}
-                {{ partialCached "desktop_course_info.html" . .Params.course_id }}
+                {{ partialCached "desktop_course_info.html" . }}
                 {{ end }}
               </div>
             </div>

--- a/course/layouts/course/course_home.html
+++ b/course/layouts/course/course_home.html
@@ -1,5 +1,4 @@
 {{ define "main" }}
-{{ $courseId := .CurrentSection.Params.course_id }}
 {{ $courseData := .Site.Data.course }}
 {{ $courseThumbnailUrl := $courseData.course_thumbnail_image_url }}
 {{ $courseImageUrl := $courseData.course_image_url }}

--- a/course/layouts/partials/archived_versions.html
+++ b/course/layouts/partials/archived_versions.html
@@ -1,4 +1,3 @@
-{{ $courseId := .Params.course_id }}
 {{ $courseData := .Site.Data.course }}
 {{ $archivedVersions := $courseData.archived_versions }}
 {{ if gt (len $archivedVersions) 0}}

--- a/course/layouts/partials/course_banner.html
+++ b/course/layouts/partials/course_banner.html
@@ -2,7 +2,6 @@
 {{ $currentPage := . }}
 <div id="course-banner" class="p-0">
   <div class="max-content-width m-auto px-5 py-6">
-    {{ $courseId := $currentPage.Params.course_id }}
     {{ $courseData := .Site.Data.course }}
     {{ $courseHomePage := .Site.GetPage "/" }}
     <a

--- a/course/layouts/partials/course_features.html
+++ b/course/layouts/partials/course_features.html
@@ -1,4 +1,3 @@
-{{ $courseId := .context.Params.course_id }}
 {{ $courseData := .context.Site.Data.course }}
 {{ $inPanel := .inPanel }}
 <div class="course-home-section w-100 {{ if $inPanel }}in-panel{{ else }}bg-light{{ end }}">

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -1,4 +1,3 @@
-{{ $courseId := .context.Params.course_id }}
 {{ $courseData := .context.Site.Data.course }}
 {{ $inPanel := .inPanel }}
 <div class="table-responsive course-info expand-container {{ if not $inPanel }}collapsed{{ end }}">

--- a/course/layouts/partials/course_instructor_number.html
+++ b/course/layouts/partials/course_instructor_number.html
@@ -1,4 +1,3 @@
-{{ $courseId := .Params.course_id }}
 {{ $courseData := .Site.Data.course }}
 <div class="instructor-and-number">
   <table class="table table-borderless mb-2">

--- a/course/layouts/partials/open_learning_library_versions.html
+++ b/course/layouts/partials/open_learning_library_versions.html
@@ -1,4 +1,3 @@
-{{ $courseId := .Params.course_id }}
 {{ $courseData := .Site.Data.course }}
 {{ $openLearningLibraryVersions := $courseData.open_learning_library_versions }}
 {{ if gt (len $openLearningLibraryVersions) 0}}

--- a/course/layouts/partials/other_versions.html
+++ b/course/layouts/partials/other_versions.html
@@ -1,4 +1,3 @@
-{{ $courseId := .Params.course_id }}
 {{ $courseData := .Site.Data.course }}
 {{ $otherVersions := $courseData.other_versions }}
 {{ if gt (len $otherVersions) 0}}

--- a/course/layouts/partials/topics.html
+++ b/course/layouts/partials/topics.html
@@ -1,4 +1,3 @@
-{{ $courseId := .context.Params.course_id }}
 {{ $courseData := .context.Site.Data.course }}
 <div class="border-bottom-gray mb-2">
   <h4 class="course-info-title font-weight-bold">Topics</h4>

--- a/course/layouts/partials/topics_oneline.html
+++ b/course/layouts/partials/topics_oneline.html
@@ -1,4 +1,3 @@
-{{ $courseId := .context.Params.course_id }}
 {{ $courseData := .context.Site.Data.course }}
 <ul class="list-unstyled pb-2 m-0">
 {{ range $topic := $courseData.topics }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/154

#### What's this PR do?
In our move to building sites with content generated by `ocw-studio`, `course_id` will no longer be set on the front matter of every page or in the course data template.  Since it is no longer necessary to build a course site, references it it have been removed in this PR.

#### How should this be manually tested?
 - Read the readme if you've never spun up a course locally before
 - Spin up any course and ensure it does so without error
 - Browse to the course and ensure that you can click around to the different sections
