### PR TITLE
accessibility: home page

### DIFF
--- a/base-theme/layouts/partials/footer.html
+++ b/base-theme/layouts/partials/footer.html
@@ -48,7 +48,7 @@
               <img class="social-icon" src="/images/Youtube.png" alt="youtube" />
             </a></li>
             <li> <a class="img-link" href="https://www.linkedin.com/company/mit-opencourseware/" target="_blank">
-              <img class="social-icon" src="/images/LinkedIn.png" alt="youtube" />
+              <img class="social-icon" src="/images/LinkedIn.png" alt="LinkedIn" />
             </a></li>
           </ul>
         </div>

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -187,10 +187,8 @@ $searchbox-height: 50px;
       }
 
       .learn-more {
-        color: $orange;
         text-transform: uppercase;
         font-size: 15px;
-        align-self: flex-end;
         padding-top: 10px;
       }
     }

--- a/www/layouts/contact/section.html
+++ b/www/layouts/contact/section.html
@@ -66,7 +66,7 @@
           <img
             width="100%"
             src="/images/contact/frequently-asked-questions.jpg"
-            alt="Discover OER on MIT OpenCourseWare"
+            alt=""
           />
         </div>
       </div>

--- a/www/layouts/home.html
+++ b/www/layouts/home.html
@@ -75,7 +75,7 @@
   <div class="give-now-wrapper">
     <div class="give-now my-5 d-flex justify-content-center">
       <div class="d-flex flex-column justify-content-center">
-        <h2>GIVE NOW</h2>
+        <h2>Give Now</h2>
         <h2>Your Donation Makes a Difference</h2>
         <div class="font-weight-normal h4">MIT OpenCourseWare is supported through the generosity of people like you, who believe that unlocking knowledge can empower minds.</div>
       </div>

--- a/www/layouts/home.html
+++ b/www/layouts/home.html
@@ -59,7 +59,7 @@
       <span class="text-white free pt-3">
         Free lecture notes, exams, and videos from MIT.<br>No registration required.
       </span>
-      <a class="learn-more font-weight-bold" href="/about">
+      <a class="learn-more text-white font-weight-bold" href="/about">
         Learn More about the OCW mission
       </a>
     </div>
@@ -85,7 +85,7 @@
           href="https://giving.mit.edu/give/to/ocw/?utm_source=ocw&utm_medium=homepage_banner&utm_campaign=nextgen_home"
           >
           <span class="h1 m-0 pr-2">GIVE</span>
-          <img src="/images/heart-orange.png" alt="heart" />
+          <img src="/images/heart-orange.png" alt="" />
         </a>
       </div>
     </div>

--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -16,7 +16,7 @@
     <div class="{{ $breakpointVisibilityClass }}">
       <div id="{{ $carouselId }}" class="carousel slide" data-interval="false" data-touch="true" data-ride="carousel">
         <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
-          <h3>New Courses</h3>
+          <h2>New Courses</h2>
           {{ partial "carousel_controls.html" $carouselId }}
         </div>
         <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
@@ -32,14 +32,14 @@
               {{ end }}
                 <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                   <div class="course-card card bg-white">
-                    <a href="/courses/{{ $courseId }}">
+                    <a href="/courses/{{ $courseId }}" aria-hidden="true" tabindex="-1">
                       {{/* The following is a temporary hack that should be removed following the decommissioning of the EC2 OCW Next build servers */}}
                       {{ $courseBaseUrl := getenv "COURSE_BASE_URL" | default "" }}
                       {{ $courseImageUrl := $courseData.course_image_url }}
                       {{ if in $courseBaseUrl "ocwnext" }}
                         {{ $courseImageUrl = replace $courseData.course_image_url "/courses" "/coursemedia" }}
                       {{ end }}
-                      <img src="{{ $courseImageUrl }}" alt="Thumbnail for {{ $courseData.course_title }}"/>
+                      <img src="{{ $courseImageUrl }}" alt=""/>
                     </a>
                     <div class="course-card-content pt-1 px-3 pb-3">
                       <div class="course-level">

