### PR TITLE
fix instructors error take 2

### DIFF
--- a/course/layouts/index.coursedata.json
+++ b/course/layouts/index.coursedata.json
@@ -1,14 +1,11 @@
 {{- $courseData := .Site.Data.course -}}
-{{- $instructors := slice -}}
-{{- if not (or (eq $courseData.instructors nil) (eq $courseData.instructors.content nil)) -}}
-{{- $instructors = partial "get_instructors.html" $courseData.instructors.content  -}}
-{{- end -}}
-
 {
   "course_title": {{- $courseData.course_title | jsonify -}},
   "course_description": {{- $courseData.course_description | jsonify -}},
   "site_uid": {{- $courseData.site_uid | jsonify -}},
   "legacy_uid": {{- $courseData.legacy_uid | jsonify -}},
+  {{- with $courseData.instructors.content -}}
+  {{- $instructors := partial "get_instructors.html" .  -}}
   "instructors": [
   {{- range $index, $instructor := $instructors -}}
   {{- if $index -}}
@@ -22,6 +19,9 @@
     "title":  {{- $instructor.title | jsonify -}}
   }
   {{- end }}],
+  {{- else -}}
+  "instructors": [],
+  {{- end -}}
   "department_numbers": {{- $courseData.department_numbers | jsonify -}},
   "learning_resource_types": {{- $courseData.learning_resource_types | jsonify -}},
   "topics": {{- $courseData.topics | jsonify -}},


### PR DESCRIPTION
#### What's this PR do?
We saw the following error when deploying to RC
```
Running hugo on courses in /opt/ocw/ocw-to-hugo/private/output...
Error: Error building site: failed to render pages: render of "home" failed: "/opt/ocw/ocw-hugo-themes/course/layouts/index.coursedata.json:4:19": execute of template failed: template: index.coursedata.json:4:19: executing "index.coursedata.json" at <partial "get_instructors.html" $courseData.instructors.content>: error calling partial: partial that returns a value needs a non-zero argument.
```
We still saw the error after yesterday's fix. This hopefully fixes the issue

#### How should this be manually tested?
Run `npm run start:course` for any course. You will need to set COURSE_CONTENT_PATH and OCW_TEST_COURSE in your .env file. You should be able to go to http://localhost:3000/course_data.json and see the course data.
Go to the source in COURSE_CONTENT_PATH. Edit course.json in the /data folder in the course output to replace the instructors data with
```
  "instructors": {
  },
```
Run `npm run start:course` again. The course should start and http://localhost:3000/course_data.json should render with ``  "instructors": [],``

Now set
```
  "instructors": {
      "content":""
  },
```
Run `npm run start:course` again. The course should still start and http://localhost:3000/course_data.json should still render with ``  "instructors": [],``

