### PR TITLE
fix: alt text removed for lecture videos

### DIFF
--- a/course/layouts/partials/video-gallery-item.html
+++ b/course/layouts/partials/video-gallery-item.html
@@ -3,12 +3,12 @@
     <div class="inner-container">
       <div class="left-col">
         {{- if isset .Params.video_files "video_thumbnail_file" -}}
-        <img class="thumbnail" src ="{{ .Params.video_files.video_thumbnail_file }}" alt="Thumbnail for {{ .Params.title }}" />
+        <img class="thumbnail" src ="{{ .Params.video_files.video_thumbnail_file }}" alt="" />
         {{- else -}}
         <img class="youtube-logo-overlay" src="/images/youtube.svg" alt="YouTube" />
         {{- end -}}
       </div>
-      <div class="right-col">
+      <div class="right-col py-5">
         <h5 class="video-title">{{ .Params.title }}</h5>
       </div>
     </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- Closes https://github.com/mitodl/ocw-hugo-themes/issues/399

#### What's this PR do?
- Sets `alt=""` for video gallery page.
- Styling was being disturbed so top and bottom padding has been added so the content is adjusted in the section and does not overflow.

#### How should this be manually tested?
- Go to course(s) which has/have video lectures and missing images. [(example)](https://ocwnext-rc.odl.mit.edu/courses/cms-611j-creating-video-games-fall-2014/video_galleries/lecture-videos/) 
- Open video gallery page: `video_galleries/lecture-videos/`
- Verify that no alt text is being shown for missing images and the content/title is not overflowing, it is smoothly adjusted in the section. 
- Please test this
    -  for multiple courses having different title sizes
    - on multiplee screen dimensions

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/93309234/152150636-1686b744-a440-46f9-b95d-53d05fbdedf0.png)

![image](https://user-images.githubusercontent.com/93309234/152150716-067b9cfd-c9ef-4e40-8b52-b72de6cc93ff.png)