--- a/www/layouts/partials/home_course_cards.html
+++ b/www/layouts/partials/home_course_cards.html
@@ -15,7 +15,7 @@
     {{ $carouselId := (printf "new-course-carousel-%v" $breakpoint) }}
     <div class="{{ $breakpointVisibilityClass }}">
       <div id="{{ $carouselId }}" class="carousel slide" data-interval="false" data-touch="true" data-ride="carousel">
-        <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
+        <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold">
           <h2>New Courses</h2>
           {{ partial "carousel_controls.html" $carouselId }}
         </div>

--- a/www/layouts/partials/home_testimonials.html
+++ b/www/layouts/partials/home_testimonials.html
@@ -2,7 +2,7 @@
 {{- $testimonialSection := .Site.GetPage "section" "testimonials" -}}
 <div class="home-testimonials standard-width container mx-auto my-3">
   <h2 class="branded mb-3">
-    <span>OpenCourseWare</span> Testimonies
+    OpenCourseWare Testimonies
   </h2>
   <div class="d-flex flex-row justify-content-between xl-and-above-only" >
     {{ range $testimonial := $testimonials }}

--- a/www/layouts/partials/home_testimonials.html
+++ b/www/layouts/partials/home_testimonials.html
@@ -1,7 +1,7 @@
 {{- $testimonials := where .Site.RegularPages "Type" "==" "testimonials" -}}
 {{- $testimonialSection := .Site.GetPage "section" "testimonials" -}}
 <div class="home-testimonials standard-width container mx-auto my-3">
-  <h2 class="branded mb-3">
+  <h2 class="mb-3">
     OpenCourseWare Testimonies
   </h2>
   <div class="d-flex flex-row justify-content-between xl-and-above-only" >

--- a/www/layouts/partials/newsletter_signup.html
+++ b/www/layouts/partials/newsletter_signup.html
@@ -1,6 +1,6 @@
 <form action="" method="get" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="newsletter-form d-flex" target="_blank" novalidate>
     <div class="icon-text-box-wrapper d-flex flex-row flex-grow-1 form-group bg-white shadow-sm border-gray p-0 m-0">
-        <img class="input-group-prepend px-2" src="/images/envelope.svg" alt="Envelope" />
+        <img class="input-group-prepend px-2" src="/images/envelope.svg" alt="" />
         <input aria-label="Subscribe to the OCW Newsletter" type="email" value="" name="EMAIL" class="email form-control border-0" id="mce-EMAIL" placeholder="Your email address...">
     </div>
     <div class="btn rounded-0 px-3 py-2 h-100 my-3 my-xl-0 ml-xl-3 signup-link">

--- a/www/layouts/partials/ocw_news.html
+++ b/www/layouts/partials/ocw_news.html
@@ -12,7 +12,7 @@
         <div class="{{ $breakpointVisibilityClass }}">
           <div id="{{ $carouselId }}" class="carousel slide">
             <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
-              <h2 class="branded">OCW News</h2>
+              <h2>OCW News</h2>
               {{ partial "carousel_controls.html" $carouselId }}
             </div>
             <div class="carousel-inner d-flex mt-2 px-0">
@@ -40,7 +40,7 @@
       {{ end }}
 
       <div class="d-none d-lg-block">
-        <h2 class="branded">OCW News</h2>
+        <h2>OCW News</h2>
         <div class="d-grid items-grid">
           {{ range $index, $item := (first 4 .items) }}
             <div class="item item-{{ $index }}"

--- a/www/layouts/partials/ocw_news.html
+++ b/www/layouts/partials/ocw_news.html
@@ -12,7 +12,7 @@
         <div class="{{ $breakpointVisibilityClass }}">
           <div id="{{ $carouselId }}" class="carousel slide">
             <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
