### PR TITLE
feat: expand/collapse enhancement

### DIFF
--- a/course/assets/css/course-home.scss
+++ b/course/assets/css/course-home.scss
@@ -76,11 +76,13 @@
     }
   }
 
-  a.collapsed span:after {
-    content: "keyboard_arrow_down";
-  }
+  .collapse-btn-section {
+    a.collapsed span:after {
+      content: "keyboard_arrow_down";
+    }
 
-  a:not(.collapsed) span:after {
-    content: "keyboard_arrow_up";
+    a:not(.collapsed) span:after {
+      content: "keyboard_arrow_up";
+    }
   }
 }

--- a/course/assets/css/course-home.scss
+++ b/course/assets/css/course-home.scss
@@ -64,4 +64,12 @@
       }
     }
   }
+
+  a.collapsed span:after {
+    content: "keyboard_arrow_down";
+  }
+
+  a:not(.collapsed) span:after {
+    content: "keyboard_arrow_up";
+  }
 }

--- a/course/assets/css/course-home.scss
+++ b/course/assets/css/course-home.scss
@@ -25,6 +25,17 @@
         margin-bottom: 0;
       }
     }
+
+    #course-image-description.collapse:not(.show) {
+      display: block;
+      /* height = lineheight * no of lines to display */
+      height: 5.3em;
+      overflow: hidden;
+    }
+
+    #course-image-description.collapsing {
+      height: 5.3em;
+    }
   }
 
   h4.course-info-title,

--- a/course/assets/css/course-info.scss
+++ b/course/assets/css/course-info.scss
@@ -152,4 +152,23 @@
       color: black;
     }
   }
+
+  a.collapsed span:after {
+    content: 'keyboard_arrow_down';
+  }
+  
+  a:not(.collapsed) span:after {
+    content: 'keyboard_arrow_up';
+  }
+  
+  #course-description.collapse:not(.show) {
+    display: block;
+    /* height = lineheight * no of lines to display */
+    height: 4.5em;
+    overflow: hidden;
+  }
+  
+  #course-description.collapsing {
+    height: 4.5em;
+  }
 }

--- a/course/assets/css/course-info.scss
+++ b/course/assets/css/course-info.scss
@@ -34,6 +34,17 @@
       margin-left: 48px;
     }
   }
+
+  #course-info.collapse:not(.show) {
+    display: block;
+    /* height = lineheight * no of lines to display */
+    height: 12.5em;
+    overflow: hidden;
+  }
+
+  #course-info.collapsing {
+    height: 12.5em;
+  }
 }
 
 .partial-collapse-overlay {
@@ -153,21 +164,13 @@
     }
   }
 
-  a.collapsed span:after {
-    content: 'keyboard_arrow_down';
-  }
-  
-  a:not(.collapsed) span:after {
-    content: 'keyboard_arrow_up';
-  }
-  
   #course-description.collapse:not(.show) {
     display: block;
     /* height = lineheight * no of lines to display */
     height: 4.5em;
     overflow: hidden;
   }
-  
+
   #course-description.collapsing {
     height: 4.5em;
   }

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -40,13 +40,15 @@
                             <img class="course-image" src="{{ $courseImageUrl }}"
                               alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
                             />
-                            <div id="course-image-description" class="caption p-3 {{ if $shouldCollapseImageDescription }}collapse{{ end }}" aria-expanded="false">
-                              <span>
-                                {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}
-                              </span>
+                            <div id="course-image-description" class="{{ if $shouldCollapseImageDescription }}collapse{{ end }}" aria-expanded="false">
+                              <div class="caption pt-3 px-3">
+                                <span>
+                                  {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}
+                                </span>
+                              </div>
                             </div>
                             {{ if $shouldCollapseImageDescription }}
-                            <div class="float-right px-2">
+                            <div class="collapse-btn-section ml-auto pt-1 px-3">
                               <a role="button" class="collapsed" data-toggle="collapse" href="#course-image-description" aria-expanded="false" aria-controls="course-image-description">
                                 <span class="material-icons"></span>
                               </a>
@@ -64,7 +66,7 @@
                           </div>
                           <hr class="mt-2 mb-0">
                           {{ if $shouldCollapseDescription }}
