### PR TITLE
course images from resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ There are some environment variables you can use to configure optional funcional
 | `SEARCH_API_URL` | `http://localhost:8063/api/v0/search/` | A URL to an `open-discussions` search API to fetch results from|
 | `OCW_STUDIO_BASE_URL` | `http://localhost:8043/` | A URL of an instance of [`ocw-studio`](https://github.com/mitodl/ocw-studio) to fetch home page content from |
 | `STATIC_API_BASE_URL` | `http://ocwnext.odl.mit.edu/` | A URL of a deployed Hugo site with a static JSON API to query against |
+| `RESOURCE_BASE_URL` | `https://open-learning-course-data-rc.s3.amazonaws.com/` | A base URL to prefix the rendered path to resources with |
 | `EXTERNAL_SITE_PATH` | `~/Code/ocw-www/site/` | A path to a Hugo site with content (Pages, Notifications, Promos, Testimonials) to use for local development |
 | `AWS_BUCKET_NAME` | `open-learning-course-data-production` | The S3 bucket `ocw-to-hugo` should source course data from |
 | `OCW_TEST_COURSE` | `18-06-linear-algebra-spring-2010` | An OCW course ID to use when spinning up a course site for local development with `npm run start:course` |

--- a/base-theme/layouts/partials/resource_url.html
+++ b/base-theme/layouts/partials/resource_url.html
@@ -1,0 +1,16 @@
+{{- $resources := where (where site.RegularPages "Section" "==" "resources") ".Params.resourcetype" "==" .resourcetype -}}
+{{- $resource := index (where $resources ".Params.uid" "==" .uid) 0 -}}
+{{/* 
+  Here we are disassembling the URL and returning it without the host and schema.
+  This is done because it is expected that ocw-studio currently returns fully 
+  qualified S3 URLs, and when deployed these will need to be behind CDN.
+
+  For temporarily backward compatability with ocw-to-hugo converted content, we check
+  file_location as well as file.
+
+  The RESOURCE_URL_PREFIX env variable is prefixed before the URL. That way for local 
+  development, you can set this to the S3 URL you expect the resources to be available at.
+*/}}
+{{- $resourceUrl := $resource.Params.file | default $resource.Params.file_location -}}
+{{- $prefix := getenv "RESOURCE_BASE_URL" | default "" -}}
+{{- return printf "%s%s" (strings.TrimSuffix "/" $prefix) (urls.Parse $resourceUrl).Path -}}

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -1,7 +1,9 @@
 {{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
-{{ $courseData := .Site.Data.course }}
-{{ $courseThumbnailUrl := $courseData.course_thumbnail_image_url }}
-{{ $courseImageUrl := $courseData.course_image_url }}
+{{- $courseData := .Site.Data.course -}}
+{{- $courseImageUid := index $courseData.course_image.content 0 -}}
+{{- $courseImageThumbnailUid := index $courseData.course_image_thumbnail.content 0 -}}
+{{- $courseImageUrl := partial "resource_url.html" (dict "resourcetype" "Image" "uid" $courseImageUid) -}}
+{{- $courseImageThumbnailUrl := partial "resource_url.html" (dict "resourcetype" "Image" "uid" $courseImageThumbnailUid) -}}
 <!doctype html>
 <html lang="{{ $.Site.Language.Lang }}">
 {{ partial "head.html" . }}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "^1.31.0",
+    "@mitodl/ocw-to-hugo": "^1.31.1",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/www/layouts/partials/resource_url.html
+++ b/www/layouts/partials/resource_url.html
@@ -1,9 +1,0 @@
-{{- $resources := where (where site.RegularPages "Type" "==" "resource") ".Params.filetype" "==" .filetype -}}
-{{- $resource := index (where $resources ".Params.uid" "==" .uid) 0 -}}
-{{/* 
-  Here we are disassembling the URL and returning it without the host and schema.
-  This is done because it is expected that ocw-studio currently returns fully 
-  qualified S3 URLs, and when deployed these will need to be behind CDN.
-*/}}
-{{- $resourceUrl := urls.Parse $resource.Params.file -}}
-{{- return printf $resourceUrl.Path -}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@^1.31.0":
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.31.0.tgz#5bd6745eee6e1b5fc05fa2ad2edf11ee6d8b6391"
-  integrity sha512-YfTW2YProjAci2tR4m80KBksNft4HNIJvnAGhbOagGibonYpXM2ajhghtRj0GgSUuyXcuC3xRHrRq9VUl3vVKA==
+"@mitodl/ocw-to-hugo@^1.31.1":
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.31.1.tgz#75cf35d28a1ab89800813991e0299565239e08ac"
+  integrity sha512-fN88JM0vw4lmoPh4jYh8IvczWq1YUGkbzKtrrW1FltMqEVxjCgmPLLeXxeFD8V9EfqUARWCRZFOBdHGa9w8ovQ==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/211

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/378, we altered the rendering of `course.json` to produce an `ocw-studio`-like reference to the course image resource content by UUID.  This PR updates the version of `ocw-to-hugo` in `package.json` and adjusts the theme to source images from the content in this manner:

 - `resource_url.html` was moved to `base-theme`
 - `resource_url.html` was set up to look for a URL in `.Params.file` first, but fall back to `.Params.file_location` because this is where `ocw-to-hugo` currently puts this property in converted legacy resources
 - An optional `RESOURCE_BASE_URL` env variable was added that will prefix resource URLs rendered in this partial with the value supplied. This way, when you are developing a course site locally, you can manually set the S3 base URL written in front of resources so images load correctly. The value can also just be left blank or unset and relative URLs will be written in instead.

#### How should this be manually tested?
 - Read the readme if you have never spun up a course site before
 - Ensure the following values are set in your `.env`:
   -`RESOURCE_BASE_URL=https://open-learning-course-data-rc.s3.amazonaws.com/`
  - `OCW_TO_HUGO_PATH` should be blank or unset
  - `OCW_TEST_COURSE` to any course id
 - Run `yarn install`
 - Run `npm run start:course` and visit http://localhost:3000
 - Ensure that the course image renders
