### PR TITLE
Adjust level, term to new ocw-to-hugo format

### DIFF
--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -47,7 +47,7 @@
       <tr>
         <td class="pl-0 text-nowrap">As Taught In:</td>
         <td>
-          {{ $courseData.term }}
+          {{ $courseData.term }} {{ $courseData.year }}
         </td>
       </tr>
       <tr>

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -47,17 +47,24 @@
       <tr>
         <td class="pl-0 text-nowrap">As Taught In:</td>
         <td>
-          {{ $courseData.term }} {{ $courseData.year }}
+          {{ $courseData.term }} {{ if isset $courseData "year" }}{{ $courseData.year }}{{ end }}
         </td>
       </tr>
       <tr>
         <td class="pl-0 pb-3">Level:</td>
         <td>
-          {{ range $courseData.level }}
-            {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) }}
+          {{ if eq (printf "%T" $courseData.level) "string" }}
+            {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
             <a href="{{ $levelSearchUrl }}" class="course-info-level">
-              {{ . }}
-            </a><br />
+              {{ $courseData.level }}
+            </a>
+          {{ else }}
+            {{ range $courseData.level }}
+              {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) }}
+              <a href="{{ $levelSearchUrl }}" class="course-info-level">
+                {{ . }}
+              </a><br />
+            {{ end }}
           {{ end }}
         </td>
       </tr>

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -53,10 +53,12 @@
       <tr>
         <td class="pl-0 pb-3">Level:</td>
         <td>
-          {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
-          <a href="{{ $levelSearchUrl }}" class="course-info-level">
-            {{ $courseData.level }}
-          </a>
+          {{ range $courseData.level }}
+            {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) }}
+            <a href="{{ $levelSearchUrl }}" class="course-info-level">
+              {{ . }}
+            </a><br />
+          {{ end }}
         </td>
       </tr>
     </table>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/pull/398

#### What's this PR do?
`level` was changed to an array so this PR changes it to output one level link per item in the array. Additionally, `term` was changed to not include a year anymore, and `year` was added with the corresponding year. 

#### How should this be manually tested?
Convert a course with the latest ocw-to-hugo and view a course with this PR. The level in the course info on the course home page should look the same as before, with a link to the search page. The text next to "As Taught In" should be a semester and a year, looking exactly like it did before