-                          <div class="mb-3 float-right">
+                          <div class="collapse-btn-section mb-3 float-right">
                             <a role="button" class="collapsed" data-toggle="collapse" href="#course-description" aria-expanded="false" aria-controls="course-description">
                               <span class="material-icons"></span>
                             </a>

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -49,7 +49,7 @@
                         {{ $shouldCollapseDescription := gt (len $courseData.course_description) 320 }}
                         <div class="col-lg-8 course-description">
                           <h4 class="font-weight-bold course-description-title">Course Description</h4>
-                          <div class="mb-1 description {{ if $shouldCollapseDescription }}collapse{{ end }}" id="course-description" aria-expanded="false">
+                          <div id="course-description" class="mb-1 description {{ if $shouldCollapseDescription }}collapse{{ end }}" aria-expanded="false">
                             {{- $courseData.course_description | markdownify -}}
                           </div>
                           <hr class="mt-2 mb-0">

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -34,14 +34,24 @@
                   <div class="homepage-content d-flex">
                     <div class="container-fluid pt-0 pb-4">
                       <div class="row px-3 pb-2 justify-content-between">
+                        {{ $shouldCollapseImageDescription := gt (len $courseImageMetadata.Params.image_metadata.caption) 100 }}
                         <div class="col-lg-4 d-none d-lg-block pl-0">
                           <div class="d-flex flex-column image-with-caption">
                             <img class="course-image" src="{{ $courseImageUrl }}"
                               alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
                             />
-                            <span class="caption p-3">
-                              {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}
-                            </span>
+                            <div id="course-image-description" class="caption p-3 {{ if $shouldCollapseImageDescription }}collapse{{ end }}" aria-expanded="false">
+                              <span>
+                                {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}
+                              </span>
+                            </div>
+                            {{ if $shouldCollapseImageDescription }}
+                            <div class="float-right px-2">
+                              <a role="button" class="collapsed" data-toggle="collapse" href="#course-image-description" aria-expanded="false" aria-controls="course-image-description">
+                                <span class="material-icons"></span>
+                              </a>
+                            </div>
+                            {{ end }}
                           </div>
                         </div>
                         {{ partial "mobile_nav_toggle.html" . }}
@@ -53,13 +63,13 @@
                             {{- $courseData.course_description | markdownify -}}
                           </div>
                           <hr class="mt-2 mb-0">
+                          {{ if $shouldCollapseDescription }}
                           <div class="mb-3 float-right">
-                            {{ if $shouldCollapseDescription }}
-                              <a role="button" class="collapsed" data-toggle="collapse" href="#course-description" aria-expanded="false" aria-controls="course-description">
-                                <span class="material-icons"></span>
-                              </a>
-                            {{ end }}
+                            <a role="button" class="collapsed" data-toggle="collapse" href="#course-description" aria-expanded="false" aria-controls="course-description">
+                              <span class="material-icons"></span>
+                            </a>
                           </div>
+                          {{ end }}
                           {{ partial "course_info.html" (dict "context" . "inPanel" false) }}
                         </div>
                       </div>

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -31,8 +31,6 @@
             <div class="container-fluid p-0">
               <div class="row m-0">
                 <div id="main-content" class="col-12 col-lg-12 col-xl-12 px-3 pl-md-5 pr-md-8 mt-3 mt-lg-5">
-                  <!-- the number here is a estimate, a count of 5 lines of characters on a sample course at minimum browser width -->
-                  {{ $shouldCollapseContent := gt (len .Content) 320 }}
                   <div class="homepage-content d-flex">
                     <div class="container-fluid pt-0 pb-4">
                       <div class="row px-3 pb-2 justify-content-between">
@@ -47,14 +45,19 @@
                           </div>
                         </div>
                         {{ partial "mobile_nav_toggle.html" . }}
-                        <div class="col-lg-8 course-description expand-container {{ if $shouldCollapseContent }}collapsed{{ end }}">
+                        <!-- the number here is a estimate, a count of 5 lines of characters on a sample course at minimum browser width -->
+                        {{ $shouldCollapseDescription := gt (len $courseData.course_description) 320 }}
+                        <div class="col-lg-8 course-description">
                           <h4 class="font-weight-bold course-description-title">Course Description</h4>
