### PR TITLE
add optional colspan and rowspan attributes to tdopen / thopen shortcodes

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -329,6 +329,10 @@ article.content {
 
       td {
         border: none;
+
+        p {
+          font-size: 1rem;
+        }
       }
     }
   }

--- a/base-theme/layouts/shortcodes/tdopen.html
+++ b/base-theme/layouts/shortcodes/tdopen.html
@@ -1,1 +1,1 @@
-<td>
+<td{{ if .Get "colspan" }} colspan="{{ .Get "colspan" }}"{{ end }}{{ if .Get "rowspan" }} rowspan="{{ .Get "rowspan" }}"{{ end }}>

--- a/base-theme/layouts/shortcodes/thopen.html
+++ b/base-theme/layouts/shortcodes/thopen.html
@@ -1,1 +1,1 @@
-<th>
+<th{{ if .Get "colspan" }} colspan="{{ .Get "colspan" }}"{{ end }}{{ if .Get "rowspan" }} rowspan="{{ .Get "rowspan" }}"{{ end }}>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/347

#### What's this PR do?
The last remaining task on https://github.com/mitodl/ocw-studio/issues/569 has to do with being able to edit tables imported from legacy courses generated by `ocw-to-hugo`.  This PR adds support for the `colspan` and `rowspan` attributes if they are included on the `tdopen` or `thopen` shortcodes.

#### How should this be manually tested?
Follow the testing instructions in https://github.com/mitodl/ocw-to-hugo/pull/429 and https://github.com/mitodl/ocw-studio/pull/899

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/149601180-ae60190c-741c-401d-8366-da3fd014a462.png)
![image](https://user-images.githubusercontent.com/12089658/149601192-b4b43360-5ef5-4390-899b-3ecedb5b518b.png)
![image](https://user-images.githubusercontent.com/12089658/149601232-e001b82a-0fe8-4aaf-879e-acd35bbe4c3e.png)
![image](https://user-images.githubusercontent.com/12089658/149601241-082b8963-4146-46d7-9ad8-aca121574518.png)

