### PR TITLE
fix home course cards topics

### DIFF
--- a/www/layouts/partials/topics_summary.html
+++ b/www/layouts/partials/topics_summary.html
@@ -1,11 +1,7 @@
 {{- $topicsList := slice -}}
-{{- range $topic := . -}}
-    {{- if not $topic.subtopics -}}
-        {{- $topicsList = $topicsList | append (title $topic.topic) -}}
-    {{- else -}}
-        {{- range $subtopic := $topic.subtopics -}}
-        {{- $topicsList = $topicsList | append (title $subtopic.subtopic) -}}
-        {{- end -}}
+{{- range $topicList := . -}}
+    {{- range $topic := $topicList -}}
+        {{- $topicsList = $topicsList | append (title $topic) -}}
     {{- end -}}
 {{- end -}}
 {{- delimit (first 3 (uniq $topicsList)) ", " -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/206

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/370, we changed the way `ocw-to-hugo` outputs topics to match the way `ocw-studio` publishes them using the `ocw-course` starter configuration.  This PR adjusts the rendering of `topics_summary.html` to reflect these changes.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-hugo-themes` to spin up `ocw-www` locally before
 - Clone https://github.com/mitodl/ocw-www and point to it in your `.env` with `EXTERNAL_SITE_PATH`
 - Make sure you have `OCW_STUDIO_BASE_URL=http://ocw-studio-rc.odl.mit.edu/` in your `.env` as well
 - Run `npm start`
 - Verify that the OCW home page is available at http://localhost:3000, noting that course images on the cards will not be available.  Verify that topics are displayed on the course cards.
