### PR TITLE
fix inpanel

### DIFF
--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -1,5 +1,5 @@
 {{ $courseData := .context.Site.Data.course }}
-{{ $inPanel := $inPanel }}
+{{ $inPanel := .inPanel }}
 <div class="table-responsive course-info expand-container {{ if not $inPanel }}collapsed{{ end }}">
   <div class="course-info-expander">
     {{ if not $inPanel }}

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -1,5 +1,5 @@
 {{ $courseData := .context.Site.Data.course }}
-{{ $inPanel := .inPanel }}
+{{ $inPanel := $inPanel }}
 <div class="table-responsive course-info expand-container {{ if not $inPanel }}collapsed{{ end }}">
   <div class="course-info-expander">
     {{ if not $inPanel }}
@@ -19,7 +19,7 @@
         {{ $instructors := partial "get_instructors.html" . }}
         <td class="pl-0">{{ if eq (len $instructors) 1 }}Instructor{{ else }}Instructors{{ end }}:</td>
         <td>
-          {{ partial "partial_collapse_list.html" (dict "list" $instructors "id" "instructors" "key" "title" "klass" "course-info-instructor" "showCollapse" .inPanel) }}
+          {{ partial "partial_collapse_list.html" (dict "list" $instructors "id" "instructors" "key" "title" "klass" "course-info-instructor" "showCollapse" $inPanel) }}
         </td>
       </tr>
       {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/199

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/196, we utilized the `with` statement to only process instructors if they exist.  An issue with this was missed where since the context is being rebound with in the `with` statement, `.inPanel` is invalid because it doesn't exist in the redefined context.  This PR sets the partial call to use the locally defined `$inPanel` variable within the course info partial.

#### How should this be manually tested?
 - Read the readme if you've never spun up a course site locally before, and make sure you have S3 access to RC set up
 - Make sure `OCW_TEST_COURSE` is set to a valid course (I used `18-06-linear-algebra-spring-2010`) and make sure `OCW_TO_HUGO_PATH` is blank
 - Run `yarn install` to make sure you have the latest `ocw-to-hugo` installed as a dependency
 - Run `npm run start:course` and make sure the course site is available at http://localhost:3000/
