### PR TITLE
Revert "Revert "Use alt-text for course image (#270)""

### DIFF
--- a/base-theme/layouts/partials/resource_metadata.html
+++ b/base-theme/layouts/partials/resource_metadata.html
@@ -1,0 +1,1 @@
+{{- return index (where (where site.RegularPages "Section" "==" "resources") ".Params.uid" "==" .) 0 -}}

--- a/base-theme/layouts/partials/resource_url.html
+++ b/base-theme/layouts/partials/resource_url.html
@@ -1,12 +1,16 @@
-{{- $resources := where (where site.RegularPages "Section" "==" "resources") ".Params.resourcetype" "==" .resourcetype -}}
-{{- $resource := index (where $resources ".Params.uid" "==" .uid) 0 -}}
+{{- $url := . -}}
 {{/*
   Here we are disassembling the URL and returning it without the host and schema.
   This is done because it is expected that ocw-studio currently returns fully
   qualified S3 URLs, and when deployed these will need to be behind CDN.
 
-  The RESOURCE_BASE_URL env variable is prefixed before the URL. That way for local 
+  The RESOURCE_BASE_URL env variable is prefixed before the URL. That way for local
   development, you can set this to the S3 URL you expect the resources to be available at.
 */}}
 {{- $prefix := getenv "RESOURCE_BASE_URL" | default "" -}}
-{{- return printf "%s%s" (strings.TrimSuffix "/" $prefix) (urls.Parse $resource.Params.file).Path -}}
+{{- $url := printf "%s%s" (strings.TrimSuffix "/" $prefix) (urls.Parse $url).Path -}}
+{{- if hasPrefix $url "http" -}}
+  {{- return $url -}}
+{{- else -}}
+  {{- partial "site_root_url.html" $url -}}
+{{- end -}}

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -1,9 +1,9 @@
 {{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
 {{- $courseData := .Site.Data.course -}}
+
 {{- $courseImageUid := $courseData.course_image.content -}}
-{{- $courseImageThumbnailUid := $courseData.course_image_thumbnail.content -}}
-{{- $courseImageUrl := partial "resource_url.html" (dict "resourcetype" "Image" "uid" $courseImageUid) -}}
-{{- $courseImageThumbnailUrl := partial "resource_url.html" (dict "resourcetype" "Image" "uid" $courseImageThumbnailUid) -}}
+{{- $courseImageMetadata := partial "resource_metadata.html" $courseImageUid }}
+{{- $courseImageUrl := partial "resource_url.html" $courseImageMetadata.Params.file -}}
 <!doctype html>
 <html lang="{{ $.Site.Language.Lang }}">
 {{ partial "head.html" . }}
@@ -35,16 +35,11 @@
                       <div class="row px-3 pb-2 justify-content-between">
                         <div class="col-lg-4 d-none d-lg-block pl-0">
                           <div class="d-flex flex-column image-with-caption">
-                            <img class="course-image" src="
-                              {{- if hasPrefix $courseImageUrl "http" -}}
-                                {{ $courseImageUrl }}
-                              {{- else -}}
-                                {{ partial "site_root_url.html" $courseImageUrl }}
-                              {{- end -}}"
-                              alt="{{ $courseData.course_image_alternate_text }}"
+                            <img class="course-image" src="{{ $courseImageUrl }}"
+                              alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
                             />
                             <span class="caption p-3">
-                              {{ $courseData.course_image_caption_text | safeHTML }}
+                              {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}
                             </span>
                           </div>
                         </div>

--- a/course/layouts/partials/image_page.html
+++ b/course/layouts/partials/image_page.html
@@ -9,13 +9,13 @@
     {{- if $metadata.caption -}}
         <div class="row">
             <div class="label col-3">Caption:</div>
-            <div class="col-9">{{ $metadata.caption }}</div>
+            <div class="col-9">{{ $metadata.caption | .RenderString }}</div>
         </div>
     {{- end -}}
     {{- if $metadata.credit -}}
         <div class="row">
             <div class="label col-3">Credit:</div>
-            <div class="col-9">{{ $metadata.credit }}</div>
+            <div class="col-9">{{ $metadata.credit | .RenderString }}</div>
         </div>
     {{- end -}}
 {{- end -}}
@@ -23,7 +23,7 @@
 {{- if .Params.file -}}
     <div class="row">
         <div class="col-12">
-            <img class="mw-100" src="{{ .Params.file }}" alt="{{ if .Params.image_metadata }}{{ index .Params.image_metadata "image-alt" }}{{ end }}" />
+            <img class="mw-100" src="{{ partial "resource_url" .Params.file }}" alt="{{ if .Params.image_metadata }}{{ index .Params.image_metadata "image-alt" }}{{ end }}" />
         </div>
     </div>
 {{- end -}}

--- a/course/layouts/partials/pdf_viewer.html
+++ b/course/layouts/partials/pdf_viewer.html
@@ -1,12 +1,12 @@
 <div class="pdf-viewer w-100 pb-5">
   <div class="pr-4">
-    <a class="download-link" href="{{ .Params.file }}">
+    <a class="download-link" href="{{ partial "resource_url" .Params.file }}">
       <div class="btn bg-link-blue text-white rounded float-right mb-3">
         <span>DOWNLOAD</span>
         <div class="ripple-container"></div>
       </div>
     </a>
   </div>
-  <div class="pdf-wrapper w-100" data-pdfurl="{{ .Params.file }}">
+  <div class="pdf-wrapper w-100" data-pdfurl="{{ partial "resource_url" .Params.file }}">
   </div>
 </div>

--- a/course/layouts/partials/video-gallery-item.html
+++ b/course/layouts/partials/video-gallery-item.html
@@ -3,9 +3,9 @@
     <div class="inner-container">
       <div class="left-col">
         {{- if isset .Params.video_files "video_thumbnail_file" -}}
-        <img class="thumbnail" src ="{{ .Params.video_files.video_thumbnail_file }}" />
+        <img class="thumbnail" src ="{{ .Params.video_files.video_thumbnail_file }}" alt="Thumbnail for {{ .Params.title }}" />
         {{- else -}}
-        <img class="youtube-logo-overlay" src="/images/youtube.svg" />
+        <img class="youtube-logo-overlay" src="/images/youtube.svg" alt="YouTube" />
         {{- end -}}
       </div>
       <div class="right-col">

--- a/course/layouts/partials/video.html
+++ b/course/layouts/partials/video.html
@@ -19,7 +19,7 @@
 	{{end}}
 	{{ if  $downloadLink }}
 	  <div class="video-download-container">
-	    <a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
+	    <a class="download-file video-download-button" href="{{ partial "resource_url" $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
 	  </div>
 	{{end}}
 	</div>

--- a/course/layouts/partials/video_embed.html
+++ b/course/layouts/partials/video_embed.html
@@ -15,7 +15,7 @@
     </div>
    	{{ if  $downloadLink }}
 	  <div class="video-download-container">
-	    <a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
+	    <a class="download-file video-download-button" href="{{ partial "resource_url" $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
 	  </div>
 	{{end}}
   </div>

--- a/course/layouts/resources/single.html
+++ b/course/layouts/resources/single.html
@@ -17,7 +17,7 @@
         {{- if .Params.file -}}
         <div class="row">
             <div class="col-12 d-flex flex-direction-row align-items-center">
-                <a class="download-file" href="{{ .Params.file }}"><span class="material-icons">file_download</span> Download File</a>
+                <a class="download-file" href="{{ partial "resource_url" .Params.file }}"><span class="material-icons">file_download</span> Download File</a>
             </div>
         </div>
         {{- end -}}

--- a/course/layouts/shortcodes/resource.html
+++ b/course/layouts/shortcodes/resource.html
@@ -3,11 +3,11 @@
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
     {{- if eq .Params.resourcetype "Image" -}}
       {{- $metadata := .Params.image_metadata | default dict -}}
-      <img src="{{ .Params.file }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
+      <img src="{{ partial "resource_url" .Params.file }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
     {{- else if eq .Params.resourcetype "Video" -}}
       {{ partial "video_embed.html" . }}
     {{- else -}}
-      <a href="{{ .Params.file }}">{{ .Params.title }}</a>
+      <a href="{{ partial "resource_url" .Params.file }}">{{ .Params.title }}</a>
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "1.3.0",
-    "@mitodl/ocw-to-hugo": "^1.35.0",
+    "@mitodl/ocw-to-hugo": "1.35.2",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/www/assets/js/components/SearchResult.js
+++ b/www/assets/js/components/SearchResult.js
@@ -40,7 +40,11 @@ const CoverImage = ({ object }) => (
         alt={`cover image for ${object.title}`}
       />
       {[object.object_type, object.content_type].includes(LR_TYPE_VIDEO) ? (
-        <img src="/images/video_play_overlay.png" className="video-play-icon" />
+        <img
+          src="/images/video_play_overlay.png"
+          className="video-play-icon"
+          alt="Play video icon"
+        />
       ) : null}
     </a>
   </div>

--- a/www/layouts/partials/promo-carousel.html
+++ b/www/layouts/partials/promo-carousel.html
@@ -17,7 +17,7 @@
       <div class="carousel-item {{ if eq $index 0}}active{{ end }}">
         <div class="carousel-content d-flex m-auto align-items-center bg-white">
           <div class="img-container p-2">
-            <img class="promo-image img-fluid" src="{{ partial "resource_url" (dict "filetype" "Image" "uid" $promo.Params.image.content) }}" alt="{{ $promo.Params.image_alt }}" />
+            <img class="promo-image img-fluid" src="{{ partial "resource_url" (partial "resource_metadata" $promo.Params.image.content).Params.file }}" alt="{{ $promo.Params.image_alt }}" />
           </div>
           <div class="promo-info d-flex flex-column px-2 px-md-4 align-items-start h-100">
             <h2>{{ $promo.Params.title }}</h2>

--- a/www/layouts/partials/testimonial_card.html
+++ b/www/layouts/partials/testimonial_card.html
@@ -2,7 +2,7 @@
 <a href="{{ $testimonial.RelPermalink }}" class="testimonial-link">
   <div
     class="testimonial d-flex flex-column justify-content-end rounded"
-    style="background-image: linear-gradient(180deg, rgba(0,0,0,0) 0%, #000000 100%), url({{ partial "resource_url" (dict "filetype" "Image" "uid" $testimonial.Params.image.content) }});"
+    style="background-image: linear-gradient(180deg, rgba(0,0,0,0) 0%, #000000 100%), url({{ partial "resource_url" (partial "resource_metadata" $testimonial.Params.image.content).Params.file }});"
   >
     <div class="name font-weight-bold pl-3">
       {{ $testimonial.Title }}

--- a/www/layouts/testimonials/list.html
+++ b/www/layouts/testimonials/list.html
@@ -15,7 +15,7 @@
       {{ range $testimonial := $testimonials }}
       <div class="testimonial d-flex flex-wrap flex-sm-nowrap">
         <div class="img-container">
-          <img src="{{ partial "resource_url" (dict "filetype" "Image" "uid" $testimonial.Params.image.content) }}" alt="{{ $testimonial.Title }}" />
+          <img src="{{ partial "resource_url" (partial "resource_metadata" $testimonial.Params.image.content).Params.file }}" alt="{{ $testimonial.Title }}" />
         </div>
         <div class="detail d-flex flex-column flex-nowrap justify-content-between p-0 ml-sm-5">
           <div class="text">

--- a/www/layouts/testimonials/single.html
+++ b/www/layouts/testimonials/single.html
@@ -9,7 +9,7 @@
     <div class="testimonials">
       <div class="testimonial d-flex flex-wrap flex-sm-nowrap">
         <div class="img-container">
-          <img src="{{ partial "resource_url" (dict "filetype" "Image" "uid" $testimonial.Params.image.content) }}" alt="{{ $testimonial.Title }}" />
+          <img src="{{ partial "resource_url" (partial "resource_metadata" $testimonial.Params.image.content).Params.file }}" alt="{{ $testimonial.Title }}" />
         </div>
         <div class="detail d-flex flex-column flex-nowrap justify-content-between p-0 ml-sm-5">
           <div class="text">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@^1.35.0":
-  version "1.35.0"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.35.0.tgz#49390977b80c1a2274df9c79533a05217d2334be"
-  integrity sha512-UUplH3tsyNxlxtZJNHRzHSd3KySTzg0jPhjsBMb6yKbkpf51E5JopN07lLBtr/T5PZaeQNIylRVK29HFnW+mEg==
+"@mitodl/ocw-to-hugo@1.35.2":
+  version "1.35.2"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.35.2.tgz#6902a69b8132b253c1a50fb1f53f24ea344f0029"
+  integrity sha512-sW04+N6uHdwvKlAas/BQAoJF/OFV5lL5yRVAVXhyszAC4VK0rS47SiRv28odcNbRbMP1waITX2b/Vp6FyoKsZA==
   dependencies:
     "@mitodl/course-search-utils" "^1.1.4"
     aws-sdk "^2.671.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to #270, #282

#### What's this PR do?
This adds back the work from #270, but with an updated ocw-to-hugo version which should fix issues with finding the right course image for certain courses.

#### How should this be manually tested?
See instructions in #270, but test with `11-521-spatial-database-management-and-advanced-geographic-information-systems-spring-2003` instead.