### PR TITLE
Update ocw-to-hugo to fix typo bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "1.30.2",
+    "@mitodl/ocw-to-hugo": "^1.31.0",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@1.30.2":
-  version "1.30.2"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.30.2.tgz#cd844cf6a9e01d42a292290f9ed12c71ea9e6bf5"
-  integrity sha512-s11fKtLJ6RFkVY5jbBdgjYAbMT4wvsIBetu6RyDDtuVsUgH30/t4Re6kj2v5afUbIRV3K0kLDyMieiWhXkdklw==
+"@mitodl/ocw-to-hugo@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.31.0.tgz#5bd6745eee6e1b5fc05fa2ad2edf11ee6d8b6391"
+  integrity sha512-YfTW2YProjAci2tR4m80KBksNft4HNIJvnAGhbOagGibonYpXM2ajhghtRj0GgSUuyXcuC3xRHrRq9VUl3vVKA==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/pull/375

#### What's this PR do?
Upgrades ocw-to-hugo to fix a typo bug

#### How should this be manually tested?
I don't think you would see any changes here regarding this bug. It only affects ocw-studio's import at the moment