### PR TITLE
fixed issue regarding box overflow

### DIFF
--- a/base-theme/assets/css/header.scss
+++ b/base-theme/assets/css/header.scss
@@ -86,5 +86,9 @@
   #desktop-header {
     position: absolute;
     background-color: transparent;
+
+    @include media-breakpoint-down(lg) {
+      height: 90px;
+    }
   }
 }

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -45,11 +45,12 @@ $searchbox-height: 50px;
     margin-top: $desktop-header-height;
 
     @include media-breakpoint-down(md) {
-      margin-top: 0;
+      margin-top: 0 !important;
     }
 
     @include media-breakpoint-down(lg) {
       flex-direction: column;
+      margin-top: 85px;
     }
 
     .first-column {


### PR DESCRIPTION
#### Pre-Flight checklist<img width="1253" alt="Screenshot 2022-01-06 at 5 05 46 PM" src="https://user-images.githubusercontent.com/87968618/148381819-fa968126-4592-418f-bf5e-f2f97d2b4e3b.png">
- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #321 

#### What's this PR do?
Updated header size and spacing to insure `Unlocking...` box does not overflow

#### How should this be manually tested?
- Verify that on multiple screen widths the `Unlocking...` box does not overflow hero image


#### Screenshots (if appropriate)
<img width="1253" alt="Screenshot 2022-01-06 at 5 05 46 PM" src="https://user-images.githubusercontent.com/87968618/148381920-49ba4604-b478-47df-ad62-32d2882dc36f.png">

<img width="783" alt="Screenshot 2022-01-06 at 5 14 50 PM" src="https://user-images.githubusercontent.com/87968618/148381871-946a4c0b-6e7c-4d8c-ae94-bcdd0c9f01dd.png">

<img width="1440" alt="Screenshot 2022-01-06 at 5 14 30 PM" src="https://user-images.githubusercontent.com/87968618/148381934-11ac0e13-71fb-4fc8-8391-4fd90e35d597.png">


