### PR TITLE
fix: removing extra font-size for h2 tag

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -298,7 +298,6 @@ article.content {
 
   h2 {
     color: $highlight-red;
-    font-size: 1.15rem;
     text-transform: uppercase;
   }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/90

#### What's this PR do?
Removes font-size for h2 tag in **article.content h2** so that default font-size of h2, defined in **main.scss**, which is 28px (for laptop) and 24px (for mobile) can be applied.  

#### How should this be manually tested?
- Open course homepage
- Go to different pages from sidenavbar
- Verify that heading (h2) is bigger than sub-heading (h3)
- Verify that color of heading (h2) is red (a31f34) and color sub-heading (h3) is black.
- Repeat the above steps for different pages and different courses.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/93309234/148955017-2dc7dbe3-9c2b-4322-8dff-0bea8896d427.png)
