### PR TITLE
json data pages

### DIFF
--- a/course/layouts/_default/baseof.coursedata.json
+++ b/course/layouts/_default/baseof.coursedata.json
@@ -1,0 +1,1 @@
+{{ block "main" . }}{{ end }}

--- a/course/layouts/_default/section.coursedata.json
+++ b/course/layouts/_default/section.coursedata.json
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "course_content.json" . }}
+{{ end }}

--- a/course/layouts/pages/single.coursedata.json
+++ b/course/layouts/pages/single.coursedata.json
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "course_content.json" . }}
+{{ end }}

--- a/course/layouts/partials/course_content.json
+++ b/course/layouts/partials/course_content.json
@@ -1,0 +1,4 @@
+{
+  "title": {{- .Title | jsonify -}},
+  "content": {{- .Plain | jsonify  -}}
+}

--- a/course/layouts/partials/video-gallery-page.json
+++ b/course/layouts/partials/video-gallery-page.json
@@ -1,0 +1,25 @@
+{{- $ctx := . -}}
+{ 
+  "title": {{- .Title | jsonify -}},
+  "description": {{- .Description | jsonify -}}
+  {{- if not (isset .Params "is_media_gallery") -}}
+  {{- if isset .Params "videos" -}}
+  , 
+  "videos": [
+    {{- range $index, $uuid := .Params.videos.content -}}
+    {{- range $ctx.Site.Pages -}}
+      {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
+        {{- if $index -}}
+         ,  
+        {{- end -}}
+        {
+          "description": {{ .Params.description | jsonify }},
+          "file": {{ .Params.file | jsonify }}
+        }
+      {{- end -}}
+    {{- end -}}
+    {{- end -}}
+    ]
+  {{- end -}}
+  {{- end -}}
+}

--- a/course/layouts/resources/single.coursedata.json
+++ b/course/layouts/resources/single.coursedata.json
@@ -1,0 +1,17 @@
+{
+  "description": {{ .Params.description | jsonify }},
+  "file": {{ .Params.file | jsonify }},
+  "learning_resource_types": {{ .Params.learning_resource_types| jsonify }},
+  "resource_type": {{ .Params.resourcetype | jsonify}},
+  "file_type": {{ .Params.file_type | jsonify}}
+  {{- if eq .Params.resourcetype "Image" -}}
+  ,
+  "image_metadata": {{ .Params.image_metadata | jsonify}}
+  {{- else if eq .Params.resourcetype "Video" -}}
+  ,
+  "youtube_key":  {{ .Params.video_metadata.youtube_id | jsonify}},
+  "captions_file": {{ .Params.video_files.video_captions_file | jsonify }},
+  "transcript_file": {{ .Params.video_files.video_transcript_file | jsonify }},
+  "archive_url": {{ .Params.video_files.archive_url | jsonify }}
+  {{- end -}}
+}

--- a/course/layouts/video_galleries/single.coursedata.json
+++ b/course/layouts/video_galleries/single.coursedata.json
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "video-gallery-page.json" . }}
+{{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/300

#### What's this PR do?
This pr generates a new data.json file for each course page or resource. This data is available by appending /data.json to any course url


#### How should this be manually tested?
https://github.com/mitodl/ocw-hugo-projects/pull/110 in ocw-hugo-projects
Set your .env to 
COURSE_HUGO_CONFIG_PATH=<path>/ocw-hugo-projects/ocw-course/config.yaml

Run ocw-to-hugo for any legacy course and set COURSE_CONTENT_PATH and OCW_TEST_COURSE to point to the data.

Run `npm run start:course`, verify that you can append ``/data.json`` to course urls to get the json representation and the data looks good

Create a course through ocw-studio. Clone the git directory of the studio course from https://github.mit.edu/ocw-content-rc.

Set COURSE_CONTENT_PATH and OCW_TEST_COURSE to point to the course data from github.

Run `npm run start:course`, verify that you can append ``/data.json`` to any course page  and the data looks good
