### PR TITLE
output githash to base-theme/dist/static

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:course:hugo": "./package_scripts/start_course.sh",
     "prebuild": "rimraf dist",
     "build": "./package_scripts/build.sh",
-    "build:githash": "mkdir -p dist/static && git rev-parse HEAD > dist/static/hash.txt",
+    "build:githash": "mkdir -p base-theme/dist/static && git rev-parse HEAD > base-theme/dist/static/hash.txt",
     "build:hugo": "hugo -d ../dist -v",
     "build:hugo:debug": "hugo -d ../dist -v --templateMetrics --debug",
     "build:webpack": "cross-env NODE_ENV=production webpack --config base-theme/assets/webpack/webpack.prod.js",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ol-infrastructure/issues/565

#### What's this PR do?
This PR alters `npm run build:githash` to output the `hash.txt` file in `base-theme/dist/static` instead of `dist/static` so that it's collected with the rest of the theme assets.

#### How should this be manually tested?
 - Run `npm run build:webpack`
 - Run `npm run build:githash`
 - Verify that there is a `hash.txt` file along with the built theme assets in `base-theme/dist/static`
