### PR TITLE
fix small oversight on typescript change

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "webpack:stats": "NODE_ENV=production webpack --config base-theme/assets/webpack/webpack.prod.js --profile --json > stats.json",
     "webpack:analyze": "webpack-bundle-analyzer stats.json dist",
     "fmt": "LOG_LEVEL= prettier-eslint --write --no-semi $PWD/'**/assets/**/*.js' $PWD/'**/assets/**/*.ts' $PWD/'**/assets/**/*.tsx' $PWD/'**/assets/**/*.scss'",
-    "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi $PWD/'**/assets/**/*.js' $PWD/'**/assets/**/*.scss'",
+    "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi $PWD/'**/assets/**/*.js' $PWD/'**/assets/**/*.ts' $PWD/'**/assets/**/*.tsx' $PWD/'**/assets/**/*.scss'",
     "scss_lint": "node ./node_modules/sass-lint/bin/sass-lint.js --verbose --no-exit ./assets",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION


#### What's this PR do?

when switching over to building w/ typescript (#335) I switched over the `fmt` package.json script but neglected to make the same edit to `fmt:check`. This changes `fmt:check` so it also checks `.ts` and `.tsx` files.

#### How should this be manually tested?

CI should pass!