### PR TITLE
fix: hide resource types when count is 0

### DIFF
--- a/course/layouts/partials/learning_resource_types.html
+++ b/course/layouts/partials/learning_resource_types.html
@@ -1,14 +1,17 @@
 {{ $courseData := .context.Site.Data.course }}
 {{ $inPanel := .inPanel }}
-<div class="course-home-section w-100 {{ if $inPanel }}in-panel{{ else }}bg-light{{ end }}">
-  <div class="container px-0 mx-0">
-    <h4 class="course-info-title font-weight-bold">Learning Resource Types</h4>
-    <div class="row">
-      {{ range $courseData.learning_resource_types }}
-        <div class="{{ if $inPanel }}col-12{{ else }}col-6 col-xl-3{{ end }}">
-          {{ partial "learning_resource_type.html" . }}
-        </div>
-      {{ end }}
+
+{{if gt (len $courseData.learning_resource_types) 0}}
+  <div class="course-home-section w-100 {{ if $inPanel }}in-panel{{ else }}bg-light{{ end }}">
+    <div class="container px-0 mx-0">
+      <h4 class="course-info-title font-weight-bold">Learning Resource Types</h4>
+      <div class="row">
+        {{ range $courseData.learning_resource_types }}
+          <div class="{{ if $inPanel }}col-12{{ else }}col-6 col-xl-3{{ end }}">
+            {{ partial "learning_resource_type.html" . }}
+          </div>
+        {{ end }}
+      </div>
     </div>
   </div>
-</div>
+{{end}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/86
**Note:** Ticket was created for **course features**, but I was unable to find course features, maybe it has been fixed or renamed, I'm not sure. Since the issue was also for **learning resource types**, so I fixed that instead.
For reference, please view [this comment](https://github.com/mitodl/ocw-hugo-themes/issues/86#issuecomment-1018337756)

#### What's this PR do?
Does not render learning resource types when it's count is 0

#### How should this be manually tested?
- Go to any course which has learning resource types:
    - Verify that the section is shown in home page and other pages.
- Go to any course which has **no** learning resource types:
    - Verify that the section is **not** shown in home page and other pages.    

#### Screenshots (if appropriate)
Before: 
![image](https://user-images.githubusercontent.com/93309234/150501497-36de7896-c775-4aec-8f02-7baf9e5ef3f9.png)

![image](https://user-images.githubusercontent.com/93309234/150501548-bbb64811-4120-416f-bb1c-07629750c429.png)

After: 
![image](https://user-images.githubusercontent.com/93309234/150501689-e32895a9-cfad-484d-aa05-569c66235e36.png)

![image](https://user-images.githubusercontent.com/93309234/150501711-432eb467-18c2-489c-9ba1-7fec8bdbf404.png)
