### PR TITLE
add templates to render instructor static JSON API responses

### DIFF
--- a/base-theme/layouts/_default/baseof.json.json
+++ b/base-theme/layouts/_default/baseof.json.json
@@ -1,0 +1,3 @@
+{
+  "data": {{ block "response" . }}{{ end }}
+}

--- a/base-theme/layouts/_default/single.json.json
+++ b/base-theme/layouts/_default/single.json.json
@@ -1,0 +1,1 @@
+{{ define "response" }} {{ .Render "item" }} {{ end }}

--- a/www/layouts/instructor/item.json.json
+++ b/www/layouts/instructor/item.json.json
@@ -1,0 +1,8 @@
+{
+  "title": "{{ .Params.title }}",
+  "first_name": "{{ .Params.first_name }}",
+  "last_name": "{{ .Params.last_name }}",
+  "middle_initial": "{{ .Params.middle_initial }}",
+  "salutation": "{{ .Params.salutation }}",
+  "uid": "{{ .Params.uid }}"
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/166

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/518, we set up `ocw-studio` to publish instructors imported from `ocw-to-hugo` output so markdown files are created for each one when publishing `ocw-www`.  This PR adds JSON templates to the base and www themes that will tell Hugo to render JSON files for content with `type: instructor`.  In the resulting site, you will have a static API that can be queried for instructor information.

#### How should this be manually tested?
 - Read the readme if you've never worked with `ocw-hugo-themes` before
 - Spin up the webpack dev server locally by running `npm run start:site:webpack`
 - Clone https://github.com/mitodl/ocw-hugo-projects on the `cg/json-media-types` branch
 - Clone https://github.mit.edu/ocw-content-rc/ocw-www/ and open a terminal in the resulting folder
 - Run `hugo server --config /path/to/ocw-hugo-projects/ocw-www/config.yaml --themesDir /path/to/ocw-hugo-themes/`, replacing the example paths with the paths to your cloned repos
 - Pick an instructor in the source `ocw-www` data and visit your local dev site verifying that the instructor exists and data is returned, for example: http://localhost:1313/instructors/0a90e4c5-5f99-646e-cbfc-402250d8aba5/index.json
