### PR TITLE
update home course cards instructors, topics and level

### DIFF
--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -42,16 +42,7 @@
                     </a>
                     <div class="course-card-content pt-1 px-3 pb-3">
                       <div class="course-level">
-                        {{ $courseData.primary_course_number }} | 
-                        {{ if eq (printf "%T" $courseData.level) "string" }}
-                          {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
-                          <a href="{{ $levelSearchUrl }}">{{ $courseData.level }}</a>
-                        {{ else }}
-                          {{ range $courseData.level }}
-                            {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) }}
-                            <a href="{{ $levelSearchUrl }}">{{ . }}</a>
-                          {{ end }}
-                        {{ end }}
+                        {{ $courseData.primary_course_number }} | {{ partial "home_course_cards_level.html" $courseData.level }}
                       </div>
                       <div class="pt-1">
                         <div class="h5">

--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -59,10 +59,10 @@
                         </div>
                       </div>
                       <div class="pt-1">
-                        <span class="card-label">Instructors(s):</span> {{ delimit (first 3 (uniq $courseData.instructors)) ", " }}
+                        <span class="card-label">Instructors(s):</span> {{ partial "home_course_cards_instructors.html" $courseData.instructors }}
                       </div>
                       <div class="pt-2">
-                        <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $courseData.topics }}
+                        <span class="card-label">Topic(s):</span> {{ partial "home_course_cards_topics.html" $courseData.topics }}
                       </div>
                     </div>
                   </div>

