### PR TITLE
check instructors before use

### DIFF
--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -14,13 +14,15 @@
   <div class="position-relative">
     <div class="opaque-layer"></div>
     <table id="course-info-table" class="table table-borderless {{ if $inPanel }}border-bottom-gray{{ end }} mb-2">
+      {{ with $courseData.instructors.content }}
       <tr>
-        {{ $instructors := partial "get_instructors.html" $courseData.instructors.content }}
+        {{ $instructors := partial "get_instructors.html" . }}
         <td class="pl-0">{{ if eq (len $instructors) 1 }}Instructor{{ else }}Instructors{{ end }}:</td>
         <td>
           {{ partial "partial_collapse_list.html" (dict "list" $instructors "id" "instructors" "key" "title" "klass" "course-info-instructor" "showCollapse" .inPanel) }}
         </td>
       </tr>
+      {{ end }}
       <tr>
         <td class="pl-0">Course Number:</td>
         <td>{{ partial "partial_collapse_list.html" (dict "list" ((slice $courseData.primary_course_number) | append (split $courseData.extra_course_numbers ",")) "id" "course_numbers" "useLinks" false) }}</td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/195

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/186 we altered how instructors are sourced, pulling their data from a static JSON API.  Unfortunately, the array of UUID's being empty was not considered and breaks the build.  This PR adds a check to make sure the array is not empty.

#### How should this be manually tested?
 - Read the readme if you've never spun up a course site locally before and make sure you have S3 access to RC set up
 - Set `OCW_TEST_COURSE` to `iit-jee`
 - Run `npm run start:course`
 - The course site should spin up without errors, although there will be missing data and the "course" will have no sections
