### PR TITLE
added aspect ratio to match youtubes video iframe

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -368,3 +368,7 @@ article.content {
 .overflow-x-hidden {
   overflow-x: hidden;
 }
+
+.aspect-ratio-16-9 {
+  aspect-ratio: 16/9 !important;
+}

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -141,7 +141,7 @@
         class="col-12 col-lg-6 d-flex align-items-center"
       >
         <iframe
-          class="w-100 h-100"
+          class="w-100 h-100 aspect-ratio-16-9"
           frameborder="0"
           scrolling="no"
           marginheight="0"

--- a/www/layouts/educator/section.html
+++ b/www/layouts/educator/section.html
@@ -93,8 +93,7 @@
           </div>
           <div class="col-lg-6">
             <iframe
-              width="100%"
-              height="350px"
+              class="w-100 h-100 aspect-ratio-16-9"
               src="https://www.youtube.com/embed/7UJ4CFRGd-U"
               title="Professor Gilbert Strang on how he teaches 18.06 Linear Algebra."
               frameborder="0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
     - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #360

#### What's this PR do?
Add's aspect ratio property to iframe

#### How should this be manually tested?
Verify Iframe is not cut off in mobile form.

#### Screenshots (if appropriate)
<img width="820" alt="Screenshot 2022-01-22 at 1 26 48 AM" src="https://user-images.githubusercontent.com/87968618/150597731-ae30e542-d3b4-4d5d-b78c-3209c536b868.png">
