### PR TITLE
download transcript theme

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -323,3 +323,27 @@ article.content {
   max-width: 795px;
   border-bottom: 1px solid $medium-gray;
 }
+
+.download-file {
+  display: inline-flex;
+  padding: 10px 22px;
+  background-color: $medium-gray;
+  color: white;
+  text-decoration: none;
+}
+
+.video-buttons-container {
+  background-color: #f6f7f9;
+  overflow: hidden;
+}
+
+.download-transcript-container {
+  float: right;
+  padding-top: 25px;
+  padding-bottom: 25px;
+  padding-right: 25px;
+}
+
+.download-transcript-button {
+  float: right;
+}

--- a/course/assets/css/resource-page.scss
+++ b/course/assets/css/resource-page.scss
@@ -6,12 +6,4 @@
     flex-direction: row;
     align-items: center;
   }
-
-  .download-file {
-    display: inline-flex;
-    padding: 10px 22px;
-    background-color: $medium-gray;
-    color: white;
-    text-decoration: none;
-  }
 }

--- a/course/layouts/partials/video.html
+++ b/course/layouts/partials/video.html
@@ -1,8 +1,10 @@
 {{ $youtubeKey := .Params.video_metadata.youtube_id }}
 {{ $captionsLocation := .Params.video_files.video_captions_file }}
+{{ $transcriptLocation := .Params.video_files.video_transcript_file }}
+
 <div class="video-page">
   <div class="description">
     {{ .Params.about_this_resource_text | safeHTML }}
   </div>
-  {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation) }}
+  {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "transcriptLocation" $transcriptLocation) }}
 </div>

--- a/course/layouts/partials/youtube_player.html
+++ b/course/layouts/partials/youtube_player.html
@@ -12,4 +12,14 @@
         <track kind="captions" src="{{ .captionsLocation }}" srclang="en" label="English" default>
       {{ end }}
   </video>
+  {{ if .captionsLocation }}
+        <track kind="captions" src="{{ .captionsLocation }}" srclang="en" label="English" default>
+  {{ end }}
 </div>
+{{ if  .transcriptLocation}}
+  <div class="video-buttons-container">
+    <div class="col-6 download-transcript-container">
+      <a class="download-file download-transcript-button" href="{{ .transcriptLocation }}"><span class="material-icons">file_download</span> Download Transcript</a>
+    </div>
+  </div>
+{{end}}

--- a/course/layouts/shortcodes/youtube.html
+++ b/course/layouts/shortcodes/youtube.html
@@ -1,3 +1,4 @@
 {{ $youtubeId := index .Params 0 }}
 {{ $captionsLocation := index .Params 1}}
-{{ partial "youtube_player.html" (dict "youtubeKey" $youtubeId "captionsLocation" $captionsLocation) }}
+{{ $transcriptLocation := index .Params 2}}
+{{ partial "youtube_player.html" (dict "youtubeKey" $youtubeId "captionsLocation" $captionsLocation "transcriptLocation" $transcriptLocation) }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
<img width="1678" alt="Screen Shot 2021-10-07 at 8 32 02 AM" src="https://user-images.githubusercontent.com/1934992/136414394-93b210cd-15b9-40a7-aaba-3a0102bc4113.png">
<img width="376" alt="Screen Shot 2021-10-07 at 8 32 29 AM" src="https://user-images.githubusercontent.com/1934992/136414400-9c29e996-1fca-4181-a0ee-4360ea111f86.png">
<img width="1676" alt="Screen Shot 2021-10-07 at 8 34 52 AM" src="https://user-images.githubusercontent.com/1934992/136414406-a0053913-e01d-44ca-9c10-313a35b8ba5f.png">
<img width="376" alt="Screen Shot 2021-10-07 at 8 34 35 AM" src="https://user-images.githubusercontent.com/1934992/136414403-0f3ba158-5f0a-4cca-8fe7-8d09b56bb3d6.png">

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/209

#### What's this PR do?
This pr adds a download button for the pdf transcript for videos

#### How should this be manually tested?
run `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download` in ocw-to-hugo branch https://github.com/mitodl/ocw-to-hugo/pull/382

Run `npm run start:course` in this PR with `OCW_TEST_COURSE=15-401-finance-theory-i-fall-2008` (or another course with video lecture pages). Go to a video page. Verify that you see a transcript download button under the video and you can download the transcript. Also verify that you can turn on captions for the video.

Run `npm run start:course` in this PR with `OCW_TEST_COURSE=15-071-the-analytics-edge-spring-2017` (or another course with embedded youtube videos). Go to a page with an embedded youtube video. Verify that you see a transcript download button under the video and you can download the transcript. Also verify that you can turn on captions for the video.