### PR TITLE
fix: horizontal scroll bar on topics in drawer

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -286,6 +286,10 @@ table {
   border-bottom: 1px solid $medium-gray;
 }
 
+.border-top-gray {
+  border-top: 1px solid $medium-gray;
+}
+
 .border-gray {
   border: 1px solid $medium-gray;
 }

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -360,3 +360,7 @@ article.content {
 .color-red {
   color: $highlight-red;
 }
+
+.overflow-x-hidden {
+  overflow-x: hidden;
+}

--- a/course/assets/css/course-info.scss
+++ b/course/assets/css/course-info.scss
@@ -3,6 +3,13 @@
   $collapsedHeight: 200px;
   $opaqueLayerHeight: 30px;
 
+  // This media query is not defined gloabally as it
+  // is targeted/specific to a particular use case only
+  // Hiding horizontal scroll on screens where content already fits in
+  @media (min-width: 1270px) {
+    overflow-x: hidden !important;
+  }
+
   &.collapsed {
     table {
       display: block;

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -57,17 +57,18 @@
                         {{ $shouldCollapseDescription := gt (len $courseData.course_description) 320 }}
                         <div class="col-lg-8 course-description">
                           <h4 class="font-weight-bold course-description-title">Course Description</h4>
-                          <div id="course-description" class="mb-1 description {{ if $shouldCollapseDescription }}collapse{{ end }}" aria-expanded="false">
+                          <div id="course-description" class="description {{ if $shouldCollapseDescription }}collapse{{ end }}" aria-expanded="false">
                             {{- $courseData.course_description | markdownify -}}
                           </div>
-                          <hr class="mt-2 mb-0">
-                          {{ if $shouldCollapseDescription }}
-                          <div class="collapse-btn-section mb-3 float-right">
-                            <a role="button" class="collapsed" data-toggle="collapse" href="#course-description" aria-expanded="false" aria-controls="course-description">
-                              <span class="material-icons"></span>
-                            </a>
+                          <div class="border-top-gray mt-2">
+                            {{ if $shouldCollapseDescription }}
+                              <div class="collapse-btn-section float-right">
+                                <a role="button" class="collapsed" data-toggle="collapse" href="#course-description" aria-expanded="false" aria-controls="course-description">
+                                  <span class="material-icons"></span>
+                                </a>
+                              </div>
+                            {{ end }}
                           </div>
-                          {{ end }}
                           {{ partial "course_info.html" (dict "context" . "inPanel" false) }}
                         </div>
                       </div>

--- a/course/layouts/partials/course_info.html
+++ b/course/layouts/partials/course_info.html
@@ -5,7 +5,7 @@
     <h4 class="course-info-title font-weight-bold">Course Info</h4>
   </div>
   <div id="course-info" class="position-relative {{ if not $inPanel }}collapse{{ end }}" aria-expanded="false">
-    <table id="course-info-table" class="table table-borderless" >
+    <table id="course-info-table" class="table table-borderless mb-0" >
       {{ with $courseData.instructors.content }}
       <tr>
         {{ $instructors := partial "get_instructors.html" . }}
@@ -63,8 +63,7 @@
     </table>
   </div>
 </div>
-<div>
-  <hr class="mb-0">
+<div class="border-top-gray {{ if not $inPanel }}mt-2{{ end }}">
   {{ if not $inPanel }}
   <div class="collapse-btn-section float-right mb-3">
     <a role="button" class="collapsed" data-toggle="collapse" href="#course-info" aria-expanded="false" aria-controls="course-info">

--- a/course/layouts/partials/topics.html
+++ b/course/layouts/partials/topics.html
@@ -1,7 +1,7 @@
 {{ $courseData := .context.Site.Data.course }}
 {{ $scratch := newScratch }}
 {{ $scratch.Set "index" 0 }}
-<div class="border-bottom-gray mb-2">
+<div class="border-bottom-gray my-2">
   <h4 class="course-info-title font-weight-bold">Topics</h4>
   <ul class="list-unstyled pb-2 m-0">
     {{- $topics := (slice (slice "Social Science" "Political Science" "American Politics") (slice "Social Science" "Public Administration" "Public Policy")) -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/255

#### What's this PR do?
- Hides horizontal scroll on course info for screens where content fits in/is adjusted.
- Makes border same for course home page and course info on other pages, to maintain consistency, which got different due to a merged PR.
- Adjusts little padding and margins

#### How should this be manually tested?
- Visit any course ( [e.g](https://ocw-draft-qa.global.ssl.fastly.net/courses/peters-test-2021-09-29-1/pages/asdf/) )
- Using responsive mode, set the browser width to "Laptop with MDPI screen" ( [width: 1280, height: 800](https://gist.github.com/TrevorJTClarke/27896c197a34e597a8a6) )
- Verify that there is no horizontal scroll.

#### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/93309234/149114741-cc12de16-98ce-43b8-9927-77f850f024ee.png)

After: 
![image](https://user-images.githubusercontent.com/93309234/149114549-feed8f5a-f5b4-4e29-9f63-5dbc5ed723c6.png)
