### PR TITLE
feat: expand/collapse in document title

### DIFF
--- a/base-theme/assets/index.ts
+++ b/base-theme/assets/index.ts
@@ -27,11 +27,11 @@ window.Popper = Popper;
 
 $(document).ready(() => {
   // hacky coming-soon popover
-  document.querySelectorAll(".coming-soon").forEach((el) => {
+  document.querySelectorAll(".coming-soon").forEach(el => {
     tippy(el, {
       content: "Coming soon!",
       trigger: "click",
-      placement: "top",
+      placement: "top"
     });
   });
 

--- a/base-theme/assets/index.ts
+++ b/base-theme/assets/index.ts
@@ -1,29 +1,29 @@
-import "../../node_modules/tippy.js/dist/tippy.css";
+import "../../node_modules/tippy.js/dist/tippy.css"
 
-import "./css/main.scss";
-import "video.js/dist/video-js.css";
+import "./css/main.scss"
+import "video.js/dist/video-js.css"
 
-import "bootstrap";
-import Popper from "popper.js";
-import tippy from "tippy.js";
-import "shifty";
-import "hammerjs";
-import "imagesloaded";
-import "screenfull";
+import "bootstrap"
+import Popper from "popper.js"
+import tippy from "tippy.js"
+import "shifty"
+import "hammerjs"
+import "imagesloaded"
+import "screenfull"
 
-import { initSentry } from "./js/sentry";
+import { initSentry } from "./js/sentry"
 
 export interface OCWWindow extends Window {
-  $: JQueryStatic;
-  jQuery: JQueryStatic;
-  Popper: typeof Popper;
+  $: JQueryStatic
+  jQuery: JQueryStatic
+  Popper: typeof Popper
 }
 
-declare let window: OCWWindow;
+declare let window: OCWWindow
 
-window.jQuery = $;
-window.$ = $;
-window.Popper = Popper;
+window.jQuery = $
+window.$ = $
+window.Popper = Popper
 
 $(document).ready(() => {
   // hacky coming-soon popover
@@ -32,17 +32,17 @@ $(document).ready(() => {
       content: "Coming soon!",
       trigger: "click",
       placement: "top"
-    });
-  });
+    })
+  })
 
-  initSentry();
-});
+  initSentry()
+})
 
 // &nbsp; causes text to overflow and it doesn't wrap inside a div
 // not sure if this is a good approach but I couldn't ANY Hugo template function
 // with which we can get rid of &nbsp;
 // not wrapping this code in function for better efficiency and to avoid glitch for user
-const elements = document.getElementsByClassName("remove-nbsp");
+const elements = document.getElementsByClassName("remove-nbsp")
 for (let i = 0; i < elements.length; i++) {
-  elements[i].innerHTML = elements[i].innerHTML.replace(/&nbsp;/g, " ");
+  elements[i].innerHTML = elements[i].innerHTML.replace(/&nbsp;/g, " ")
 }

--- a/base-theme/assets/index.ts
+++ b/base-theme/assets/index.ts
@@ -37,12 +37,3 @@ $(document).ready(() => {
 
   initSentry()
 })
-
-// &nbsp; causes text to overflow and it doesn't wrap inside a div
-// not sure if this is a good approach but I couldn't ANY Hugo template function
-// with which we can get rid of &nbsp;
-// not wrapping this code in function for better efficiency and to avoid glitch for user
-const elements = document.getElementsByClassName("remove-nbsp")
-for (let i = 0; i < elements.length; i++) {
-  elements[i].innerHTML = elements[i].innerHTML.replace(/&nbsp;/g, " ")
-}

--- a/base-theme/assets/index.ts
+++ b/base-theme/assets/index.ts
@@ -1,39 +1,48 @@
-import "../../node_modules/tippy.js/dist/tippy.css"
+import "../../node_modules/tippy.js/dist/tippy.css";
 
-import "./css/main.scss"
-import "video.js/dist/video-js.css"
+import "./css/main.scss";
+import "video.js/dist/video-js.css";
 
-import "bootstrap"
-import Popper from "popper.js"
-import tippy from "tippy.js"
-import "shifty"
-import "hammerjs"
-import "imagesloaded"
-import "screenfull"
+import "bootstrap";
+import Popper from "popper.js";
+import tippy from "tippy.js";
+import "shifty";
+import "hammerjs";
+import "imagesloaded";
+import "screenfull";
 
-import { initSentry } from "./js/sentry"
+import { initSentry } from "./js/sentry";
 
 export interface OCWWindow extends Window {
-  $: JQueryStatic
-  jQuery: JQueryStatic
-  Popper: typeof Popper
+  $: JQueryStatic;
+  jQuery: JQueryStatic;
+  Popper: typeof Popper;
 }
 
-declare let window: OCWWindow
+declare let window: OCWWindow;
 
