### PR TITLE
fix instructors

### DIFF
--- a/course/layouts/index.coursedata.json
+++ b/course/layouts/index.coursedata.json
@@ -1,7 +1,7 @@
 {{- $courseData := .Site.Data.course -}}
 {{- $instructors := slice -}}
-{{- if not (eq  $courseData.instructors nil) -}}
-{{- $instructors = partial "get_instructors.html" $courseData.instructors.content -}}
+{{- if not (or (eq $courseData.instructors nil) (eq $courseData.instructors.content nil)) -}}
+{{- $instructors = partial "get_instructors.html" $courseData.instructors.content  -}}
 {{- end -}}
 
 {


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
We saw the following error when deploying to RC
```
Running hugo on courses in /opt/ocw/ocw-to-hugo/private/output...
Error: Error building site: failed to render pages: render of "home" failed: "/opt/ocw/ocw-hugo-themes/course/layouts/index.coursedata.json:4:19": execute of template failed: template: index.coursedata.json:4:19: executing "index.coursedata.json" at <partial "get_instructors.html" $courseData.instructors.content>: error calling partial: partial that returns a value needs a non-zero argument.
```
this fixes the issue

#### How should this be manually tested?
Run `npm run start:course` for any course. You will need to set COURSE_CONTENT_PATH and OCW_TEST_COURSE in your .env file. You should be able to go to http://localhost:3000/course_data.json and see the course data.
Go to the source in COURSE_CONTENT_PATH. Edit course.json in the /data folder in the course output to replace the instructors data with
```
  "instructors": {
  },
```
Run `npm run start:course` again. The course should start and http://localhost:3000/course_data.json should render with ``  "instructors": [],``


