### PR TITLE
use level text and search url

### DIFF
--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -34,7 +34,7 @@
                     </a>
                     <div class="course-card-content pt-1 px-3 pb-3">
                       <div class="course-level">
-                        {{ $courseData.primary_course_number }} | {{ $courseData.level }}
+                        {{ $courseData.primary_course_number }} | <a href="{{ $courseData.level.url }}">{{ $courseData.level.level }}</a>
                       </div>
                       <div class="pt-1">
                         <div class="h5">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/161

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/244, the `level` property was changed to an object containing the text of a level as well as a search URL.  The `home_course_cards.html` template was never adjusted to match this, and instead of displaying the level, it's displaying a string representation of the level object.  This PR adjusts the template to generate a link to the search URL using the data contained in the object.

#### How should this be manually tested?
 - Read the readme if you've never spun up `ocw-wvw` before using `ocw-hugo-themes`, you'll need to clone https://github.com/mitodl/ocw-www and point to it using `EXTERNAL_SITE_PATH`
 - Spin up `ocw-www` using `npm start`
 - Verify that the `level` links on the course home cards are clickable links that take you to `/search` with the appropriate query string (note that images will not work locally)
