### PR TITLE
feat: menu (sandwich) for mobile devices

### DIFF
--- a/base-theme/assets/css/header.scss
+++ b/base-theme/assets/css/header.scss
@@ -7,6 +7,17 @@
     margin-left: -115px;
     margin-top: -18px;
   }
+
+  .search-icon {
+    display: flex;
+    text-decoration: none;
+    color: $orange;
+    padding-bottom: 0;
+
+    .material-icons {
+      font-size: 1.75rem;
+    }
+  }
 }
 
 #desktop-header {

--- a/base-theme/layouts/partials/header.html
+++ b/base-theme/layouts/partials/header.html
@@ -35,7 +35,7 @@
           >
         </li>
         <li class="nav-item">
-          <a class="nav-link coming-soon" href="#">About OCW</a>
+          <a class="nav-link" href="/about">About OCW</a>
         </li>
         <li class="nav-item">
           <a class="nav-link coming-soon" href="#">Help & Faqs</a>

--- a/base-theme/layouts/partials/header.html
+++ b/base-theme/layouts/partials/header.html
@@ -1,17 +1,56 @@
-<div id="mobile-header" class="position-relative bg-black medium-and-below-only px-3 py-2">
-  <div class="container-fluid">
-    <div class="position-relative pt-1 pb-1">
-      <div class="">
-        <i class="material-icons display-4 text-white align-bottom">menu</i>
-      </div>
-      <div id="ocw-logo-mobile" class="position-absolute">
-        <a href="/">
-          <img width="250" src="/images/ocw_logo_white.png" alt="MIT OpenCourseWare" />
-        </a>
-      </div>
+<!-- navbar for mobile screens -->
+<div
+  id="mobile-header"
+  class="position-relative bg-black medium-and-below-only"
+>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-black">
+    <button
+      class="navbar-toggler"
+      type="button"
+      data-toggle="collapse"
+      data-target="#navbarSupportedContent"
+      aria-controls="navbarSupportedContent"
+      aria-expanded="false"
+      aria-label="Toggle navigation"
+    >
+      <i class="material-icons display-4 text-white align-bottom">menu</i>
+    </button>
+    <div class="mx-auto">
+      <a href="/">
+        <img
+          width="250"
+          src="/images/ocw_logo_white.png"
+          alt="MIT OpenCourseWare"
+        />
+      </a>
     </div>
-  </div>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav mr-auto pl-2 pt-2">
+        <li class="nav-item">{{ block "extraheader" . }}{{ end }}</li>
+        <li class="nav-item">
+          <a
+            class="nav-link"
+            href="https://giving.mit.edu/give/to/ocw/?utm_source=ocw&utm_medium=homepage_banner&utm_campaign=nextgen_home"
+            >Give Now</a
+          >
+        </li>
+        <li class="nav-item">
+          <a class="nav-link coming-soon" href="#">About OCW</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link coming-soon" href="#">Help & Faqs</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="https://ocw.mit.edu/about/contactus/"
+            >Contact Us</a
+          >
+        </li>
+      </ul>
+    </div>
+  </nav>
 </div>
+
+<!-- navbar for laptop/desktop screens -->
 <div id="desktop-header">
   <div class="contents px-6">
     <div class="left">
@@ -23,17 +62,26 @@
     </div>
     <div class="right">
       {{ block "extraheader" . }}{{ end }}
-      <a class="d-flex give-button-header py-2 px-3" href="https://giving.mit.edu/give/to/ocw/?utm_source=ocw&utm_medium=homepage_banner&utm_campaign=nextgen_home">
+      <a
+        class="d-flex give-button-header py-2 px-3"
+        href="https://giving.mit.edu/give/to/ocw/?utm_source=ocw&utm_medium=homepage_banner&utm_campaign=nextgen_home"
+      >
         <span class="font-weight-bold w-100">Give now</span>
       </a>
       <a href="/about">
-        <div class="text-white font-weight-bold w-100 px-3 pl-5 py-2">About OCW</div>
+        <div class="text-white font-weight-bold w-100 px-3 pl-5 py-2">
+          About OCW
+        </div>
       </a>
       <a class="coming-soon">
-        <div class="text-white font-weight-bold w-100 px-3 py-2 coming-soon">help & faqs</div>
+        <div class="text-white font-weight-bold w-100 px-3 py-2 coming-soon">
+          help & faqs
+        </div>
       </a>
       <a href="https://ocw.mit.edu/about/contactus/">
-        <div class="text-white font-weight-bold w-100 px-3 py-2">contact us</div>
+        <div class="text-white font-weight-bold w-100 px-3 py-2">
+          contact us
+        </div>
       </a>
     </div>
   </div>

--- a/course/layouts/partials/extraheader.html
+++ b/course/layouts/partials/extraheader.html
@@ -1,5 +1,5 @@
 {{ define "extraheader" }}
-<a class="search-icon pr-6" href="/search">
+<a class="nav-link search-icon pr-6" href="/search">
   <i class="material-icons">search</i>
 </a>
 {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/26

#### What's this PR do?
Adds sandwich menu for mobile devices with appropriate links.

#### How should this be manually tested?
- This PR is deployed [here](https://ocw-hugo-themes-pr-310--ocw-next.netlify.app)
- Verify that sandwich icon shows up for tablets and mobiles devices (devices having width 991 px or less)
- Verify that sandwich icon shows menu when clicked.
- Verify that all the links shown are working.
     - search box (in ocw-course only)
     -  Give link
     - about link
     - help & faq link
     - contact us link
- Repeat the above steps with multiple browsers.

#### Screenshots (if appropriate)

- Mobile navbar - closed (for both, ocw-www and ocw-course)

![image](https://user-images.githubusercontent.com/93309234/147938369-0a1d7a37-c053-4532-8151-d9c62adc16a1.png)

---------------------------------------------

- ocw-www: 
    - Navbar for Desktop/laptop: 

![Screenshot 2022-01-04 at 3 41 56 PM](https://user-images.githubusercontent.com/93309234/148047544-c02ee4f3-44dc-4974-b81d-17e7618c1472.png)

- ocw-www: 
    - Navbar for Mobile: 
    
![Screenshot 2022-01-04 at 3 45 33 PM](https://user-images.githubusercontent.com/93309234/148047928-c6a34a46-2ee4-4e71-b9a5-aaf07aa5c906.png)

---------------------------------------------

- ocw-course:
    - Navbar for Desktop/laptop: 

![Screenshot 2022-01-04 at 3 21 47 PM](https://user-images.githubusercontent.com/93309234/148047972-c1d38991-5995-43bb-a3cc-65db17ba0f31.png)

- ocw-course:
    - Navbar for Mobile: 
    
![Screenshot 2022-01-04 at 3 40 59 PM](https://user-images.githubusercontent.com/93309234/148048018-167aefdf-d88a-47b4-8f2a-b6db7a7ec1a4.png)
