### PR TITLE
Video Downloads

### DIFF
--- a/course/assets/css/video.scss
+++ b/course/assets/css/video.scss
@@ -79,27 +79,54 @@
   margin-bottom: 35px;
 }
 
-.download-transcript-container {
+.video-download-container {
   float: right;
   padding-top: 25px;
   padding-bottom: 25px;
   padding-right: 25px;
 }
 
-.download-transcript-button {
+.video-download-button {
   float: right;
   font-size: 14px;
+  color: white;
+}
+
+a.video-download-button:visited {
+  color: white;
 }
 
 .video_page_link {
   font-size: 16px;
   text-transform: uppercase;
-  padding-top: 25px;
+  padding-top: 35px;
   padding-bottom: 25px;
   padding-left: 10px;
   font-weight: bold;
+  display: inline-flex;
 }
 
-.video-page-link-icon {
-  transform: translateY(6px);
+#main-content a.download-file.video-download-button:link {
+  color: white;
+}
+
+#main-content a.download-file.video-download-button:visited {
+  color: white;
+}
+
+@include media-breakpoint-down(md) {
+  .video-download-container {
+    padding-top: 15px;
+    padding-bottom: 15px;
+    padding-right: 15px;
+  }
+  .video-download-container:first-child {
+    padding-bottom: 0px;
+  }
+
+  .video_page_link {
+    float: right;
+    padding-top: 15px;
+    padding-bottom: 0px;
+  }
 }

--- a/course/layouts/partials/video.html
+++ b/course/layouts/partials/video.html
@@ -1,12 +1,29 @@
 {{ $youtubeKey := .Params.video_metadata.youtube_id }}
 {{ $captionsLocation := .Params.video_files.video_captions_file }}
 {{ $transcriptPdfLocation := .Params.video_files.video_transcript_file }}
+{{ $downloadLink := .Params.file }}
+{{ if (eq $downloadLink nil) }}
+{{ $downloadLink = .Params.video_files.archive_url }}
+{{ end }}
 
 <div class="video-page">
   <div class="description">
     {{ .Params.about_this_resource_text | safeHTML }}
   </div>
-  {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "transcriptPdfLocation" $transcriptPdfLocation) }}
+  {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation)}}
+  <div class="video-buttons-container">
+	{{ if  $transcriptPdfLocation}}
+	  <div class="video-download-container">
+	    <a class="download-file video-download-button" href="{{ $transcriptPdfLocation }}"><span class="material-icons">file_download</span> Download Transcript</a>
+	  </div>
+	{{end}}
+	{{ if  $downloadLink }}
+	  <div class="video-download-container">
+	    <a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
+	  </div>
+	{{end}}
+	</div>
+
   {{if $captionsLocation}}
   <div class="transcript-box">
   	<div class="transcript-header">

--- a/course/layouts/partials/video_embed.html
+++ b/course/layouts/partials/video_embed.html
@@ -1,6 +1,10 @@
 {{ $youtubeKey := .Params.video_metadata.youtube_id }}
 {{ $captionsLocation := .Params.video_files.video_captions_file }}
 {{ $uid := .Params.uid }}
+{{ $downloadLink := .Params.file }}
+{{ if (eq $downloadLink nil) }}
+{{ $downloadLink = .Params.video_files.archive_url }}
+{{ end }}
 
 {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation) }}
 {{- range where $.Site.Pages "Params.uid" $uid -}}
@@ -9,5 +13,10 @@
       <a href="{{- .Permalink -}}">View Video Page</a>
       <i class="material-icons video-page-link-icon">chevron_right</i>
     </div>
+   	{{ if  $downloadLink }}
+	  <div class="video-download-container">
+	    <a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
+	  </div>
+	{{end}}
   </div>
 {{- end -}}

--- a/course/layouts/partials/youtube_player.html
+++ b/course/layouts/partials/youtube_player.html
@@ -16,10 +16,3 @@
         <track kind="captions" src="{{ .captionsLocation }}" srclang="en" label="English" default>
   {{ end }}
 </div>
-{{ if  .transcriptPdfLocation}}
-  <div class="video-buttons-container">
-    <div class="col-6 download-transcript-container">
-      <a class="download-file download-transcript-button" href="{{ .transcriptPdfLocation }}"><span class="material-icons">file_download</span> Download Transcript</a>
-    </div>
-  </div>
-{{end}}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "^1.33.2",
+    "@mitodl/ocw-to-hugo": "^1.33.3",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@^1.33.2":
-  version "1.33.2"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.33.2.tgz#11b9d177f91fde7b84308b01fb31d2331078733e"
-  integrity sha512-BOiJwATzbGXtAhzaq9eoGRHOJtEucffKmGYWZ0qEqRyUHtbJzYRb4ntvktYSA592TZVhgxfPAW3y5t14sHMShQ==
+"@mitodl/ocw-to-hugo@^1.33.3":
+  version "1.33.3"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.33.3.tgz#328300395c02ff932cb38cd8e6e15c16e896c4dc"
+  integrity sha512-LJpQGZdNMEv/lpurhF3PJY/OecJ7wUACPNApzXxwcnpL2z3XBaSZCm/kL8qvKJ4Tn2/N/RhCS4nFJuYGJ8EN8g==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
<img width="1680" alt="Screen Shot 2021-10-28 at 10 36 28 AM" src="https://user-images.githubusercontent.com/1934992/139278638-29306f88-8d61-43bc-96ab-75cfde10961a.png">
<img width="1179" alt="Screen Shot 2021-10-28 at 10 36 12 AM" src="https://user-images.githubusercontent.com/1934992/139278655-be08fa50-4d27-4230-8873-93fbc26317f0.png">
<img width="381" alt="Screen Shot 2021-10-28 at 10 35 41 AM" src="https://user-images.githubusercontent.com/1934992/139278663-5e213e62-d0c1-4c82-be63-467ee415674a.png">
<img width="1171" alt="Screen Shot 2021-10-28 at 10 35 29 AM" src="https://user-images.githubusercontent.com/1934992/139278670-47b4ccc0-bc43-409b-a834-9df242532db3.png">

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/145

#### What's this PR do?
This PR adds links to download videos. For legacy courses these links go to internet archive. For ocw-studio courses they go to s3.

#### How should this be manually tested?
run node . -i private/input -o private/output -c course_json_examples/example_courses.json --download in https://github.com/mitodl/ocw-to-hugo/pull/397

Set  OCW_TEST_COURSE=15-071-the-analytics-edge-spring-2017
Set COURSE_CONTENT_PATH= the path to /private/output from ocw-to-hugo

Run `npm run start:course`

Go to a page with an embedded youtube video. Verify that you see a video download button under the video and the link takes you to the video file on the internet archive. Click through to a video resource page. Again, verify that you see a video download button under the video and the link takes you to the video file on archive.

Given the current issues with youtube, it's probably not worth setting up a ocw-studio course with videos just to test this PR, but if you already have one, clone that course's data from github and run `npm run start:course` with OCW_TEST_COURSE and  COURSE_CONTENT_PATH pointing to the course's data.
Both embedded videos and video resource pages should have buttons to download the video. Right now clicking the link will play the video with the aws video player in the browser. The aws player has a download button. After https://github.com/mitodl/ocw-studio/pull/749 is merged, new video files will download immediately instead of playing in the browser.

