### PR TITLE
add back td-colspan shortcode

### DIFF
--- a/base-theme/layouts/shortcodes/td-colspan.html
+++ b/base-theme/layouts/shortcodes/td-colspan.html
@@ -1,0 +1,3 @@
+<td colspan="{{ .Get 0 }}">
+  {{ .Inner | markdownify }}
+</td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/245

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/241, we added some new shortcodes to support a new strategy for rendering tables in `ocw-studio`.  As part of this, the `td-colspan.html` shortcode was removed.  While this isn't necessary for `ocw-studio` generated courses, it's still necessary to keep around for legacy courses converted with `ocw-to-hugo`.  This PR simply adds it back for now.

#### How should this be manually tested?
 - Clone `ocw-to-hugo` and make sure you are set up to download courses from S3
 - In your `ocw-to-hugo` folder, run `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download`
 - Back here in `ocw-hugo-themes`, make sure you have the following in your `.env` file:
   - `COURSE_CONTENT_PATH=/path/to/ocw-to-hugo/private/output/`
   - `OCW_TEST_COURSE=12-001-introduction-to-geology-fall-2013`
 - Run `npm run start:course`
 - Visit http://localhost:3000/ and verify that the course loads properly
