### PR TITLE
set up some defaults for the course image metadata

### DIFF
--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -2,7 +2,10 @@
 {{- $courseData := .Site.Data.course -}}
 
 {{- $courseImageUid := $courseData.course_image.content -}}
-{{- $courseImageMetadata := partial "resource_metadata.html" $courseImageUid }}
+{{- $courseImageMetadata := (dict "Params" (dict "file" "None" "image_metadata" (dict "image-alt" "" "caption" ""))) -}}
+{{- if $courseImageUid -}}
+{{- $courseImageMetadata = partial "resource_metadata.html" $courseImageUid }}
+{{- end -}}
 {{- $courseImageUrl := partial "resource_url.html" $courseImageMetadata.Params.file -}}
 <!doctype html>
 <html lang="{{ $.Site.Language.Lang }}">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/291

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/284, we added back in some template code that pulls out the `image-alt` and `caption` properties on the course image in the course home page.  If the course image on a site isn't set, a hard error will be thrown when building the course.  This PR sets up a default value for `$courseImageMetadata` so that the build does not fail if the course image is not set.  It will simply be missing in the rendered site.

#### How should this be manually tested?
 - Clone [`ocw-to-hugo`](https://github.com/mitodl/ocw-to-hugo) and read the readme if you've never used it before, making sure you are set up to download courses from S3
 - In `ocw-to-hugo`, create a file at `private/courses.json` and place the following in it:
```
{
  "courses": [
    "iit-jee"
  ]
}
```
 - Still in `ocw-to-hugo`, run `node . -i private/input -o private/output -c private/courses.json --download --rm`
 - Back in `ocw-hugo-themes`, make sure the following is set in your `.env` file:
   - `COURSE_CONTENT_PATH=/path/to/ocw-to-hugo/private/output/`
   - `OCW_TEST_COURSE=iit-jee`
 - Run `npm run start:course` and the course should build successfully
 - Verify that the course site is available at http://localhost:3000
