### PR TITLE
feat: new design for course expand and collapse

### DIFF
--- a/course/assets/css/course-home.scss
+++ b/course/assets/css/course-home.scss
@@ -30,7 +30,7 @@
           max-height: 4.5rem;
           overflow: hidden;
         }
-      }    
+      }
     }
   }
 

--- a/course/assets/css/course-home.scss
+++ b/course/assets/css/course-home.scss
@@ -24,6 +24,13 @@
       p {
         margin-bottom: 0;
       }
+
+      &.collapsed {
+        .image-description {
+          max-height: 4.5rem;
+          overflow: hidden;
+        }
+      }    
     }
   }
 
@@ -62,6 +69,17 @@
       li {
         padding-bottom: 4px;
       }
+    }
+  }
+
+  .expand-link {
+    border: 0;
+    padding: 0;
+    background-color: white;
+    color: $blue;
+
+    .material-icons {
+      color: black;
     }
   }
 }

--- a/course/assets/css/course-info.scss
+++ b/course/assets/css/course-info.scss
@@ -1,5 +1,4 @@
 .course-info {
-  overflow: hidden;
   $collapsedHeight: 200px;
   $opaqueLayerHeight: 30px;
 
@@ -141,7 +140,6 @@
   }
 
   .expand-link {
-    display: flex;
     align-items: center;
     border: 0;
     padding: 0;

--- a/course/assets/css/course-info.scss
+++ b/course/assets/css/course-info.scss
@@ -27,12 +27,6 @@
       }
     }
   }
-
-  .course-info-expander {
-    .material-icons {
-      margin-left: 48px;
-    }
-  }
 }
 
 .partial-collapse-overlay {
@@ -136,18 +130,6 @@
     .description {
       max-height: 6rem;
       overflow: hidden;
-    }
-  }
-
-  .expand-link {
-    align-items: center;
-    border: 0;
-    padding: 0;
-    background-color: white;
-    color: $blue;
-
-    .material-icons {
-      color: black;
     }
   }
 }

--- a/course/assets/css/course.scss
+++ b/course/assets/css/course.scss
@@ -70,3 +70,8 @@ div[class^="reveal"],
 .multiple_choice_buttons {
   margin: 10px;
 }
+
+hr {
+  margin-top: 1% !important;
+  margin-bottom: 0 !important;
+}

--- a/course/assets/js/course_expander.js
+++ b/course/assets/js/course_expander.js
@@ -7,14 +7,14 @@ const toggleExpand = (button, container) => {
     button.setAttribute("aria-expanded", "false")
     container.classList.add("collapsed")
     if (arrow) {
-      arrow.textContent = "keyboard_arrow_right"
+      arrow.textContent = "keyboard_arrow_down"
     }
   } else {
     button.classList.add("expanded")
     button.setAttribute("aria-expanded", "true")
     container.classList.remove("collapsed")
     if (arrow) {
-      arrow.textContent = "keyboard_arrow_down"
+      arrow.textContent = "keyboard_arrow_up"
     }
   }
 

