### PR TITLE
render the video gallery description if set

### DIFF
--- a/course/layouts/partials/video-gallery.html
+++ b/course/layouts/partials/video-gallery.html
@@ -1,4 +1,9 @@
 {{- $ctx := . -}}
+{{ if isset .Params "description" }}
+<div class="pb-5">
+{{ $ctx.RenderString .Params.description }}
+</div>
+{{ end }}
 {{- range .Params.videos.content -}}
   {{- $uuid := . -}}
   {{- range $ctx.Site.Pages -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [ ] Testing
  - [ ] Changes have been manually tested to be compatible with [`ocw-to-hugo`](https://github.com/mitodl/ocw-to-hugo)
  - [ ] Changes have been manually tested to be compatible with published output of an [`ocw-studio`](https://github.com/mitodl/ocw-studio) site

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/252

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/93, we added a markdown description field to video galleries.  This PR adds the necessary template changes to display this content above the video gallery, if present.

#### How should this be manually tested?
 - Follow the testing instructions in https://github.com/mitodl/ocw-hugo-projects/pull/93
 - Confirm the changes work with an [`ocw-to-hugo`](https://github.com/mitodl/ocw-to-hugo) converted course with a video gallery such as `ec-711-d-lab-energy-spring-2011` from the example courses, adjusting `COURSE_CONTENT_PATH` and `OCW_TEST_COURSE` as necessary

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/139958205-7eb3942b-1732-4a0e-973a-8069d3123701.png)
![image](https://user-images.githubusercontent.com/12089658/139958264-225d317e-04cf-415f-95c5-396103935481.png)

