### PR TITLE
conditionally iterate level as a map in home_course_cards

### DIFF
--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -36,8 +36,16 @@
                     </a>
                     <div class="course-card-content pt-1 px-3 pb-3">
                       <div class="course-level">
-                        {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
-                        {{ $courseData.primary_course_number }} | <a href="{{ $levelSearchUrl }}">{{ $courseData.level }}</a>
+                        {{ $courseData.primary_course_number }} | 
+                        {{ if eq (printf "%T" $courseData.level) "string" }}
+                          {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
+                          <a href="{{ $levelSearchUrl }}">{{ $courseData.level }}</a>
+                        {{ else }}
+                          {{ range $courseData.level }}
+                            {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) }}
+                            <a href="{{ $levelSearchUrl }}">{{ . }}</a>
+                          {{ end }}
+                        {{ end }}
                       </div>
                       <div class="pt-1">
                         <div class="h5">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/261

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/257, we updated the `home_course_cards.html` template to be compatible to recent changes in the structure of the `level` metadata property.  This PR missed the fact that this is now stored as an array with potentially multiple items in it.  This PR adjusts the rendering to iterate the times if it is indeed an array.

#### How should this be manually tested?
 - Set `OCW_STUDIO_BASE_URL=http://ocw-studio-rc.odl.mit.edu/` in your `.env`
 - Run `npm run start:www`
 - Verify that the level display on the home course cards is not surrounded in square braces
