### PR TITLE
Disable autoplay

### DIFF
--- a/course/layouts/partials/youtube_player.html
+++ b/course/layouts/partials/youtube_player.html
@@ -2,7 +2,6 @@
   <video
     id="video-player"
     class="video-js vjs-default-skin vjs-big-play-centered vjs-ocw"
-    autoplay
     controls
     data-setup='{
     "fluid": true,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #163 

#### What's this PR do?
Removes the autoplay attribute from the video element to disable autoplay

#### How should this be manually tested?
I don't have access to a Safari browser but if you do you can view /courses/5-112-principles-of-chemical-science-fall-2005/sections/video-lectures/lecture-2-discovery-of-nucleus/ for example and see if the video autoplays