### PR TITLE
fix aria-live situation

### DIFF
--- a/www/assets/js/components/SearchPage.test.tsx
+++ b/www/assets/js/components/SearchPage.test.tsx
@@ -10,7 +10,6 @@ import {
   LR_TYPE_COURSE,
   LR_TYPE_RESOURCEFILE
 } from "@mitodl/course-search-utils/dist/constants"
-import FilterableFacet from "./FilterableFacet"
 
 import SearchPage, { SEARCH_PAGE_SIZE } from "./SearchPage"
 
@@ -236,8 +235,10 @@ describe("SearchPage component", () => {
   it("should display the number of results", async () => {
     const wrapper = await render()
     await resolveSearch()
-    const resultsText = wrapper.find(".results-total").text()
-    expect(resultsText).toBe("10 Results")
+    const results = wrapper.find(".results-total")
+    expect(results.text()).toBe("10 Results")
+    expect(results.prop("aria-live")).toBe("polite")
+    expect(results.prop("aria-atomic")).toBe("true")
   })
 
   //

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -190,7 +190,7 @@ export default function SearchPage() {
           </div>
           <div className="col-lg-3" />
         </div>
-        <div className="row" role="search" aria-live="polite">
+        <div className="row">
           <SearchFilterDrawer
             facetMap={facetMap}
             facetOptions={facetOptions}
@@ -254,7 +254,11 @@ export default function SearchPage() {
                     Resources
                   </button>
                 </li>
-                <li className="nav-item flex-grow-1 d-flex align-items-center justify-content-center results-total">
+                <li
+                  aria-live="polite"
+                  aria-atomic="true"
+                  className="nav-item flex-grow-1 d-flex align-items-center justify-content-center results-total"
+                >
                   {completedInitialLoad ? `${total} Results` : null}
                 </li>
                 {!isResourceSearch ? (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #378 

#### What's this PR do?

The issue has a bit of information, but basically we had mis-used `aria-live` in a way that made the search page pretty terrible for using a screenreader. In short, all of the changes within a div marked `aria-live="polite"` are read out when they change, and we were wrapping both the search facets and the search results with that, so every time the results changed the screenreader would read out all that stuff.

Instead, a recommendation for dynamic search UIs like ours is to only wrap the result count with `aria-live="polite"`, so that when the search results update there is a notification to the user but they aren't deluged with a ton of stuff.

#### How should this be manually tested?

Optimally, try out the search page using a screenreader and confirm that the setup is better now (i.e. when you run a search you should just hear "43 results" or whatever, not a bunch of nonsense).