### PR TITLE
Use resource_url partial to get file url

### DIFF
--- a/base-theme/layouts/partials/resource_url.html
+++ b/base-theme/layouts/partials/resource_url.html
@@ -1,14 +1,14 @@
 {{- $resources := where (where site.RegularPages "Section" "==" "resources") ".Params.resourcetype" "==" .resourcetype -}}
 {{- $resource := index (where $resources ".Params.uid" "==" .uid) 0 -}}
-{{/* 
+{{/*
   Here we are disassembling the URL and returning it without the host and schema.
-  This is done because it is expected that ocw-studio currently returns fully 
+  This is done because it is expected that ocw-studio currently returns fully
   qualified S3 URLs, and when deployed these will need to be behind CDN.
 
   For temporarily backward compatability with ocw-to-hugo converted content, we check
   file_location as well as file.
 
-  The RESOURCE_URL_PREFIX env variable is prefixed before the URL. That way for local 
+  The RESOURCE_BASE_URL env variable is prefixed before the URL. That way for local
   development, you can set this to the S3 URL you expect the resources to be available at.
 */}}
 {{- $resourceUrl := $resource.Params.file | default $resource.Params.file_location -}}

--- a/course/layouts/partials/image_page.html
+++ b/course/layouts/partials/image_page.html
@@ -20,10 +20,10 @@
     {{- end -}}
 {{- end -}}
 
-{{- if .Params.file_location -}}
+{{- if (partial "resource_url.html" .Params) -}}
     <div class="row">
         <div class="col-12">
-            <img class="mw-100" src="{{ .Params.file_location }}" alt="{{ if .Params.image_metadata }}{{ index .Params.image_metadata "image-alt" }}{{ end }}" />
+            <img class="mw-100" src="{{ partial "resource_url.html" .Params }}" alt="{{ if .Params.image_metadata }}{{ index .Params.image_metadata "image-alt" }}{{ end }}" />
         </div>
     </div>
 {{- end -}}

--- a/course/layouts/partials/pdf_viewer.html
+++ b/course/layouts/partials/pdf_viewer.html
@@ -1,12 +1,12 @@
 <div class="pdf-viewer w-100 pb-5">
   <div class="pr-4">
-    <a class="download-link" href="{{ .Params.file_location }}">
+    <a class="download-link" href="{{ partial "resource_url.html" .Params }}">
       <div class="btn bg-link-blue text-white rounded float-right mb-3">
         <span>DOWNLOAD</span>
         <div class="ripple-container"></div>
       </div>
     </a>
   </div>
-  <div class="pdf-wrapper w-100" data-pdfurl="{{ .Params.file_location }}">
+  <div class="pdf-wrapper w-100" data-pdfurl="{{ partial "resource_url.html" .Params }}">
   </div>
 </div>

--- a/course/layouts/resources/single.html
+++ b/course/layouts/resources/single.html
@@ -14,10 +14,10 @@
                 <div class="col-9">{{ delimit (.Params.learning_resource_types | default slice) ", " }}</div>
             </div>
         {{- end -}}
-        {{- if .Params.file_location -}}
+        {{- if (partial "resource_url.html" .Params) -}}
         <div class="row">
             <div class="col-12 d-flex flex-direction-row align-items-center">
-                <a class="download-file" href="{{ .Params.file_location }}"><span class="material-icons">file_download</span> Download File</a>
+                <a class="download-file" href="{{ partial "resource_url.html" .Params }}"><span class="material-icons">file_download</span> Download File</a>
             </div>
         </div>
         {{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #221 

#### What's this PR do?
Uses `file` where available, using the `resource_url` partial

#### How should this be manually tested?
- Download https://github.mit.edu/ocw-content-rc/18.06-spring-2010/tree/preview, unpack and save to a directory called `18-06-linear-algebra-spring-2010`. 
- Place it in a temporary directory and change `OCW_TO_HUGO_OUTPUT_DIR` to point to that directory.
- Set `RESOURCE_BASE_URL` to `https://ol-ocw-studio-app-qa.s3.amazonaws.com/`
- Go to Assignments and click the first PDF link
- Click the download link. It should work fine. You won't see the PDF rendered, but if you look at the browser console that is due to a CORS error. You should be able to click on the `data-pdfurl` link to download the PDF