### PR TITLE
Gracefully handle missing image metadata for older JSON files

### DIFF
--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -36,7 +36,7 @@
                         <div class="col-lg-4 d-none d-lg-block pl-0">
                           <div class="d-flex flex-column image-with-caption">
                             <img class="course-image" src="{{ $courseImageUrl }}"
-                              alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
+                              alt="{{ index ($courseImageMetadata.Params.image_metadata | default dict) "image-alt" }}"
                             />
                             <span class="caption p-3">
                               {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to #260 

#### What's this PR do?
Fixes an error where the course JSON does not contain image_metadata yet. In that case it will assume an empty string

#### How should this be manually tested?
 - Convert a course using commit `a598198` of ocw-to-hugo (just before the image metadata change)
 - Run `npm run start:course` and verify that you see expected content at localhost:3000

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)
