### PR TITLE
fix: subnav scroll going a bit down

### DIFF
--- a/www/assets/js/subnav.js
+++ b/www/assets/js/subnav.js
@@ -1,7 +1,7 @@
 const initSubNav = () => {
   // [START] Scrolling to appropriate section when subnav item is clicked
   $(".on-page-sub-nav .nav-link").on("click", e => {
-    const navbar = $(".navbar")
+    const navbar = $(".on-page-sub-nav")
     const clickedLink = $(e.target)
     navbar.find(".active").removeClass("active")
     clickedLink.addClass("active")


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
For mobile, When user clicks any subnav item, on about page or educator page, the smooth scroll do not stop at the start of the section, instead it goes a bit down. This PR fixes this issue.

#### How should this be manually tested?
- Go to about us or educator page on mobile 
- Open the on-page sub navbar and click on any menu item.
- Verify that smooth scroll stops at the beginning of the section

#### Screenshots (if appropriate)
Before: 
![Screenshot 2022-01-05 at 8 56 23 PM](https://user-images.githubusercontent.com/93309234/148249249-70a08e47-aa76-484b-a815-a6bfaced56e5.png)

After:
![image](https://user-images.githubusercontent.com/93309234/148249221-94ffda5b-afaa-400c-b290-5f6c68c9bc47.png)

