### PR TITLE
add course image to coursedata.json

### DIFF
--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -1,12 +1,8 @@
 {{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
 {{- $courseData := .Site.Data.course -}}
-
-{{- $courseImageUid := $courseData.course_image.content -}}
-{{- $courseImageMetadata := (dict "Params" (dict "file" "None" "image_metadata" (dict "image-alt" "" "caption" ""))) -}}
-{{- if $courseImageUid -}}
-{{- $courseImageMetadata = partial "resource_metadata.html" $courseImageUid }}
-{{- end -}}
-{{- $courseImageUrl := partial "resource_url.html" $courseImageMetadata.Params.file -}}
+{{- $imageData := partial "course-image-url.html" . -}}
+{{- $courseImageUrl := index $imageData 0 -}}
+{{- $courseImageMetadata := index $imageData 1 -}}
 <!doctype html>
 <html lang="{{ $.Site.Language.Lang }}">
 {{ partial "head.html" . }}

--- a/course/layouts/index.coursedata.json
+++ b/course/layouts/index.coursedata.json
@@ -1,4 +1,5 @@
 {{- $courseData := .Site.Data.course -}}
+{{- $courseImageMetadata := index (partial "course-image-url.html" .) 1 -}}
 {
   "course_title": {{- $courseData.course_title | jsonify -}},
   "course_description": {{- $courseData.course_description | jsonify -}},
@@ -29,6 +30,8 @@
   "extra_course_numbers":  {{- $courseData.extra_course_numbers | jsonify -}},
   "term":  {{- $courseData.term | jsonify -}},
   "year":  {{- $courseData.year | jsonify -}},
-  "level":  {{- $courseData.level | jsonify -}}
+  "level":  {{- $courseData.level | jsonify -}},
+  "image_src": {{- $courseImageMetadata.Params.file | jsonify -}},
+  "course_image_metadata": {{- $courseImageMetadata.Params | jsonify -}}
 }
 

--- a/course/layouts/partials/course-image-url.html
+++ b/course/layouts/partials/course-image-url.html
@@ -1,0 +1,8 @@
+{{- $courseData := .Site.Data.course -}}
+{{- $courseImageUid := $courseData.course_image.content -}}
+{{- $courseImageMetadata := (dict "Params" (dict "file" "None" "image_metadata" (dict "image-alt" "" "caption" ""))) -}}
+{{- if $courseImageUid -}}
+{{- $courseImageMetadata = partial "resource_metadata.html" $courseImageUid }}
+{{- end -}}
+{{- $courseImageUrl := partial "resource_url.html" $courseImageMetadata.Params.file -}}
+{{ return (slice $courseImageUrl $courseImageMetadata )}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #338

#### What's this PR do?

This adds the course image to `coursedata.json` under the `image_src` key (which is what we're using in the search index currently).

We already had code to pull the image out for displaying it on the course home page, so I just wrapped that up in a partial so we can have that logic live in one place.

#### How should this be manually tested?

Run a course build (`start:course` should do I think) and confirm that a correct looking `image_src` property shows up in `coursedata.json` and that the image works on the course home page.

<img width="960" alt="Screen Shot 2022-01-12 at 5 14 01 PM" src="https://user-images.githubusercontent.com/6207644/149231423-7fe3b9ca-a308-4e2e-99f2-95c83e0be3f3.png">
