### PR TITLE
fix: carousel height and thumb swipe fixed

### DIFF
--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -476,6 +476,14 @@ $promo-carousel-height: 200px;
     }
   }
 
+  .carousel-section {
+    height: $promo-carousel-height;
+
+    @include media-breakpoint-down(xs) {
+      padding-top: 5%;
+    }
+  }
+
   .carousel-indicators {
     margin-bottom: 0;
     bottom: -30px;

--- a/www/layouts/partials/promo-carousel.html
+++ b/www/layouts/partials/promo-carousel.html
@@ -1,13 +1,13 @@
 {{- $pages := .Site.RegularPages -}}
 {{- $promos := where $pages "Type" "==" "promos" -}}
 {{- $carouselId := "promo-carousel" -}}
-<div id="{{ $carouselId }}" class="promo-carousel pt-2 carousel carousel-fade slide" data-interval="false">
+<div id="{{ $carouselId }}" class="promo-carousel pt-2 carousel carousel-fade slide" data-interval="false" data-touch="true" data-ride="carousel">
   <ol class="carousel-indicators">
     {{ range $index, $promo := $promos }}
     <li data-target="#{{ $carouselId }}" data-slide-to="{{ $index }}" class="{{ if eq $index 0}}active{{ end }}" />
     {{ end }}
   </ol>
-  <div class="d-flex flex-direction-row align-items-center">
+  <div class="carousel-section d-flex flex-direction-row align-items-sm-center">
     <a href="#{{ $carouselId }}" role="button" data-slide="prev" class="bg-white prev">
       <span class="material-icons" aria-hidden="true">keyboard_arrow_left</span>
       <span class="sr-only">Previous</span>
@@ -22,7 +22,7 @@
           <div class="promo-info d-flex flex-column px-2 px-md-4 align-items-start h-100">
             <h2>{{ $promo.Params.title }}</h2>
             <h3>{{ $promo.Params.subtitle }}</h3>
-            <a class="px-3 font-weight-bold" href="{{ $promo.Params.link_url }}">
+            <a class="font-weight-bold" href="{{ $promo.Params.link_url }}">
               {{ $promo.Params.link_title }}
             </a>
           </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/69

#### What's this PR do?
- Fixes the moving section of promo carousel when sliding on mobile screen.
- Enable sliding by thumb on mobile screen first time, without clicking any previous or next button. 

#### How should this be manually tested?
- Go to home page via mobile screen or change laptop's width to mobile (small devices)
- Verify that while sliding the carousel, its position is fixed and it does not move.
- Please test this:
    - on multiple screen dimensions (few common dimensions can be taken from [here](https://gist.github.com/TrevorJTClarke/27896c197a34e597a8a6))
    - on multiple browsers 

#### Screenshots (if appropriate)
Position of arrow buttons and whole section remains fixed/same, however, height increase/decrease depending upon the size of content. 

![image](https://user-images.githubusercontent.com/93309234/150975227-0e73d7ee-140a-4325-aa85-005c62b1ea1e.png)

![image](https://user-images.githubusercontent.com/93309234/150975254-cfa0e1eb-3cc7-4e62-bddc-ca41a8051d89.png)

![image](https://user-images.githubusercontent.com/93309234/150975271-3a749998-17e3-48b0-a294-0e9775822bdb.png)
