### PR TITLE
fix: increased value for expand widget for course image description

### DIFF
--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -30,7 +30,8 @@
                   <div class="homepage-content d-flex">
                     <div class="container-fluid pt-0 pb-4">
                       <div class="row px-3 pb-2 justify-content-between">
-                        {{ $shouldCollapseImageDescription := gt (len $courseImageMetadata.Params.image_metadata.caption) 130 }}
+                        {{- $imageCaption := $courseImageMetadata.Params.image_metadata.caption -}}
+                        {{ $shouldCollapseImageDescription := gt (len $imageCaption) 130 }}
                         <div class="col-lg-4 d-none d-lg-block pl-0">
                           <div class="d-flex flex-column image-with-caption">
                             <img class="course-image" src="{{ $courseImageUrl }}"
@@ -39,7 +40,7 @@
                             <div id="course-image-description" class="{{ if $shouldCollapseImageDescription }}collapse{{ else }} mb-3 {{ end }}" aria-expanded="false">
                               <div class="caption pt-3 px-3">
                                 <span>
-                                  {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}
+                                  {{ $imageCaption | .RenderString }}
                                 </span>
                               </div>
                             </div>

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -30,13 +30,13 @@
                   <div class="homepage-content d-flex">
                     <div class="container-fluid pt-0 pb-4">
                       <div class="row px-3 pb-2 justify-content-between">
-                        {{ $shouldCollapseImageDescription := gt (len $courseImageMetadata.Params.image_metadata.caption) 100 }}
+                        {{ $shouldCollapseImageDescription := gt (len $courseImageMetadata.Params.image_metadata.caption) 130 }}
                         <div class="col-lg-4 d-none d-lg-block pl-0">
                           <div class="d-flex flex-column image-with-caption">
                             <img class="course-image" src="{{ $courseImageUrl }}"
                               alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
                             />
-                            <div id="course-image-description" class="{{ if $shouldCollapseImageDescription }}collapse{{ end }}" aria-expanded="false">
+                            <div id="course-image-description" class="{{ if $shouldCollapseImageDescription }}collapse{{ else }} mb-3 {{ end }}" aria-expanded="false">
                               <div class="caption pt-3 px-3">
                                 <span>
                                   {{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/396

#### What's this PR do?
- Increases length value for course caption comparison
- Adds some bottom margin when the expand widget is not showing so the caption does not stick/or come too close with the border

#### How should this be manually tested?
- Go to any course homepage
- Ensure that expand/collapse is only shown and working when the course image caption is **not** adjusted in the available area.
- Please repeat this for maximum courses or change the caption in course content

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/93309234/152138339-e70a850f-b874-47f7-bd8f-8ea4dc81997c.png)

![image](https://user-images.githubusercontent.com/93309234/152138534-10aceba8-7ddd-45cb-912d-e606eb561fe9.png)

![image](https://user-images.githubusercontent.com/93309234/152138561-5663cbbf-92be-4c2d-9510-bdf0a7160b60.png)
