### PR TITLE
add course_data.json

### DIFF
--- a/course/layouts/index.coursedata.json
+++ b/course/layouts/index.coursedata.json
@@ -1,0 +1,34 @@
+{{- $courseData := .Site.Data.course -}}
+{{- $instructors := slice -}}
+{{- if not (eq  $courseData.instructors nil) -}}
+{{- $instructors = partial "get_instructors.html" $courseData.instructors.content -}}
+{{- end -}}
+
+{
+  "course_title": {{- $courseData.course_title | jsonify -}},
+  "course_description": {{- $courseData.course_description | jsonify -}},
+  "site_uid": {{- $courseData.site_uid | jsonify -}},
+  "legacy_uid": {{- $courseData.legacy_uid | jsonify -}},
+  "instructors": [
+  {{- range $index, $instructor := $instructors -}}
+  {{- if $index -}}
+    ,  
+  {{- end -}}
+  {
+    "first_name":  {{- $instructor.first_name | jsonify -}},
+    "last_name":  {{- $instructor.last_name | jsonify -}},
+    "middle_initial":  {{- $instructor.middle_initial | jsonify -}},
+    "salutation":  {{- $instructor.salutation | jsonify -}},
+    "title":  {{- $instructor.title | jsonify -}}
+  }
+  {{- end }}],
+  "department_numbers": {{- $courseData.department_numbers | jsonify -}},
+  "learning_resource_types": {{- $courseData.learning_resource_types | jsonify -}},
+  "topics": {{- $courseData.topics | jsonify -}},
+  "primary_course_number": {{- $courseData.primary_course_number | jsonify -}},
+  "extra_course_numbers":  {{- $courseData.extra_course_numbers | jsonify -}},
+  "term":  {{- $courseData.term | jsonify -}},
+  "year":  {{- $courseData.year | jsonify -}},
+  "level":  {{- $courseData.level | jsonify -}}
+}
+


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/300

#### What's this PR do?
This pr generates a new course_data.json file for each course in ocw-hugo-themes. This data is available at /course_data.json


#### How should this be manually tested?
checkout https://github.com/mitodl/ocw-hugo-projects/pull/107 in ocw-hugo-projects
Set your .env to 
COURSE_HUGO_CONFIG_PATH=<path>/ocw-hugo-projects/ocw-course/config.yaml

Run ocw-to-hugo for any legacy course and set COURSE_CONTENT_PATH and OCW_TEST_COURSE to point to the data.

Run `npm run start:course`, verify that you can go to http://localhost:3000/course_data.json and the data looks good

Create a course through ocw-studio. Clone the git directory of the studio course from https://github.mit.edu/ocw-content-rc.

Set COURSE_CONTENT_PATH and OCW_TEST_COURSE to point to the course data from github.

Run `npm run start:course`, verify that you can go to http://localhost:3000/course_data.json and the data looks good