-                          <div class="mb-1 description">{{- $courseData.course_description | markdownify -}}</div>
-                          <div class="mb-3">
-                            {{ if $shouldCollapseContent }}
-                              <button class="expand-link" aria-expanded="false">
-                                <span class="read-more-text">Read More</span>
-                              </button>
+                          <div class="mb-1 description {{ if $shouldCollapseDescription }}collapse{{ end }}" id="course-description" aria-expanded="false">
+                            {{- $courseData.course_description | markdownify -}}
+                          </div>
+                          <hr class="mt-2 mb-0">
+                          <div class="mb-3 float-right">
+                            {{ if $shouldCollapseDescription }}
+                              <a role="button" class="collapsed" data-toggle="collapse" href="#course-description" aria-expanded="false" aria-controls="course-description">
+                                <span class="material-icons"></span>
+                              </a>
                             {{ end }}
                           </div>
                           {{ partial "course_info.html" (dict "context" . "inPanel" false) }}

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -5,7 +5,7 @@
     <h4 class="course-info-title font-weight-bold">Course Info</h4>
   </div>
   <div id="course-info" class="position-relative {{ if not $inPanel }}collapse{{ end }}" aria-expanded="false">
-    <table id="course-info-table" class="table table-borderless mb-2" >
+    <table id="course-info-table" class="table table-borderless" >
       {{ with $courseData.instructors.content }}
       <tr>
         {{ $instructors := partial "get_instructors.html" . }}
@@ -43,7 +43,7 @@
         </td>
       </tr>
       <tr>
-        <td class="pl-0 pb-3">Level:</td>
+        <td class="pl-0">Level:</td>
         <td>
           {{ if eq (printf "%T" $courseData.level) "string" }}
             {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
@@ -62,15 +62,14 @@
       </tr>
     </table>
   </div>
-  <div>
-    <hr class="mt-2 mb-0">
-    {{ if not $inPanel }}
-    <div class="float-right mb-3">
-      <a role="button" class="collapsed" data-toggle="collapse" href="#course-info" aria-expanded="false" aria-controls="course-info">
-        <span class="material-icons"></span>
-      </a>
-    </div>
-    {{ end }}
-  </div>
 </div>
-
+<div>
+  <hr class="mb-0">
+  {{ if not $inPanel }}
+  <div class="collapse-btn-section float-right mb-3">
+    <a role="button" class="collapsed" data-toggle="collapse" href="#course-info" aria-expanded="false" aria-controls="course-info">
+      <span class="material-icons"></span>
+    </a>
+  </div>
+  {{ end }}
+</div>

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -1,19 +1,11 @@
 {{ $courseData := .context.Site.Data.course }}
 {{ $inPanel := .inPanel }}
-<div class="table-responsive course-info expand-container {{ if not $inPanel }}collapsed{{ end }}">
+<div class="table-responsive course-info">
   <div class="course-info-expander">
-    {{ if not $inPanel }}
-    <a class="expand-link d-flex align-items-center text-decoration-none" aria-expanded="false" href="#">
-      <h4 class="course-info-title font-weight-bold d-inline m-0">Course Info</h4>
-      <span class="expander-arrow material-icons">keyboard_arrow_right</span>
-    </a>
-    {{ else }}
     <h4 class="course-info-title font-weight-bold">Course Info</h4>
-    {{ end }}
   </div>
-  <div class="position-relative">
-    <div class="opaque-layer"></div>
-    <table id="course-info-table" class="table table-borderless {{ if $inPanel }}border-bottom-gray{{ end }} mb-2">
+  <div id="course-info" class="position-relative {{ if not $inPanel }}collapse{{ end }}" aria-expanded="false">
+    <table id="course-info-table" class="table table-borderless mb-2" >
       {{ with $courseData.instructors.content }}
       <tr>
         {{ $instructors := partial "get_instructors.html" . }}
@@ -69,6 +61,16 @@
         </td>
       </tr>
     </table>
+  </div>
+  <div>
+    <hr class="mt-2 mb-0">
+    {{ if not $inPanel }}
+    <div class="float-right mb-3">
+      <a role="button" class="collapsed" data-toggle="collapse" href="#course-info" aria-expanded="false" aria-controls="course-info">
+        <span class="material-icons"></span>
+      </a>
+    </div>
+    {{ end }}
   </div>
 </div>
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/329

#### What's this PR do?
New enhanced design for expanding and collapsing course description, course meta-data and image description.

#### How should this be manually tested?
- Verify that image description, course description and course info (meta-data) expands and collapse correctly when arrow icon is clicked/toggled.
- Change the size of the content or test them on different courses having different sizes/lengths of content.
- Test the above on multiple browsers and multiple screen sizes.

#### Screenshots (if appropriate)
Video link: https://drive.google.com/file/d/1R8yhyXMAMVmjZn9dphS0kjAjpxwbkwm2/view?usp=sharing
