### PR TITLE
replace "sections" with "pages"

### DIFF
--- a/www/assets/js/lib/search.js
+++ b/www/assets/js/lib/search.js
@@ -510,7 +510,7 @@ export const getSectionUrl = result => {
   ) {
     return "/"
   }
-  return `/sections/${urlPieces.join("/")}`
+  return `/pages/${urlPieces.join("/")}`
 }
 
 export const getResourceUrl = result => {

--- a/www/assets/js/lib/search.test.js
+++ b/www/assets/js/lib/search.test.js
@@ -517,12 +517,12 @@ describe("search library", () => {
       })
     })
 
-    it("adds a /sections if it is pointing to a section within a course url", () => {
+    it("adds a /pages if it is pointing to a section within a course url", () => {
       const result = {
         ...makeLearningResourceResult(),
         url: "/courses/course-id/other-part/path/to/a/pdf"
       }
-      expect(getSectionUrl(result)).toBe("/sections/path/to/a/pdf")
+      expect(getSectionUrl(result)).toBe("/pages/path/to/a/pdf")
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/233

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/331, we altered the output of `ocw-to-hugo` to write the different sections of a course to the `content/pages` folder to match how `ocw-studio` publishes content.  Moving forward, content published to OCW sites will follow the patterns described in the starter configurations (`ocw-studio.yaml`) in https://github.com/mitodl/ocw-hugo-projects.  This PR adjusts the search app to prefix pages with `/pages` instead of `/sections` to match this in search results.

#### How should this be manually tested?
 - Clone https://github.com/mitodl/ocw-www
 - In your `.env` file, make sure `EXTERNAL_SITE_PATH` is set to the path to `ocw-www`
 - Also in your `.env`, make sure `SEARCH_API_URL` is set to https://discussions-rc.odl.mit.edu/api/v0/search/
 - Start Google Chrome with `google-chrome --disable-web-security --user-data-dir=/tmp/chrometest` to avoid CORS errors (this is the command in Linux, for other OSes or browsers Google is your friend)
 - Visit http://localhost:3000/search and click the Resources tab
 - Check the "Lecture Videos" facet
 - Verify that the search result links have `/pages` in them instead of `/sections` (note that you won't actually be able to visit the pages locally because we are not running the entire site)
