### PR TITLE
Fix calculation for course home page cards

### DIFF
--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -20,7 +20,8 @@
           {{ partial "carousel_controls.html" $carouselId }}
         </div>
         <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
-          {{ range $index, $courseItem := (first 10 $results)  }}
+          {{ $resultsSlice := first 10 $results }}
+          {{ range $index, $courseItem := $resultsSlice  }}
             {{ with $courseItem }}
               {{ $courseId := $courseItem.name }}
               {{ $courseData := $courseItem.metadata}}
@@ -58,7 +59,7 @@
                     </div>
                   </div>
                 </div>
-              {{ if (or (eq $modulo (sub $itemsInCarousel 1)) (eq $index (sub 10 1))) }}
+              {{ if (or (eq $modulo (sub $itemsInCarousel 1)) (eq $index (sub (len $resultsSlice) 1))) }}
               </div>
               {{ end }}
             {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
This fixes an edge case where the number of course cards on the home page carousel is less than 10. In that case the home page breaks because of a missing div tag

#### How should this be manually tested?
Make sure the home page works as normal by running `npm run start:www`. You should see 10 carousel cards in the "new courses" section.

In `home_course_cards.html` edit `{{ $typeQuery := querify "type" $courseStarterSlug }}` to be `{{ $typeQuery := querify "search" "computational mech" }}`. On main you should see a broken home page, but on this PR you should see a single carousel card.

