### PR TITLE
fix course image

### DIFF
--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -1,7 +1,7 @@
 {{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
 {{- $courseData := .Site.Data.course -}}
-{{- $courseImageUid := index $courseData.course_image.content 0 -}}
-{{- $courseImageThumbnailUid := index $courseData.course_image_thumbnail.content 0 -}}
+{{- $courseImageUid := $courseData.course_image.content -}}
+{{- $courseImageThumbnailUid := $courseData.course_image_thumbnail.content -}}
 {{- $courseImageUrl := partial "resource_url.html" (dict "resourcetype" "Image" "uid" $courseImageUid) -}}
 {{- $courseImageThumbnailUrl := partial "resource_url.html" (dict "resourcetype" "Image" "uid" $courseImageThumbnailUid) -}}
 <!doctype html>

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "^1.31.1",
+    "@mitodl/ocw-to-hugo": "^1.32.0",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@^1.31.1":
-  version "1.31.1"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.31.1.tgz#75cf35d28a1ab89800813991e0299565239e08ac"
-  integrity sha512-fN88JM0vw4lmoPh4jYh8IvczWq1YUGkbzKtrrW1FltMqEVxjCgmPLLeXxeFD8V9EfqUARWCRZFOBdHGa9w8ovQ==
+"@mitodl/ocw-to-hugo@^1.32.0":
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.32.0.tgz#90b3e869affb73bd700467d72e8318e0ed8993a7"
+  integrity sha512-gLvOLK5SknHkJXRBniAow0pSQ/FA6/cKSAmkI5aEvmyMlTeaw3suij7Mru+c0B/FMqqfsS0thV9lyrdOSTiVaA==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/217

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/386, we fixed a bug where `ocw-to-hugo` would render the course image content as a list with a single UUID, rather than just a single string.  Since `ocw-studio` defines this as a 1 to 1 relationship, it isn't rendered as a list.  This PR updates the version of `ocw-to-hugo` to point at 1.32.0 and makes the necessary changes to the template to source the image URLs properly.

#### How should this be manually tested?
 - Read the readme if you've never spun up a course site locally before and make sure you're set up to download content from S3
 - Ensure that in your `.env`, `OCW_TO_HUGO_PATH` is omitted or set to blank, `RESOURCE_BASE_URL` is set to https://open-learning-course-data-rc.s3.amazonaws.com/ and `OCW_TEST_COURSE` is set to any course id
 - Run `yarn install`
 - Run `npm run start:course`
 - Verify that your course site renders and is available at http://localhost:3000 and that the course image is displayed
