### PR TITLE
allow comments in .env, put .env sourcing in one place

### DIFF
--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -2,9 +2,8 @@
 
 set -euo pipefail
 
-if test -f ".env"; then
-  export $(cat .env | xargs)
-fi
+source build_scripts/common.sh
+load_env
 
 if [[ -z "${EXTERNAL_SITE_PATH}" ]]; then
   echo "EXTERNAL_SITE_PATH not set"

--- a/build_scripts/build_all_courses.sh
+++ b/build_scripts/build_all_courses.sh
@@ -2,9 +2,8 @@
 
 set -euo pipefail
 
-if test -f ".env"; then
-  export $(cat .env | xargs)
-fi
+source build_scripts/common.sh
+load_env
 
 # If the VERBOSE variable isn't set, default it to 0
 if [[ -z "${VERBOSE+x}" ]]; then

--- a/build_scripts/common.sh
+++ b/build_scripts/common.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# test for `.env` file and export all env vars in it if found
+# 
+# pass --require-dot-env to error if the file is not present
+#
+# note that you *must* `set -euo pipefail` in scripts that call this function!
+load_env () {
+    if test -f ".env"; then
+        export $(cat .env | grep -v '#' | xargs)
+    else
+        # .env not found, check if we're requiring its presence
+        if [[ "$1" ]]; then
+            if [[ "$1" == "--require-dot-env" ]]; then
+                echo ".env file not found"
+                return 1
+            else
+                echo "unrecognized argument: $1"
+                echo "pass --require-dot-env to error if .env file not present"
+                return 1
+            fi
+        fi
+    fi
+}

--- a/build_scripts/import_courses.sh
+++ b/build_scripts/import_courses.sh
@@ -2,9 +2,8 @@
 
 set -euo pipefail
 
-if test -f ".env"; then
-  export $(cat .env | xargs)
-fi
+source build_scripts/common.sh
+load_env
 
 if [[ -z "${OCW_TO_HUGO_PATH}" ]]; then
   OCW_TO_HUGO_PATH="node_modules/@mitodl/ocw-to-hugo"

--- a/build_scripts/prep_external_site.sh
+++ b/build_scripts/prep_external_site.sh
@@ -2,9 +2,8 @@
 
 set -euo pipefail
 
-if test -f ".env"; then
-  export $(cat .env | xargs)
-fi
+source build_scripts/common.sh
+load_env
 
 if [[ -z "${EXTERNAL_SITE_PATH}" ]]; then
   echo "EXTERNAL_SITE_PATH not set"

--- a/build_scripts/start_course.sh
+++ b/build_scripts/start_course.sh
@@ -2,12 +2,8 @@
 
 set -euo pipefail
 
-if test -f ".env"; then
-  export $(cat .env | xargs)
-else
-  echo ".env file not found"
-  exit 1
-fi
+source build_scripts/common.sh
+load_env --require-dot-env
 
 # If the DOWNLOAD variable isn't set, default it to 1
 if [[ -z "${DOWNLOAD+x}" ]]; then

--- a/build_scripts/start_site.sh
+++ b/build_scripts/start_site.sh
@@ -2,12 +2,8 @@
 
 set -euo pipefail
 
-if test -f ".env"; then
-  export $(cat .env | xargs)
-else
-  echo ".env file not found"
-  exit 1
-fi
+source build_scripts/common.sh
+load_env --require-dot-env
 
 if [[ -z "${EXTERNAL_SITE_PATH}" ]]; then
   echo "EXTERNAL_SITE_PATH not set"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #178 

#### What's this PR do?

two things:

- allow use of `#` to comment out lines in a `.env` file
- write a single function for sourcing `.env` which can be called in all of our bash scripts in this repo

#### How should this be manually tested?

I think try a few things:

- ensure all functionality works as normal with your standard `.env` file
- add a commented line to it and ensure it still works as well
- delete `.env` and ensure that build scripts still fail on `env file not found` NOT on trying to access a variable. i.e. if you want add an `echo` statement just after the line where we call `source_env` in one of the build scripts and ensure that that line doesn't execute.

those are the main things I think.