### PR TITLE
populate resource title

### DIFF
--- a/course/layouts/resources/single.coursedata.json
+++ b/course/layouts/resources/single.coursedata.json
@@ -1,4 +1,5 @@
 {
+  "title": {{- .Title | jsonify -}},
   "description": {{ .Params.description | jsonify }},
   "file": {{ .Params.file | jsonify }},
   "learning_resource_types": {{ .Params.learning_resource_types| jsonify }},


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None
#### What's this PR do?
The data.json files for resources are missing the title. This fixes the issue

#### How should this be manually tested?
Run `npm run start:course` for any course
Go to the resource page for any course resource
Append /data.json to the resource page url
Verify that you see a title