--- a/course/assets/js/course_expander.test.js
+++ b/course/assets/js/course_expander.test.js
@@ -11,7 +11,7 @@ describe("initCourseInfoExpander", () => {
       <div class="course-info expand-container collapsed">
         <a class="expand-link course-info-link" aria-expanded="false">
           <h4>Course Info</h4>
-          <span class="expander-arrow material-icons">keyboard_arrow_right</span>
+          <span class="expander-arrow material-icons">keyboard_arrow_down</span>
         </a>
       </div>
       <button class="expand-link read-more" aria-expanded="false">
@@ -33,7 +33,7 @@ describe("initCourseInfoExpander", () => {
     const arrow = button.querySelector(".expander-arrow")
     if (arrow) {
       expect(arrow.textContent).toBe(
-        expanded ? "keyboard_arrow_down" : "keyboard_arrow_right"
+        expanded ? "keyboard_arrow_up" : "keyboard_arrow_down"
       )
     }
   }

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -31,29 +31,35 @@
             <div class="container-fluid p-0">
               <div class="row m-0">
                 <div id="main-content" class="col-12 col-lg-12 col-xl-12 px-3 pl-md-5 pr-md-8 mt-3 mt-lg-5">
-                  <!-- the number here is a estimate, a count of 5 lines of characters on a sample course at minimum browser width -->
-                  {{ $shouldCollapseContent := gt (len .Content) 320 }}
                   <div class="homepage-content d-flex">
                     <div class="container-fluid pt-0 pb-4">
-                      <div class="row px-3 pb-2 justify-content-between">
+                      <div class="row px-3 pb-2 justify-content-between">                          
                         <div class="col-lg-4 d-none d-lg-block pl-0">
                           <div class="d-flex flex-column image-with-caption">
                             <img class="course-image" src="{{ $courseImageUrl }}"
                               alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
                             />
-                            <span class="caption p-3">
+                            {{/*  <img class="course-image" src="https://www.3playmedia.com/wp-content/uploads/mit-ocw-laptop-1.png.webp"
+                            alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
+                          />  */}}
+                          <div class="caption p-3">
+                            <span class="image-description">
                               {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}
                             </span>
                           </div>
                         </div>
+                        </div>
                         {{ partial "mobile_nav_toggle.html" . }}
-                        <div class="col-lg-8 course-description expand-container {{ if $shouldCollapseContent }}collapsed{{ end }}">
+                        <!-- the number here is a estimate, a count of 5 lines of characters on a sample course at minimum browser width -->
+                        {{ $shouldCollapseCourseDescription := gt (len $courseData.course_description) 320 }}
+                        <div class="col-lg-8 course-description expand-container {{ if $shouldCollapseCourseDescription }}collapsed{{ end }}">
                           <h4 class="font-weight-bold course-description-title">Course Description</h4>
-                          <div class="mb-1 description">{{- $courseData.course_description | markdownify -}}</div>
+                          <div class="description">{{- $courseData.course_description | markdownify -}}</div>
+                          <hr>
                           <div class="mb-3">
-                            {{ if $shouldCollapseContent }}
-                              <button class="expand-link" aria-expanded="false">
-                                <span class="read-more-text">Read More</span>
+                            {{ if $shouldCollapseCourseDescription }}
+                              <button class="expand-link float-right" aria-expanded="false">
+                                <span class="expander-arrow material-icons">keyboard_arrow_down</span>
                               </button>
                             {{ end }}
                           </div>

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -37,12 +37,9 @@
                         {{ $shouldCollapseCourseImageDescription := gt (len $courseImageMetadata.Params.image_metadata.caption) 100 }}                        
                         <div class="col-lg-4 d-none d-lg-block pl-0">
                           <div class="d-flex flex-column image-with-caption">
-                            {{/*  <img class="course-image" src="{{ $courseImageUrl }}"
+                            <img class="course-image" src="{{ $courseImageUrl }}"
                               alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
-                            />  */}}
-                            <img class="course-image" src="https://www.3playmedia.com/wp-content/uploads/mit-ocw-laptop-1.png.webp"
-                            alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
-                          />
+                            />
                           <div class="caption px-3 pt-3 expand-container {{ if $shouldCollapseCourseImageDescription }}collapsed{{ end }}">
                             <div class="image-description">
                               {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -33,19 +33,25 @@
                 <div id="main-content" class="col-12 col-lg-12 col-xl-12 px-3 pl-md-5 pr-md-8 mt-3 mt-lg-5">
                   <div class="homepage-content d-flex">
                     <div class="container-fluid pt-0 pb-4">
-                      <div class="row px-3 pb-2 justify-content-between">                          
+                      <div class="row px-3 pb-2 justify-content-between">  
+                        {{ $shouldCollapseCourseImageDescription := gt (len $courseImageMetadata.Params.image_metadata.caption) 100 }}                        
                         <div class="col-lg-4 d-none d-lg-block pl-0">
                           <div class="d-flex flex-column image-with-caption">
-                            <img class="course-image" src="{{ $courseImageUrl }}"
+                            {{/*  <img class="course-image" src="{{ $courseImageUrl }}"
                               alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
-                            />
-                            {{/*  <img class="course-image" src="https://www.3playmedia.com/wp-content/uploads/mit-ocw-laptop-1.png.webp"
+                            />  */}}
+                            <img class="course-image" src="https://www.3playmedia.com/wp-content/uploads/mit-ocw-laptop-1.png.webp"
                             alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
-                          />  */}}
-                          <div class="caption p-3">
-                            <span class="image-description">
+                          />
+                          <div class="caption px-3 pt-3 expand-container {{ if $shouldCollapseCourseImageDescription }}collapsed{{ end }}">
+                            <div class="image-description">
                               {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}
-                            </span>
+                            </div>
+                            {{ if $shouldCollapseCourseImageDescription }}
+                            <button class="expand-link float-right" aria-expanded="false">
+                              <span class="expander-arrow material-icons">keyboard_arrow_down</span>
+                            </button>
+                            {{ end }}
                           </div>
                         </div>
                         </div>

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -1,74 +1,75 @@
 {{ $courseData := .context.Site.Data.course }}
 {{ $inPanel := .inPanel }}
-<div class="table-responsive course-info expand-container {{ if not $inPanel }}collapsed{{ end }}">
+<div class="course-info expand-container {{ if not $inPanel }}collapsed{{ end }}">
+  <div class="table-responsive overflow-hidden">
+    <div>
+      <h4 class="course-info-title font-weight-bold">Course Info</h4>
+    </div>
+    <div class="position-relative" >
+      <table id="course-info-table" class="table table-borderless mb-2">
+        {{ with $courseData.instructors.content }}
+        <tr>
+          {{ $instructors := partial "get_instructors.html" . }}
+          <td class="pl-0">{{ if eq (len $instructors) 1 }}Instructor{{ else }}Instructors{{ end }}:</td>
+          <td>
+            {{ partial "partial_collapse_list.html" (dict "list" $instructors "id" "instructors" "key" "title" "klass" "course-info-instructor" "showCollapse" $inPanel) }}
+          </td>
+        </tr>
+        {{ end }}
+        <tr>
+          <td class="pl-0">Course Number:</td>
+          <td>{{ partial "partial_collapse_list.html" (dict "list" ((slice $courseData.primary_course_number) | append (split $courseData.extra_course_numbers ",")) "id" "course_numbers" "useLinks" false) }}</td>
+        </tr>
+        {{ with $courseData.department_numbers }}
+        <tr>
+          <td class="pl-0">Departments:</td>
+          <td>
+            {{ $departments := partial "get_departments.html" . }}
+            {{ partial "partial_collapse_list.html" (dict "list" $departments "id" "departments" "key" "title" "klass" "course-info-department" "useLinks" true) }}
+          </td>
+        </tr>
+        {{ end }}
+        {{ if not $inPanel }}
+        <tr>
+          <td class="pl-0">Topics:</td>
+          <td>
+            {{ partial "topics_oneline.html" . }}
+          </td>
+        </tr>
+        {{ end }}
+        <tr>
+          <td class="pl-0 text-nowrap">As Taught In:</td>
+          <td>
+            {{ $courseData.term }} {{ if isset $courseData "year" }}{{ $courseData.year }}{{ end }}
+          </td>
+        </tr>
+        <tr>
+          <td class="pl-0 pb-3">Level:</td>
+          <td>
+            {{ if eq (printf "%T" $courseData.level) "string" }}
+              {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
+              <a href="{{ $levelSearchUrl }}" class="course-info-level">
+                {{ $courseData.level }}
+              </a>
+            {{ else }}
+              {{ range $courseData.level }}
+                {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) }}
+                <a href="{{ $levelSearchUrl }}" class="course-info-level">
+                  {{ . }}
+                </a><br />
+              {{ end }}
+            {{ end }}
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
   <div class="course-info-expander">
+    <hr>
     {{ if not $inPanel }}
-    <a class="expand-link d-flex align-items-center text-decoration-none" aria-expanded="false" href="#">
-      <h4 class="course-info-title font-weight-bold d-inline m-0">Course Info</h4>
-      <span class="expander-arrow material-icons">keyboard_arrow_right</span>
+    <a class="expand-link float-right" aria-expanded="false" href="#">
+      <span class="expander-arrow material-icons">keyboard_arrow_down</span>
     </a>
-    {{ else }}
-    <h4 class="course-info-title font-weight-bold">Course Info</h4>
     {{ end }}
   </div>
-  <div class="position-relative">
-    <div class="opaque-layer"></div>
-    <table id="course-info-table" class="table table-borderless {{ if $inPanel }}border-bottom-gray{{ end }} mb-2">
-      {{ with $courseData.instructors.content }}
-      <tr>
-        {{ $instructors := partial "get_instructors.html" . }}
-        <td class="pl-0">{{ if eq (len $instructors) 1 }}Instructor{{ else }}Instructors{{ end }}:</td>
-        <td>
-          {{ partial "partial_collapse_list.html" (dict "list" $instructors "id" "instructors" "key" "title" "klass" "course-info-instructor" "showCollapse" $inPanel) }}
-        </td>
-      </tr>
-      {{ end }}
-      <tr>
-        <td class="pl-0">Course Number:</td>
-        <td>{{ partial "partial_collapse_list.html" (dict "list" ((slice $courseData.primary_course_number) | append (split $courseData.extra_course_numbers ",")) "id" "course_numbers" "useLinks" false) }}</td>
-      </tr>
-      {{ with $courseData.department_numbers }}
-      <tr>
-        <td class="pl-0">Departments:</td>
-        <td>
-          {{ $departments := partial "get_departments.html" . }}
-          {{ partial "partial_collapse_list.html" (dict "list" $departments "id" "departments" "key" "title" "klass" "course-info-department" "useLinks" true) }}
-        </td>
-      </tr>
-      {{ end }}
-      {{ if not $inPanel }}
-      <tr>
-        <td class="pl-0">Topics:</td>
-        <td>
-          {{ partial "topics_oneline.html" . }}
-        </td>
-      </tr>
-      {{ end }}
-      <tr>
-        <td class="pl-0 text-nowrap">As Taught In:</td>
-        <td>
-          {{ $courseData.term }} {{ if isset $courseData "year" }}{{ $courseData.year }}{{ end }}
-        </td>
-      </tr>
-      <tr>
-        <td class="pl-0 pb-3">Level:</td>
-        <td>
-          {{ if eq (printf "%T" $courseData.level) "string" }}
-            {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
-            <a href="{{ $levelSearchUrl }}" class="course-info-level">
-              {{ $courseData.level }}
-            </a>
-          {{ else }}
-            {{ range $courseData.level }}
-              {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) }}
-              <a href="{{ $levelSearchUrl }}" class="course-info-level">
-                {{ . }}
-              </a><br />
-            {{ end }}
-          {{ end }}
-        </td>
-      </tr>
-    </table>
-  </div>
 </div>