-              <h2 class="branded"><span>OCW</span> News</h2>
+              <h2 class="branded">OCW News</h2>
               {{ partial "carousel_controls.html" $carouselId }}
             </div>
             <div class="carousel-inner d-flex mt-2 px-0">
@@ -40,7 +40,7 @@
       {{ end }}
 
       <div class="d-none d-lg-block">
-        <h2 class="branded"><span>OCW</span> News</h2>
+        <h2 class="branded">OCW News</h2>
         <div class="d-grid items-grid">
           {{ range $index, $item := (first 4 .items) }}
             <div class="item item-{{ $index }}"

--- a/www/layouts/partials/promo-carousel.html
+++ b/www/layouts/partials/promo-carousel.html
@@ -17,7 +17,7 @@
       <div class="carousel-item {{ if eq $index 0}}active{{ end }}">
         <div class="carousel-content d-flex m-auto align-items-center bg-white">
           <div class="img-container p-2">
-            <img class="promo-image img-fluid" src="{{ partial "resource_url" (partial "resource_metadata" $promo.Params.image.content).Params.file }}" alt="{{ $promo.Params.image_alt }}" />
+            <img class="promo-image img-fluid" src="{{ partial "resource_url" (partial "resource_metadata" $promo.Params.image.content).Params.file }}" alt="" />
           </div>
           <div class="promo-info d-flex flex-column px-2 px-md-4 align-items-start h-100">
             <h2>{{ $promo.Params.title }}</h2>

--- a/www/layouts/testimonials/list.html
+++ b/www/layouts/testimonials/list.html
@@ -15,7 +15,7 @@
       {{ range $testimonial := $testimonials }}
       <div class="testimonial d-flex flex-wrap flex-sm-nowrap">
         <div class="img-container">
-          <img src="{{ partial "resource_url" (partial "resource_metadata" $testimonial.Params.image.content).Params.file }}" alt="{{ $testimonial.Title }}" />
+          <img src="{{ partial "resource_url" (partial "resource_metadata" $testimonial.Params.image.content).Params.file }}" alt="" />
         </div>
         <div class="detail d-flex flex-column flex-nowrap justify-content-between p-0 ml-sm-5">
           <div class="text">

--- a/www/layouts/testimonials/single.html
+++ b/www/layouts/testimonials/single.html
@@ -9,7 +9,7 @@
     <div class="testimonials">
       <div class="testimonial d-flex flex-wrap flex-sm-nowrap">
         <div class="img-container">
-          <img src="{{ partial "resource_url" (partial "resource_metadata" $testimonial.Params.image.content).Params.file }}" alt="{{ $testimonial.Title }}" />
+          <img src="{{ partial "resource_url" (partial "resource_metadata" $testimonial.Params.image.content).Params.file }}" alt="" />
         </div>
         <div class="detail d-flex flex-column flex-nowrap justify-content-between p-0 ml-sm-5">
           <div class="text">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/413

#### What's this PR do?
- [x] Orange text on white background doesn't have enough contrast. Remove the span tag so all the text is black 
   See <img width="159" alt="image" src="https://user-images.githubusercontent.com/430126/152714747-172a104b-a1ea-4e13-b0f6-9f35eaff9a1f.png">
- [x] Use the [wcag-color-contrast-check](https://chrome.google.com/webstore/detail/wcag-color-contrast-check/plnahcmalebffmaghcpcmpaciebdhgdf) chrome extension or similar to review any other contrast issues: (There are some contrast issues indicated by this extension, but they are quite minimal and will require design changes)
- [x] Set `alt=""` for course thumbnails (we could extract the alt text from the course site, but these images are essentially decorative on the home page and the screen reader user would prefer to link to the course quickly
- [x] add `aria-hidden="true" tabindex="-1"` to the `a` enclosing the image to hide them from screen readers 
- [x] review the rest of the images on the page if they also need to be hidden. 

#### How should this be manually tested?
- Go to www homepage.
- Verify all the above-mentioned points.