--- a/www/layouts/partials/home_course_cards_instructors.html
+++ b/www/layouts/partials/home_course_cards_instructors.html
@@ -1,0 +1,8 @@
+{{- $instructors := slice -}}
+{{- with first 3 (uniq .) -}}
+  {{- $instructorName := ((index . 0).instructor) -}}
+  {{- $instructorSearchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" $instructorName) -}}
+  {{- $instructorLink := print "<a href=\"" $instructorSearchUrl "\">" $instructorName "</a>" -}}
+  {{- $instructors = $instructors | append $instructorLink -}}
+{{- end -}}
+{{ delimit $instructors ", " }}

--- a/www/layouts/partials/home_course_cards_instructors.html
+++ b/www/layouts/partials/home_course_cards_instructors.html
@@ -1,8 +1,10 @@
 {{- $instructors := slice -}}
 {{- with first 3 (uniq .) -}}
-  {{- $instructorName := ((index . 0).instructor) -}}
-  {{- $instructorSearchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" $instructorName) -}}
-  {{- $instructorLink := print "<a href=\"" $instructorSearchUrl "\">" $instructorName "</a>" -}}
-  {{- $instructors = $instructors | append $instructorLink -}}
+  {{- range . -}}
+    {{- $instructorName := .instructor -}}
+    {{- $instructorSearchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" $instructorName) -}}
+    {{- $instructorLink := print "<a href=\"" $instructorSearchUrl "\">" $instructorName "</a>" -}}
+    {{- $instructors = $instructors | append $instructorLink -}}
+  {{- end -}}
 {{- end -}}
 {{ delimit $instructors ", " }}

--- a/www/layouts/partials/home_course_cards_instructors.html
+++ b/www/layouts/partials/home_course_cards_instructors.html
@@ -1,10 +1,11 @@
-{{- $instructors := slice -}}
 {{- with first 3 (uniq .) -}}
-  {{- range . -}}
-    {{- $instructorName := .instructor -}}
+  {{- $numInstructors := len . -}}
+  {{- range $index, $instructorObject := . -}}
+    {{- $instructorName := $instructorObject.instructor -}}
     {{- $instructorSearchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" $instructorName) -}}
-    {{- $instructorLink := print "<a href=\"" $instructorSearchUrl "\">" $instructorName "</a>" -}}
-    {{- $instructors = $instructors | append $instructorLink -}}
+    <a href="{{ $instructorSearchUrl }}">{{ $instructorName }}</a>
+    {{- if ne (add $index 1) $numInstructors -}}
+    ,&nbsp;
+    {{- end -}}
   {{- end -}}
 {{- end -}}
-{{ delimit $instructors ", " }}

--- a/www/layouts/partials/home_course_cards_level.html
+++ b/www/layouts/partials/home_course_cards_level.html
@@ -1,0 +1,12 @@
+{{- if eq (printf "%T" .) "string" -}}
+  {{- $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) -}}
+  <a href="{{ $levelSearchUrl }}">{{ . }}</a>
+{{- else -}}
+  {{- $levels := slice -}}
+  {{- range . -}}
+    {{- $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) -}}
+    {{- $levelLink := print "<a href=\"" $levelSearchUrl "\">" . "</a>" -}}
+    {{- $levels = $levels | append $levelLink -}}
+  {{- end -}}
+  {{ delimit $levels ", " }}
+{{- end -}}

--- a/www/layouts/partials/home_course_cards_level.html
+++ b/www/layouts/partials/home_course_cards_level.html
@@ -2,11 +2,12 @@
   {{- $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) -}}
   <a href="{{ $levelSearchUrl }}">{{ . }}</a>
 {{- else -}}
-  {{- $levels := slice -}}
-  {{- range . -}}
-    {{- $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) -}}
-    {{- $levelLink := print "<a href=\"" $levelSearchUrl "\">" . "</a>" -}}
-    {{- $levels = $levels | append $levelLink -}}
+  {{- $numLevels := len . -}}
+  {{- range $index, $level := . -}}
+    {{- $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $level) -}}
+    <a href="{{ $levelSearchUrl }}">{{ $level }}</a>
+    {{- if ne (add $index 1) $numLevels -}}
+    ,&nbsp;
+    {{- end -}}
   {{- end -}}
-  {{ delimit $levels ", " }}
 {{- end -}}

--- a/www/layouts/partials/home_course_cards_topics.html
+++ b/www/layouts/partials/home_course_cards_topics.html
@@ -1,0 +1,10 @@
+{{- $topicsList := slice -}}
+{{- range $topicList := . -}}
+  {{- range $topic := $topicList -}}
+    {{- $topicTitle := title $topic -}}
+    {{- $topicSearchUrl := partial "get_search_url.html" (dict "key" "topic" "value" $topicTitle) -}}
+    {{- $topicLink := print "<a href=\"" $topicSearchUrl "\">" (title $topicTitle) "</a>" -}}
+    {{- $topicsList = $topicsList | append $topicLink -}}
+  {{- end -}}
+{{- end -}}
+{{ delimit (first 3 (uniq $topicsList)) ", " }}

--- a/www/layouts/partials/home_course_cards_topics.html
+++ b/www/layouts/partials/home_course_cards_topics.html
@@ -1,10 +1,10 @@
-{{- $topicsList := slice -}}
-{{- range $topicList := . -}}
-  {{- range $topic := $topicList -}}
-    {{- $topicTitle := title $topic -}}
-    {{- $topicSearchUrl := partial "get_search_url.html" (dict "key" "topic" "value" $topicTitle) -}}
-    {{- $topicLink := print "<a href=\"" $topicSearchUrl "\">" (title $topicTitle) "</a>" -}}
-    {{- $topicsList = $topicsList | append $topicLink -}}
+{{- $topics := slice -}}
+{{- range . -}}
+  {{- range . -}}
+    {{- $topic := title . -}}
+    {{- $topicSearchUrl := partial "get_search_url.html" (dict "key" "topic" "value" $topic) -}}
+    {{- $topicLink := print "<a href=\"" $topicSearchUrl "\">" (title $topic) "</a>" -}}
+    {{- $topics = $topics | append $topicLink -}}
   {{- end -}}
 {{- end -}}
-{{ delimit (first 3 (uniq $topicsList)) ", " }}
+{{ delimit (first 3 (uniq $topics)) ", " }}

--- a/www/layouts/partials/home_course_cards_topics.html
+++ b/www/layouts/partials/home_course_cards_topics.html
@@ -1,10 +1,16 @@
 {{- $topics := slice -}}
 {{- range . -}}
   {{- range . -}}
-    {{- $topic := title . -}}
-    {{- $topicSearchUrl := partial "get_search_url.html" (dict "key" "topic" "value" $topic) -}}
-    {{- $topicLink := print "<a href=\"" $topicSearchUrl "\">" (title $topic) "</a>" -}}
-    {{- $topics = $topics | append $topicLink -}}
+    {{- $topics = $topics | append (title .) -}}
   {{- end -}}
 {{- end -}}
-{{ delimit (first 3 (uniq $topics)) ", " }}
+{{- $topics = (first 3 (uniq $topics)) -}}
+{{- $numTopics := len $topics -}}
+{{- range $index, $rawTopic := $topics -}}
+  {{- $topic := title $rawTopic -}}
+  {{- $topicSearchUrl := partial "get_search_url.html" (dict "key" "topic" "value" $topic) -}}
+  <a href="{{ $topicSearchUrl }}">{{ $topic }}</a>
+  {{- if ne (add $index 1) $numTopics -}}
+  ,&nbsp;
+  {{- end -}}
+{{- end -}}

--- a/www/layouts/partials/topics_summary.html
+++ b/www/layouts/partials/topics_summary.html
@@ -1,7 +1,0 @@
-{{- $topicsList := slice -}}
-{{- range $topicList := . -}}
-    {{- range $topic := $topicList -}}
-        {{- $topicsList = $topicsList | append (title $topic) -}}
-    {{- end -}}
-{{- end -}}
-{{- delimit (first 3 (uniq $topicsList)) ", " -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/267
Closes https://github.com/mitodl/ocw-hugo-themes/issues/268

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/449, we modified the `ocw-studio` REST API that the `home_course_cards.html` partial uses to get new courses to serialize instructor information alongside the UUID's of the instructors.  This changed the API schema to deliver objects for instructors instead of strings, which broke their display in the partial.  This PR creates a new partial called `home_course_cards_instructors.html` that is responsible for pulling these instructors out of the response and creating clickable search links for them to go in the card.  The same was done with topics as well as level, for better organization of the different parts of the cards that require a bit more processing.

#### How should this be manually tested?
 - Set `OCW_STUDIO_BASE_URL=http://ocw-studio-rc.odl.mit.edu/`
 - Run `npm run start:www`
 - Verify that instructors are displayed and are clickable links that go to `/search` with a proper query string
 - Verify the same thing for topics
