### PR TITLE
fix: instructor insights images scaled up

### DIFF
--- a/course/assets/css/instructor-insights.scss
+++ b/course/assets/css/instructor-insights.scss
@@ -1,62 +1,64 @@
 @import "../../../base-theme/assets/css/variables.scss";
-
 h2 {
-  margin-bottom: 1.25rem !important;
+    margin-bottom: 1.25rem !important;
 }
 
 h3 {
-  font-size: 1rem !important;
+    font-size: 1rem !important;
 }
 
 p {
-  margin-bottom: 1.25rem;
+    margin-bottom: 1.25rem;
 }
 
 .quotewrapper {
-  margin: 0;
-  line-height: 1.75em;
+    margin: 0;
+    line-height: 1.75em;
 }
 
 .quotewrapper blockquote,
 figcaption {
-  font-family: "Helvetica-Oblique", "Helvetica", sans-serif;
-  font-style: italic;
-  margin: 0;
+    font-family: "Helvetica-Oblique", "Helvetica", sans-serif;
+    font-style: italic;
+    margin: 0;
 }
 
 .quotewrapper blockquote.quote {
-  font-size: 1.5em;
-  font-weight: bold;
-  color: $medium-gray;
+    font-size: 1.5em;
+    font-weight: bold;
+    color: $medium-gray;
 }
 
 .quotewrapper .sigwrapper {
-  display: flex;
+    display: flex;
 }
 
 .quotewrapper figcaption.sig {
-  margin-left: auto;
-  text-transform: uppercase;
-  order: 2;
-  font-size: 1.25em;
+    margin-left: auto;
+    text-transform: uppercase;
+    order: 2;
+    font-size: 1.25em;
 }
 
 .approx-students {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  background-color: $approx-students-red;
-  border-radius: 50%;
-  h1 {
-    margin-top: 0.75rem;
-    margin-bottom: 0;
-  }
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: $approx-students-red;
+    border-radius: 50%;
+    h1 {
+        margin-top: 0.75rem;
+        margin-bottom: 0;
+    }
+    h1,
+    h2 {
+        color: $white !important;
+        text-transform: none !important;
+        user-select: none;
+    }
+}
 
-  h1,
-  h2 {
-    color: $white !important;
-    text-transform: none !important;
-    user-select: none;
-  }
+img {
+    width: 100%;
 }

--- a/course/assets/css/instructor-insights.scss
+++ b/course/assets/css/instructor-insights.scss
@@ -1,64 +1,66 @@
 @import "../../../base-theme/assets/css/variables.scss";
+
 h2 {
-    margin-bottom: 1.25rem !important;
+  margin-bottom: 1.25rem !important;
 }
 
 h3 {
-    font-size: 1rem !important;
+  font-size: 1rem !important;
 }
 
 p {
-    margin-bottom: 1.25rem;
+  margin-bottom: 1.25rem;
 }
 
 .quotewrapper {
-    margin: 0;
-    line-height: 1.75em;
+  margin: 0;
+  line-height: 1.75em;
 }
 
 .quotewrapper blockquote,
 figcaption {
-    font-family: "Helvetica-Oblique", "Helvetica", sans-serif;
-    font-style: italic;
-    margin: 0;
+  font-family: "Helvetica-Oblique", "Helvetica", sans-serif;
+  font-style: italic;
+  margin: 0;
 }
 
 .quotewrapper blockquote.quote {
-    font-size: 1.5em;
-    font-weight: bold;
-    color: $medium-gray;
+  font-size: 1.5em;
+  font-weight: bold;
+  color: $medium-gray;
 }
 
 .quotewrapper .sigwrapper {
-    display: flex;
+  display: flex;
 }
 
 .quotewrapper figcaption.sig {
-    margin-left: auto;
-    text-transform: uppercase;
-    order: 2;
-    font-size: 1.25em;
+  margin-left: auto;
+  text-transform: uppercase;
+  order: 2;
+  font-size: 1.25em;
 }
 
 .approx-students {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    background-color: $approx-students-red;
-    border-radius: 50%;
-    h1 {
-        margin-top: 0.75rem;
-        margin-bottom: 0;
-    }
-    h1,
-    h2 {
-        color: $white !important;
-        text-transform: none !important;
-        user-select: none;
-    }
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: $approx-students-red;
+  border-radius: 50%;
+  h1 {
+    margin-top: 0.75rem;
+    margin-bottom: 0;
+  }
+
+  h1,
+  h2 {
+    color: $white !important;
+    text-transform: none !important;
+    user-select: none;
+  }
 }
 
 img {
-    width: 100%;
+  width: 100%;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/65

#### What's this PR do?
- Gives 100% width to all the images in instructor insights only. 

#### How should this be manually tested?
- Open any course
- Go to instructor insights and verify that the images are scaled and takes 100% width of the section.
- Verify that **no** other image in other sections/modules is scaled.
- Repeat the above step for: 
    - Multiple screen dimensions
    - Multiple browsers  

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/93309234/151172904-d6d32fc3-33f5-426b-befb-6e39445adc19.png)

![image](https://user-images.githubusercontent.com/93309234/151172938-72b97397-883f-41f7-b53e-b74aaee475ed.png)

![image](https://user-images.githubusercontent.com/93309234/151508381-df8619b0-251a-4758-a067-59101e534a0d.png)