-

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -5,8 +5,8 @@
     <div>
       <h4 class="course-info-title font-weight-bold">Course Info</h4>
     </div>
-    <div class="position-relative" >
-      <table id="course-info-table" class="table table-borderless mb-2">
+    <div class="position-relative">
+      <table id="course-info-table" class="table table-borderless {{ if $inPanel }}border-bottom-gray{{ end }} mb-2">
         {{ with $courseData.instructors.content }}
         <tr>
           {{ $instructors := partial "get_instructors.html" . }}
@@ -64,7 +64,7 @@
       </table>
     </div>
   </div>
-  <div class="course-info-expander">
+  <div>
     <hr>
     {{ if not $inPanel }}
     <a class="expand-link float-right" aria-expanded="false" href="#">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/286

#### What's this PR do?
New design for expanding and collapsing course description, course meta-data and image description.

#### How should this be manually tested?
- Verify that image description, course description and course info (meta-data) expands and collapse correctly when arrow icon is clicked/toggled.
- Change the size of the content or test them on different courses having different sizes/lengths of content.
- Test the above on multiple browsers and multiple screen sizes.

#### Screenshots (if appropriate)

All three, image description, course description and info closed:
![image](https://user-images.githubusercontent.com/93309234/148742927-3377d545-98f9-4ce8-a71a-f3de6858cac9.png)

Image Description open and course description and info closes:
![image](https://user-images.githubusercontent.com/93309234/148743000-50a4d958-6196-43d2-87f7-95acc1fe6894.png) 

Both, Course description and info open:
![image](https://user-images.githubusercontent.com/93309234/148743106-fcea2170-00f5-4ce2-b3cc-e135a55feca5.png)

info open and course description closed:
![image](https://user-images.githubusercontent.com/93309234/148743207-228c64a2-01a7-49e9-af8d-e27d88b49843.png)

