### PR TITLE
slugify text before using it as an ID

### DIFF
--- a/www/assets/js/components/SearchFacetItem.tsx
+++ b/www/assets/js/components/SearchFacetItem.tsx
@@ -2,6 +2,8 @@
 import React from "react"
 import Dotdotdot from "react-dotdotdot"
 
+import { slugify } from "../lib/util"
+
 const featuredFacetNames = ["audience", "certification"]
 
 export default function SearchFacetItem(props) {
@@ -9,7 +11,8 @@ export default function SearchFacetItem(props) {
 
   const labelText = labelFunction ? labelFunction(facet.key) : facet.key
 
-  const facetId = `${name}-${facet.key}`
+  const facetId = slugify(`${name}-${facet.key}`)
+
   return (
     <div className={isChecked ? "facet-visible checked" : "facet-visible"}>
       <input

--- a/www/assets/js/lib/util.test.ts
+++ b/www/assets/js/lib/util.test.ts
@@ -1,0 +1,16 @@
+import { slugify } from "./util"
+
+describe("util tests", () => {
+  it("slugify should, well, slugify things", () => {
+    [
+      ["foo Bar baz", "foo-bar-baz"],
+      ["foo_bar-baz", "foo-bar-baz"],
+      ["foo_bar-baz", "foo-bar-baz"],
+      ["foo BAR BaZ", "foo-bar-baz"],
+      ["foo\\BAR)BaZ", "foo-bar-baz"],
+      ["foo\\BAR]BaZ", "foo-bar-baz"]
+    ].forEach(([input, exp]) => {
+      expect(slugify(input)).toEqual(exp)
+    })
+  })
+})

--- a/www/assets/js/lib/util.ts
+++ b/www/assets/js/lib/util.ts
@@ -6,3 +6,10 @@ export const getViewportWidth = () => window.innerWidth
 
 export const isDoubleQuoted = (text: string) =>
   !emptyOrNil(match(/^".+"$/, text || ""))
+
+export const slugify = (text: string) =>
+  text
+    .split(" ")
+    .map(subString => subString.toLowerCase())
+    .join("-")
+    .replace(/[\W_]/g, "-")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #370 

#### What's this PR do?

This just sort of slugifies some text before we use it as an element ID. This should help us meet accessibility guidelines.

#### How should this be manually tested?

Check out the `id` on the checkbox `input` and the `htmlFor` on the `label` which are rendered by `SearchFacetItem`. They shouldn't have spaces!

![Screen Shot 2022-01-25 at 11 19 07 AM](https://user-images.githubusercontent.com/6207644/151016008-237ef9aa-64a3-46f6-8d01-03d151f4eb86.png)