### PR TITLE
show transcripts under video

### DIFF
--- a/course/assets/course.js
+++ b/course/assets/course.js
@@ -9,9 +9,11 @@ import "videojs-youtube"
 import { initPdfViewers } from "./js/pdf_viewer"
 import { initDesktopCourseInfoToggle } from "./js/course_info_toggle"
 import { initCourseInfoExpander } from "./js/course_expander"
+import { initVideoTranscriptTrack } from "./js/video_transcript_track"
 
 $(document).ready(() => {
   initPdfViewers()
   initDesktopCourseInfoToggle()
   initCourseInfoExpander(document)
+  initVideoTranscriptTrack()
 })

--- a/course/assets/css/course.scss
+++ b/course/assets/css/course.scss
@@ -14,6 +14,7 @@
 @import "video";
 @import "videojs_player";
 @import "resource-page";
+@import "video-transcript";
 
 #course-banner {
   color: $white;

--- a/course/assets/css/video-transcript.scss
+++ b/course/assets/css/video-transcript.scss
@@ -1,0 +1,53 @@
+#transcript {
+  width: 100%;
+  margin: auto;
+  font-family: Arial, sans-serif;
+}
+
+.transcript-body {
+  height: 200px;
+  overflow-y: scroll;
+}
+
+.transcript-line {
+  position: relative;
+  padding: 5px;
+  cursor: pointer;
+  line-height: 1.3;
+}
+
+.transcript-timestamp {
+  position: absolute;
+  display: inline-block;
+  width: 75px;
+  margin-left: 20px;
+}
+
+.transcript-text {
+  display: block;
+  margin-left: 95px;
+}
+
+.transcript-line:hover {
+  background-color: #f6f7f9;
+}
+
+.transcript-line.is-active {
+  font-weight: bold;
+  color: #a31f34;
+}
+
+.transcript-section-toggle {
+  float: right;
+  margin-right: 15px;
+}
+
+.transcript-header {
+  background-color: #f6f7f9;
+  font-size: 23px;
+  padding-left: 20px;
+  padding-bottom: 5px;
+  padding-top: 10px;
+  margin-top: 35px;
+  margin-bottom: 10px;
+}

--- a/course/assets/js/navigation.js
+++ b/course/assets/js/navigation.js
@@ -1,24 +1,28 @@
 function courseNav() {
-  document.querySelectorAll(".course-nav").forEach(navEl => {
-    // set .active on the currently active link
-    navEl.querySelectorAll(".nav-link").forEach(navLinkEl => {
-      if (navLinkEl.getAttribute("href") === window.location.pathname) {
-        navLinkEl.classList.add("active")
-      }
-    })
+  document
+    .querySelectorAll(".course-nav, .transcript-header")
+    .forEach(navEl => {
+      // set .active on the currently active link
+      navEl.querySelectorAll(".nav-link").forEach(navLinkEl => {
+        if (navLinkEl.getAttribute("href") === window.location.pathname) {
+          navLinkEl.classList.add("active")
+        }
+      })
 
-    const activeEl = navEl.querySelector("a.nav-link.active")
+      const activeEl = navEl.querySelector("a.nav-link.active")
 
-    // iterate through nav items, find any that are parents of the active link, expanded if needed
-    navEl.querySelectorAll(".course-nav-list-item").forEach(navItemEl => {
-      const collapseEl = navItemEl.querySelector(".collapse")
-      if (collapseEl && collapseEl.contains(activeEl)) {
-        collapseEl.classList.add("show")
-        navItemEl
-          .querySelector(".course-nav-section-toggle")
-          .setAttribute("aria-expanded", true)
-      }
+      // iterate through nav items, find any that are parents of the active link, expanded if needed
+      navEl.querySelectorAll(".course-nav-list-item").forEach(navItemEl => {
+        const collapseEl = navItemEl.querySelector(".collapse")
+        if (collapseEl && collapseEl.contains(activeEl)) {
+          collapseEl.classList.add("show")
+          navItemEl
+            .querySelector(
+              ".course-nav-section-toggle, transcript-section-toggle"
+            )
+            .setAttribute("aria-expanded", true)
+        }
+      })
     })
-  })
 }
 courseNav()

--- a/course/assets/js/video_transcript_track.js
+++ b/course/assets/js/video_transcript_track.js
@@ -1,0 +1,20 @@
+import videojs from "video.js"
+
+export const initVideoTranscriptTrack = () => {
+  if (document.querySelector("#video-player")) {
+    videojs("video-player").ready(function() {
+      window.videojs = videojs
+      require("videojs-transcript-ac")
+
+      const options = {
+        showTitle:         false,
+        showTrackSelector: false
+      }
+
+      const transcript = this.transcript(options)
+
+      const transcriptContainer = document.querySelector("#transcript")
+      transcriptContainer.appendChild(transcript.el())
+    })
+  }
+}

--- a/course/layouts/partials/video.html
+++ b/course/layouts/partials/video.html
@@ -1,10 +1,27 @@
 {{ $youtubeKey := .Params.video_metadata.youtube_id }}
 {{ $captionsLocation := .Params.video_files.video_captions_file }}
-{{ $transcriptLocation := .Params.video_files.video_transcript_file }}
+{{ $transcriptPdfLocation := .Params.video_files.video_transcript_file }}
 
 <div class="video-page">
   <div class="description">
     {{ .Params.about_this_resource_text | safeHTML }}
   </div>
-  {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "transcriptLocation" $transcriptLocation) }}
+  {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "transcriptPdfLocation" $transcriptPdfLocation) }}
+  {{if $captionsLocation}}
+  <div class="transcript-box">
+  	<div class="transcript-header">
+	   	<span>
+	       Transcript
+	    </span>
+	    <a class="transcript-section-toggle course-nav-section-toggle"
+	      href="#transcript"
+	      data-toggle="collapse"
+	      aria-controls="transcript"
+	      aria-expanded="">
+	      <i class="material-icons md-18"></i>
+	    </a>
+	</div>
+  	<div id="transcript" class="collapse show"></div>
+  </div>
+  {{end}}
 </div>

