### PR TITLE
Match window pathname and href in anchor tag irrespective of trailing slash

### DIFF
--- a/course/assets/js/navigation.js
+++ b/course/assets/js/navigation.js
@@ -4,7 +4,14 @@ function courseNav() {
     .forEach(navEl => {
       // set .active on the currently active link
       navEl.querySelectorAll(".nav-link").forEach(navLinkEl => {
-        if (navLinkEl.getAttribute("href") === window.location.pathname) {
+        const navLink = navLinkEl.getAttribute("href") ?
+          navLinkEl.getAttribute("href") :
+          ""
+        if (
+          // @ts-ignore
+          navLink.replace(/\/$/, "") ===
+          window.location.pathname.replace(/\/$/, "")
+        ) {
           navLinkEl.classList.add("active")
         }
       })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #345 

#### What's this PR do?
Matches the window pathname and href in anchor tag irrespective of path name.

#### How should this be manually tested?

On Course Page
- Click `SYLLABUS` and verify that it becomes active
- Click any assignment and after reload verify it becomes active

#### Screenshots (if appropriate)

<img width="1424" alt="Screenshot 2022-01-18 at 2 46 54 PM" src="https://user-images.githubusercontent.com/87968618/149912672-721b13fe-2ab7-4203-89e2-d114e855e654.png">

<img width="1424" alt="Screenshot 2022-01-18 at 2 46 54 PM" src="https://user-images.githubusercontent.com/87968618/149912766-99bc2677-c2f4-4956-b112-b5dbd978d535.png">

