### PR TITLE
default subtopics to an empty slice

### DIFF
--- a/course/layouts/partials/topic.html
+++ b/course/layouts/partials/topic.html
@@ -1,9 +1,12 @@
 {{ $index := .index }}
 {{ $context := .context }}
+{{ $subtopics := slice }}
+{{ if not (eq .subtopics nil) }}
 {{ $subtopics := .subtopics }}
+{{ end }}
 {{ $scratch := newScratch }}
-<div class="position-relative pt-1 pb-1{{ if gt (len .subtopics) 0 }} pl-4{{ end }}">
-  {{ if gt (len .subtopics) 0 }}
+<div class="position-relative pt-1 pb-1{{ if gt (len $subtopics) 0 }} pl-4{{ end }}">
+  {{ if gt (len $subtopics) 0 }}
   <a class="topic-toggle"
     href="#subtopic-container_{{ $index }}"
     data-toggle="collapse"
@@ -18,10 +21,10 @@
     </a>
   </span>
 </div>
-{{ if gt (len .subtopics) 0 }}
+{{ if gt (len $subtopics) 0 }}
 <div class="pl-4 subtopic-container collapse{{if eq $index 0 }} show{{ end }}" id="subtopic-container_{{ $index }}">
   {{ $scratch.Set "index" 0 }}
-  {{ range $subtopic, $specialities := .subtopics }}
+  {{ range $subtopic, $specialities := $subtopics }}
   {{ $subtopicIndex := $scratch.Get "index" }}
   <div class="position-relative pt-1 pb-1 {{ if gt (len ($specialities | default slice)) 0 }} pl-4{{ end }}">
     {{ if gt (len ($specialities | default slice)) 0 }}

--- a/course/layouts/partials/topic.html
+++ b/course/layouts/partials/topic.html
@@ -2,7 +2,7 @@
 {{ $context := .context }}
 {{ $subtopics := slice }}
 {{ if not (eq .subtopics nil) }}
-{{ $subtopics := .subtopics }}
+{{ $subtopics = .subtopics }}
 {{ end }}
 {{ $scratch := newScratch }}
 <div class="position-relative pt-1 pb-1{{ if gt (len $subtopics) 0 }} pl-4{{ end }}">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/201

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/193, we updated the topics partial to be compatible with the updated structure in the latest version of `ocw-to-hugo` that was set up to match the published output of `ocw-studio`.  This PR fixes a bug introduced there where if subtopics are not set, there will be an error caused by calling `len` on them.  It's fixed by defaulting the local variable to an empty slice.

#### How should this be manually tested?
 - Read the readme if you've never spun up a course site locally before, and make sure you have S3 access to RC set up
 - Make sure `OCW_TEST_COURSE` is set to `10-01-ethics-for-engineers-spring-2020` and make sure `OCW_TO_HUGO_PATH` is blank
 - Overwrite `course/layouts/partials/course_info.html` with https://raw.githubusercontent.com/mitodl/ocw-hugo-themes/cg/fix-inpanel/course/layouts/partials/course_info.html
 - Run `yarn install` to make sure you have the latest `ocw-to-hugo` installed as a dependency
 - Run `npm run start:course` and make sure the course site is available at http://localhost:3000/
