### PR TITLE
Implement simple resource embed

### DIFF
--- a/base-theme/layouts/partials/resource_url.html
+++ b/base-theme/layouts/partials/resource_url.html
@@ -1,14 +1,14 @@
 {{- $resources := where (where site.RegularPages "Section" "==" "resources") ".Params.resourcetype" "==" .resourcetype -}}
 {{- $resource := index (where $resources ".Params.uid" "==" .uid) 0 -}}
-{{/* 
+{{/*
   Here we are disassembling the URL and returning it without the host and schema.
-  This is done because it is expected that ocw-studio currently returns fully 
+  This is done because it is expected that ocw-studio currently returns fully
   qualified S3 URLs, and when deployed these will need to be behind CDN.
 
   For temporarily backward compatability with ocw-to-hugo converted content, we check
   file_location as well as file.
 
-  The RESOURCE_URL_PREFIX env variable is prefixed before the URL. That way for local 
+  The RESOURCE_BASE_URL env variable is prefixed before the URL. That way for local
   development, you can set this to the S3 URL you expect the resources to be available at.
 */}}
 {{- $resourceUrl := $resource.Params.file | default $resource.Params.file_location -}}

--- a/course/layouts/partials/video_embed.html
+++ b/course/layouts/partials/video_embed.html
@@ -1,0 +1,3 @@
+{{ $youtubeKey := .Params.video_metadata.youtube_id }}
+{{ $captionsLocation := .Params.video_files.video_captions_file }}
+{{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation) }}

--- a/course/layouts/shortcodes/resource.html
+++ b/course/layouts/shortcodes/resource.html
@@ -1,6 +1,13 @@
 {{- $uuid := index .Params 0 -}}
 {{- range $.Site.Pages -}}
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
-    {{- .Permalink -}}
+    {{- if eq .Params.resourcetype "Image" -}}
+      {{- $metadata := .Params.image_metadata | default dict -}}
+      <img src="{{ .Params.file }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
+    {{- else if eq .Params.resourcetype "Video" -}}
+      {{ partial "video_embed.html" . }}
+    {{- else -}}
+      <a href="{{ .Params.file }}">{{ .Params.title }}</a>
+    {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #221 

#### What's this PR do?
Implements simple resource embeds

#### How should this be manually tested?
 - Go to RC and publish two courses to staging. I chose `18-06-linear-algebra-spring-2010` for the video embed and `1-011-project-evaluation-spring-2011` for the PDF and image resources, but feel free to pick any course that's applicable. I already added resource embeds in these two courses, but feel free to make modifications.
 - Go to github.mit.edu/ocw-course-rc and download the courses, and unzip them in a temporary directory
 - Point ocw-hugo-themes to the temporary directory, and delete `Title` from the `menu.yaml` file to workaround a bug
 - Point to `18-06-linear-algebra-spring-2010` and go to `/pages/test-page-2`. You should see the image and PDF resource embeds. Verify that the markdown contains two `resource` markdown elements. The image should also contain some trivial alt text.
 - Point to `1-011-project-evaluation-spring-2011` and go to `/pages/test-page`. It should show a video embed

#### Screenshots
![Screenshot from 2021-10-12 15-33-40](https://user-images.githubusercontent.com/863262/137019095-d5afba59-2768-4e75-be2d-d1887587a0fe.png)
![Screenshot from 2021-10-12 15-34-38](https://user-images.githubusercontent.com/863262/137019096-6591e542-23e5-4863-b481-b548398ba575.png)
