### PR TITLE
fix home course card links

### DIFF
--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -22,7 +22,7 @@
         <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
           {{ range $index, $courseItem := (first 10 $results)  }}
             {{ with $courseItem }}
-              {{ $courseId := $courseItem.metadata.course_id }}
+              {{ $courseId := $courseItem.name }}
               {{ $courseData := $courseItem.metadata}}
               {{ $modulo := (mod $index $itemsInCarousel) }}
               {{ $group := (div $index $itemsInCarousel) }}
@@ -31,7 +31,7 @@
               {{ end }}
                 <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                   <div class="course-card card bg-white">
-                    <a href="/courses/{{ $courseData.course_id }}">
+                    <a href="/courses/{{ $courseId }}">
                       <img src="{{ $courseData.course_image_url }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
                     </a>
                     <div class="course-card-content pt-1 px-3 pb-3">
@@ -40,7 +40,7 @@
                       </div>
                       <div class="pt-1">
                         <div class="h5">
-                          <a href="/courses/{{ $courseData.course_id }}">{{ $courseData.course_title }}</a>
+                          <a href="/courses/{{ $courseId }}">{{ $courseData.course_title }}</a>
                         </div>
                       </div>
                       <div class="pt-1">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/175

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/331, we made some adjustments to the `ocw-to-hugo` output to more closely match published content from `ocw-studio`.  One of these changes was removing the `course_id` property that was deposited in the course data template and all pages' front matter.  Since `ocw-studio` imports legacy OCW courses by consuming `ocw-to-hugo` output, this change was imported into `ocw-studio` and `course_id` is now not present in the API results.  This PR changes calls to `course_id` in the `home_course_cards.html` layout to instead get this value from `name`, where the same value is stored as the slug of the `Website` object in `ocw-studio`

#### How should this be manually tested?
 - Read the readme before if you have never spun up `ocw-www` locally
 - Clone https://github.com/mitodl/ocw-www
 - In your `.env`, make sure `EXTERNAL_SITE_PATH` is set to your path to `ocw-www` and make sure `OCW_STUDIO_BASE_URL` is set to http://ocw-studio-rc.odl.mit.edu and `OCW_IMPORT_STARTER_SLUG` is set to `ocw-course`
 - Run `npm start`
 - Visit http://localhost:3000/ and ensure that courses are displayed in the new courses section, noting that images will not work because of the current `coursemedia` prefix being assigned
 - Verify that the links on the cards are generated properly in that they look something like http://localhost:3000/courses/17-263-american-elections-fall-2020/ (for example), noting that the links will not actually go to a course because you are only running `ocw-www` locally.  As long as the links are generated properly, they should work as long as that course exists within the rendered site.