--- a/course/layouts/partials/youtube_player.html
+++ b/course/layouts/partials/youtube_player.html
@@ -16,10 +16,10 @@
         <track kind="captions" src="{{ .captionsLocation }}" srclang="en" label="English" default>
   {{ end }}
 </div>
-{{ if  .transcriptLocation}}
+{{ if  .transcriptPdfLocation}}
   <div class="video-buttons-container">
     <div class="col-6 download-transcript-container">
-      <a class="download-file download-transcript-button" href="{{ .transcriptLocation }}"><span class="material-icons">file_download</span> Download Transcript</a>
+      <a class="download-file download-transcript-button" href="{{ .transcriptPdfLocation }}"><span class="material-icons">file_download</span> Download Transcript</a>
     </div>
   </div>
 {{end}}

--- a/course/layouts/shortcodes/youtube.html
+++ b/course/layouts/shortcodes/youtube.html
@@ -1,4 +1,4 @@
 {{ $youtubeId := index .Params 0 }}
 {{ $captionsLocation := index .Params 1}}
-{{ $transcriptLocation := index .Params 2}}
-{{ partial "youtube_player.html" (dict "youtubeKey" $youtubeId "captionsLocation" $captionsLocation "transcriptLocation" $transcriptLocation) }}
+{{ $transcriptPdfLocation := index .Params 2}}
+{{ partial "youtube_player.html" (dict "youtubeKey" $youtubeId "captionsLocation" $captionsLocation "transcriptPdfLocation" $transcriptPdfLocation) }}

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "tmp": "^0.2.1",
     "url-loader": "^3.0.0",
     "video.js": "^7.11.8",
+    "videojs-transcript-ac": "^0.8.8",
     "videojs-youtube": "^2.6.1",
     "walk": "^2.3.14",
     "webpack": "^4.44.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13478,6 +13478,11 @@ videojs-font@3.2.0:
   resolved "https://registry.yarnpkg.com/videojs-font/-/videojs-font-3.2.0.tgz#212c9d3f4e4ec3fa7345167d64316add35e92232"
   integrity sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA==
 
+videojs-transcript-ac@^0.8.8:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/videojs-transcript-ac/-/videojs-transcript-ac-0.8.8.tgz#84620ddf24874569cc3be3e67487e76522f50f69"
+  integrity sha1-hGIN3ySHRWnMO+PmdIfnZSL1D2k=
+
 videojs-vtt.js@^0.15.2:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/videojs-vtt.js/-/videojs-vtt.js-0.15.3.tgz#84260393b79487fcf195d9372f812d7fab83a993"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
<img width="382" alt="Screen Shot 2021-10-14 at 7 46 23 PM" src="https://user-images.githubusercontent.com/1934992/137410233-702aa59a-651d-44b2-b29d-87a21aae1384.png">
<img width="1639" alt="Screen Shot 2021-10-14 at 7 44 58 PM" src="https://user-images.githubusercontent.com/1934992/137410238-2c86d4b2-d754-48c9-869b-999ae27bc053.png">

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/210

#### What's this PR do?
This pr adds a div with caption text under videos. The caption corresponding to the current point in the video should be highlighted. Also, the user should be able to select a caption and have the video update to that point.

#### How should this be manually tested?
Run `npm run start:course` with a course that has (non-inline) lecture videos for example set `OCW_TEST_COURSE=15-401-finance-theory-i-fall-2008` in your .env file.

Go to a lecture video. Verify that you see a box with captions and the captions look good
