### PR TITLE
fix: sanity check for Learning Resource Types

### DIFF
--- a/course/layouts/partials/learning_resource_types.html
+++ b/course/layouts/partials/learning_resource_types.html
@@ -1,7 +1,7 @@
 {{ $courseData := .context.Site.Data.course }}
 {{ $inPanel := .inPanel }}
 
-{{if gt (len $courseData.learning_resource_types) 0}}
+{{ if gt (len ($courseData.learning_resource_types | default slice)) 0 }}
   <div class="course-home-section w-100 {{ if $inPanel }}in-panel{{ else }}bg-light{{ end }}">
     <div class="container px-0 mx-0">
       <h4 class="course-info-title font-weight-bold">Learning Resource Types</h4>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Did not create an issue for it but we have a relevant [comment](https://github.com/mitodl/ocw-hugo-themes/pull/364#issuecomment-1022257547)

#### What's this PR do?
- Adds a check for Learning Resource Types as we have a `len` function on it so if `Learning Resource Types` does not exist, code will not break 

#### How should this be manually tested?
- Open any course and go to it's home page 
- Remove the attribute: `learning resource types` and verify that the page loads without any error
