### PR TITLE
Fix MathJax Javascript URL

### DIFF
--- a/course/layouts/_default/baseof.html
+++ b/course/layouts/_default/baseof.html
@@ -81,7 +81,7 @@
 
   <script src="{{ partial "webpack_url.html" $theme.js }}"></script>
   <script src="{{ partial "webpack_url.html" $courseTheme.js }}"></script>
-  <script src="{{ partial "webpack_url.html" "/mathjax/tex-svg.js" }}" defer></script>
+  <script src="{{ partial "webpack_url.html" "/static/mathjax/tex-svg.js" }}" defer></script>
   <!-- Appzi: Capture Insightful Feedback -->
 
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -100,7 +100,6 @@
   {{ partialCached "responsive_tables_js.html" . }}
   {{- $theme := .Site.Data.webpack.main -}}
   {{- $courseTheme := .Site.Data.webpack.course -}}
-  {{- $mathjax := .Site.Data.webpack.mathjax -}}
 
   <script src="{{ partial "webpack_url.html" $theme.js }}"></script>
   <script src="{{ partial "webpack_url.html" $courseTheme.js }}"></script>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/250

#### What's this PR do?
In https://github.com/mitodl/hugo-course-publisher/pull/155 we added support for rendering equations from legacy OCW courses containing MathML using the MathJax library.  When we created the `ocw-hugo-course` and `ocw-www` repos, then subsequently created `ocw-hugo-themes`, we broke the loading of this library.  In https://github.com/mitodl/ocw-hugo-themes/pull/98, we made sure that all static resources built by webpack are placed in the `static` folder.  This PR simply changes the call to the MathJax `tex-svg.js` file to be properly sourced from this folder.

#### How should this be manually tested?
 - Clone [`ocw-to-hugo`](https://github.com/mitodl/ocw-to-hugo) and ensure that you are set up to download courses from AWS
 - Place the following in `ocw-to-hugo/private/courses.json:
```
{
  "courses": [
    "8-01sc-classical-mechanics-fall-2016",
    "16-121-analytical-subsonic-aerodynamics-fall-2017",
    "18-s997-introduction-to-matlab-programming-fall-2011",
    "15-071-the-analytics-edge-spring-2017/sections/logistic-regression"
  ]
}
```
 - Run `node . -i private/input -o private/output -c private/courses.json --download --rm`
 - Back in `ocw-hugo-themes`, in your `.env` file set:
   - `COURSE_CONTENT_PATH=/path/to/ocw-to-hugo/private/output/`
   - `OCW_TEST_COURSE=8-01sc-classical-mechanics-fall-2016`
 - Run `npm run start:course`
 - Visit http://localhost:3000/pages/week-1-kinematics/1.7-worked-example-derivatives-in-kinematics/ and verify that the equations are displayed correctly
 - Repeat the process, changing the `OCW_TEST_COURSE` variable to the next course and trying out MathJax content from other courses
