### PR TITLE
add in a hack for /coursemedia

### DIFF
--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -32,7 +32,13 @@
                 <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                   <div class="course-card card bg-white">
                     <a href="/courses/{{ $courseId }}">
-                      <img src="{{ $courseData.course_image_url }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
+                      {{/* The following is a temporary hack that should be removed following the decommissioning of the EC2 OCW Next build servers */}}
+                      {{ $courseBaseUrl := getenv "COURSE_BASE_URL" | default "" }}
+                      {{ $courseImageUrl := $courseData.course_image_url }}
+                      {{ if in $courseBaseUrl "ocwnext" }}
+                        {{ $courseImageUrl = replace $courseData.course_image_url "/courses" "/coursemedia" }}
+                      {{ end }}
+                      <img src="{{ $courseImageUrl }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
                     </a>
                     <div class="course-card-content pt-1 px-3 pb-3">
                       <div class="course-level">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
In https://github.com/mitodl/ol-infrastructure/pull/440, we added a pipeline definition to run `ocw-to-hugo` on its own and upload the output to the `ocw-to-hugo-output` S3 buckets for consumption by `ocw-studio`.  Since `ocw-studio` is responsible for delivering the API that renders the "new courses" section of the home page, the course image URLs have changed.  The current EC2 based build servers that deploy https://ocwnext-rc.odl.mit.edu and https://ocwnext.odl.mit.edu have a custom fastly redirect mounted at `/coursemedia` to source static material directly from the `open-learning-course-data` buckets.  Since this won't be the case when it comes to the `ocw-studio` published courses, the new `ocw-to-hugo` pipeline uses a `staticPrefix` of `/courses`.  This had the effect of breaking the course images in the new courses carousel on the existing EC2 built sites.  This PR adds in a temporary hack to replace `/courses` with `/coursemedia` when the `COURSE_BASE_URL` contains `ocwnext`.  This code can be removed when the EC2 servers are deprecated.

#### How should this be manually tested?
 - Clone `ocw-hugo-themes` on this PR branch and run `yarn install` if you've never used it before
 - In your `.env` file, set:
   - OCW_STUDIO_BASE_URL=http://ocw-studio-rc.odl.mit.edu/
   - COURSE_BASE_URL=http://ocwnext-rc.odl.mit.edu/courses
 - Run `npm run start:www`
 - Visit http://localhost:3000 and right click on one of the broken new course images and inspect.  The course image URL should be prefixed with `/coursemedia` (although it won't work locally and this is expected)
