### PR TITLE
ensure unique video id

### DIFF
--- a/course/assets/css/video-transcript.scss
+++ b/course/assets/css/video-transcript.scss
@@ -1,4 +1,4 @@
-#transcript {
+.transcript {
   width: 100%;
   margin: auto;
   font-family: Arial, sans-serif;
@@ -49,4 +49,8 @@
   padding-bottom: 5px;
   padding-top: 10px;
   margin-bottom: 10px;
+}
+
+.transcript-footer {
+  height: 15px;
 }

--- a/course/assets/js/video_transcript_track.js
+++ b/course/assets/js/video_transcript_track.js
@@ -1,20 +1,31 @@
 import videojs from "video.js"
 
 export const initVideoTranscriptTrack = () => {
-  if (document.querySelector("#video-player")) {
-    videojs("video-player").ready(function() {
-      window.videojs = videojs
-      require("videojs-transcript-ac")
+  if (document.querySelector(".video-container")) {
+    const videoPlayers = document.querySelectorAll(".vjs-ocw")
 
-      const options = {
-        showTitle:         false,
-        showTrackSelector: false
-      }
+    for (const videoPlayer of videoPlayers) {
+      videojs(videoPlayer.id).ready(function() {
+        window.videojs = videojs
+        require("videojs-transcript-ac")
 
-      const transcript = this.transcript(options)
+        const options = {
+          showTitle:         false,
+          showTrackSelector: false
+        }
 
-      const transcriptContainer = document.querySelector("#transcript")
-      transcriptContainer.appendChild(transcript.el())
-    })
+        const transcript = this.transcript(options)
+
+        if (videoPlayer.closest(".video-page")) {
+          const transcriptContainer = videoPlayer
+            .closest(".video-page")
+            .querySelector(".transcript")
+
+          if (transcriptContainer) {
+            transcriptContainer.appendChild(transcript.el())
+          }
+        }
+      })
+    }
   }
 }

--- a/course/layouts/partials/video.html
+++ b/course/layouts/partials/video.html
@@ -31,14 +31,15 @@
 	       Transcript
 	    </span>
 	    <a class="transcript-section-toggle course-nav-section-toggle"
-	      href="#transcript"
+	      href=".transcript"
 	      data-toggle="collapse"
 	      aria-controls="transcript"
 	      aria-expanded="">
 	      <i class="material-icons md-18"></i>
 	    </a>
 	</div>
-  	<div id="transcript" class="collapse show"></div>
+	<div class="transcript collapse show"></div>
   </div>
+  <div class="transcript-footer"></div>
   {{end}}
 </div>

--- a/course/layouts/partials/youtube_player.html
+++ b/course/layouts/partials/youtube_player.html
@@ -1,6 +1,7 @@
+{{ $random := delimit (shuffle (split (md5 "seed") "" )) "" }}
 <div class="video-container">
   <video
-    id="video-player"
+    id="video-player-{{ .youtubeKey }}-{{ $random }}"
     class="video-js vjs-default-skin vjs-big-play-centered vjs-ocw"
     controls
     data-setup='{


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/285

#### What's this PR do?
Videos don't play correctly when there is more then one on a page because we have duplicate ids, which is not valid html and breaks videojs.

#### How should this be manually tested?
In  ocw-to-hugo set example_courses.json to
```
{
    "courses": [
		"6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016",

    ]
}
```
and run
```
node . -i private/input -o private/output -c course_json_examples/example_courses.json --download
```

In ocw-hugo-themes,
Set your .env to
```
OCW_TEST_COURSE=6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016
COURSE_CONTENT_PATH=/ocw-to-hugo/private/output
DOWNLOAD=0
```
Run
```
npm run start:course
```

Go to
http://localhost:3000/pages/in-class-questions-and-video-solutions/lecture-1/

Verify that you can play all the videos

Also verify that the transcripts page works correctly when you click "View Video Page"