### PR TITLE
add the resource_file shortcode to the course theme

### DIFF
--- a/course/layouts/shortcodes/resource_file.html
+++ b/course/layouts/shortcodes/resource_file.html
@@ -1,0 +1,4 @@
+{{- $uuid := index .Params 0 -}}
+{{- range where $.Site.Pages "Params.uid" $uuid -}}
+{{- .Params.file -}}
+{{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/issues/352

#### What's this PR do?
This PR adds a new shortcode to the course theme; `resource_file`.  It allows you to get just the `file` property of a resource on its own for use in `img` `src` attributes and possibly other applications.

#### How should this be manually tested?
This PR should be tested in conjuction with https://github.com/mitodl/ocw-to-hugo/pull/412.  Follow the steps there to test both of these PR's together.

#### Screenshots
![image](https://user-images.githubusercontent.com/12089658/142672682-26b98dab-2947-4cf1-b7ca-5ab73fe52aa8.png)
![image](https://user-images.githubusercontent.com/12089658/142672865-47c84bdb-082f-4008-a228-d49e872f4daf.png)
