### PR TITLE
Add joining slash if none exists to course feature urls

### DIFF
--- a/course/layouts/partials/course_feature.html
+++ b/course/layouts/partials/course_feature.html
@@ -1,4 +1,5 @@
-<a href="{{- strings.TrimSuffix "/" site.BaseURL -}}{{- .url -}}">
+{{- $baseUrl := strings.TrimSuffix "/" site.BaseURL -}}
+<a href="{{- if $baseUrl -}}/{{- strings.TrimPrefix "/" .url -}}{{- else -}}{{- .url -}}{{- end -}}">
   <div class="d-inline-flex pr-5 pb-2 font-weight-bold">
     <i class="course-feature-icon material-icons h2 pr-2 mb-0">
       {{- if eq .feature "Course Introduction" -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #182 

#### What's this PR do?
Adjusts the template code for course feature links to handle joining the baseurl to links without prefix slashes 

#### How should this be manually tested?
Convert a course with feature links using https://github.com/mitodl/ocw-to-hugo/pull/342 and run `npm run build:course` using that course. The links should work properly, on the course home page or any other page. 

This PR should also work with courses not converted by https://github.com/mitodl/ocw-to-hugo/pull/342 so that it can be merged without blocking anything