### PR TITLE
add a data template for creating a course content map

### DIFF
--- a/course/layouts/index.contentmap.json
+++ b/course/layouts/index.contentmap.json
@@ -1,0 +1,5 @@
+{{- $contentMap := dict -}}
+{{- range where $.Site.Pages "Params.uid" "!=" nil -}}
+  {{- $contentMap = merge $contentMap (dict .Params.uid .RelPermalink) -}}
+{{- end -}}
+{{- $contentMap | jsonify -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

this is part of #279

#### What's this PR do?

This PR adds a new json template which renders a map from UUID to relative link for all pages. We need this because for the resource collections we're storing the site name and the UUID for pieces of content. With this map we'll be able to get complete URLs to request the `data.json` file for each piece of content.

#### How should this be manually tested?

Check out the rendered course. There should be a json file at `/content_map.json` that looks like what I described.

Note that you'll need to check out this PR for ocw-hugo-projects for it to work correctly (for the course theme Hugo config) https://github.com/mitodl/ocw-hugo-projects/pull/119
