### PR TITLE
fix up role="search" situation

### DIFF
--- a/www/assets/js/components/SearchBox.test.tsx
+++ b/www/assets/js/components/SearchBox.test.tsx
@@ -14,8 +14,11 @@ describe("SearchBox component", () => {
     const wrapper = render({ onChange, value, onSubmit })
     expect(wrapper.find("input").prop("onChange")).toEqual(onChange)
     expect(wrapper.find("input").prop("value")).toBe(value)
+    expect(wrapper.find("input").prop("type")).toBe("search")
 
     expect(wrapper.find("form").prop("onSubmit")).toEqual(onSubmit)
+    expect(wrapper.find("form").prop("role")).toEqual("search")
+
     expect(wrapper.find("button").prop("type")).toEqual("submit")
   })
 })

--- a/www/assets/js/components/SearchBox.tsx
+++ b/www/assets/js/components/SearchBox.tsx
@@ -10,10 +10,14 @@ export default function SearchBox(props: Props) {
   const { value, onChange, onSubmit } = props
 
   return (
-    <form onSubmit={onSubmit} className="search-box d-flex flex-direction-row">
+    <form
+      onSubmit={onSubmit}
+      role="search"
+      className="search-box d-flex flex-direction-row"
+    >
       <input
         className="w-100 pl-2"
-        type="text"
+        type="search"
         onChange={onChange}
         value={value ?? ""}
         placeholder="Enter Course Name, Department, Course Number..."


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #379 

#### What's this PR do?

- sets `role="search"` on the `form` tag which wraps the search input
- sets `type="search"` on the `input` tag itself

these two changes should signal to a screenreader user that the search box is, well, a search box, and not just a random text field. setting `role="search"` on the form should also allow that to be recognized as a functional region by screenreaders.

#### How should this be manually tested?

You can just confirm that the change makes sense, and possibly try out in a screenreader if you want.

Note that I removed the existing (erroneous) `role="search"` in #380 