-window.jQuery = $
-window.$ = $
-window.Popper = Popper
+window.jQuery = $;
+window.$ = $;
+window.Popper = Popper;
 
 $(document).ready(() => {
   // hacky coming-soon popover
-  document.querySelectorAll(".coming-soon").forEach(el => {
+  document.querySelectorAll(".coming-soon").forEach((el) => {
     tippy(el, {
       content: "Coming soon!",
       trigger: "click",
-      placement: "top"
-    })
-  })
+      placement: "top",
+    });
+  });
 
-  initSentry()
-})
+  initSentry();
+});
+
+// &nbsp; causes text to overflow and it doesn't wrap inside a div
+// not sure if this is a good approach but I couldn't ANY Hugo template function
+// with which we can get rid of &nbsp;
+// not wrapping this code in function for better efficiency and to avoid glitch for user
+const elements = document.getElementsByClassName("remove-nbsp");
+for (let i = 0; i < elements.length; i++) {
+  elements[i].innerHTML = elements[i].innerHTML.replace(/&nbsp;/g, " ");
+}

--- a/course/assets/css/course-content.scss
+++ b/course/assets/css/course-content.scss
@@ -1,0 +1,9 @@
+#course-title.collapse:not(.show) {
+  display: block;
+  height: 5.7em;
+  overflow: hidden;
+}
+
+#course-title.collapsing {
+  height: 5.7em;
+}

--- a/course/assets/css/course.scss
+++ b/course/assets/css/course.scss
@@ -15,6 +15,7 @@
 @import "videojs_player";
 @import "resource-page";
 @import "video-transcript";
+@import "course-content";
 
 #course-banner {
   color: $white;

--- a/course/layouts/partials/course_content.html
+++ b/course/layouts/partials/course_content.html
@@ -8,7 +8,7 @@
       {{ with .Params.parent_title }}
       <h3 class="parent-title">{{ . }}</h3>
       {{ end }}
-      <h1 class="text-uppercase font-weight-bold remove-nbsp pb-1 mb-3">{{ .Title }}</h1>
+      <h1 class="text-uppercase font-weight-bold pb-1 mb-3">{{ .Title }}</h1>
     </div>
     <div class="d-flex">
       {{ if $shouldCollapseTitle }}

--- a/course/layouts/partials/course_content.html
+++ b/course/layouts/partials/course_content.html
@@ -1,10 +1,30 @@
-<div class="pb-4 rounded">
+{{ $shouldCollapseTitle := gt (len .Title) 75 }}
+<div class="rounded mb-2">
   <header>
-    <div class="course-section-title-container">
+    <div
+      class="course-section-title-container {{ if $shouldCollapseTitle }}collapse{{ end }}"
+      id="course-title"
+    >
       {{ with .Params.parent_title }}
       <h3 class="parent-title">{{ . }}</h3>
       {{ end }}
-      <h1 class="text-uppercase font-weight-bold pb-1 mb-3">{{ .Title }}</h1>
+      <h1 class="text-uppercase font-weight-bold remove-nbsp pb-1 mb-3">{{ .Title }}</h1>
+    </div>
+    <div class="d-flex">
+      {{ if $shouldCollapseTitle }}
+      <div class="collapse-btn-section ml-auto pt-2 px-3">
+        <a
+          role="button"
+          class="collapsed"
+          data-toggle="collapse"
+          href="#course-title"
+          aria-expanded="false"
+          aria-controls="course-title"
+        >
+          <span class="material-icons"></span>
+        </a>
+      </div>
+      {{ end }}
     </div>
   </header>
   {{ partial "mobile_nav_toggle.html" . }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/361

#### What's this PR do?
**Note:** Initially this PR was opened to fix the `issue of title being overflown: title was not wrapped in it's div, it flowed to right outside it's section` but as per discussion in this [thread](https://github.com/mitodl/ocw-hugo-themes/pull/364#discussion_r791214738), this issue should be addressed upstream hence now this PR only adds expand/collapse in document title 

- Expand/collapse shows up if title covers more than 3 lines. 

#### How should this be manually tested?
- Verify that document title remains in it's section regardless of it's length/size. It is not flowed outside like shown in the issue.
- Verify that on increasing title length, expand/collapse shows up which correctly works with a smooth transition.
- Please repeat the above step for:
    1. all sections where title section is being rendered.
    2. multiple courses.
    3. on multiple browsers.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/93309234/150792107-b3cd383b-eef1-474e-b2a6-3c644ac4b219.png)

![image](https://user-images.githubusercontent.com/93309234/150792235-cf27076a-655c-4777-bac2-281b66c47d0f.png)

![image](https://user-images.githubusercontent.com/93309234/150792264-1c17a08b-10d4-444d-aeef-a84ad92a532f.png)
