### PR TITLE
fix: adding data attributes to carousel

### DIFF
--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -14,7 +14,7 @@
     {{ $isMobile := (eq $itemsInCarousel 1) }}
     {{ $carouselId := (printf "new-course-carousel-%v" $breakpoint) }}
     <div class="{{ $breakpointVisibilityClass }}">
-      <div id="{{ $carouselId }}" class="carousel slide" data-interval="false">
+      <div id="{{ $carouselId }}" class="carousel slide" data-interval="false" data-touch="true" data-ride="carousel">
         <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
           <h3>New Courses</h3>
           {{ partial "carousel_controls.html" $carouselId }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/85

#### What's this PR do?
- Adds data attributes to course carousel on home page so it can be swiped on mobile screens. 

#### How should this be manually tested?
- Go home page (www) on mobile
- Verify that the course cards are scrollable by thumb first time, without clicking any `Next` or `Previous` button.
(Note: If you're opening mobile view from laptop, do refresh the page once mobile view is opened)
