### PR TITLE
fix: line break on resource links

### DIFF
--- a/course/layouts/shortcodes/resource_link.html
+++ b/course/layouts/shortcodes/resource_link.html
@@ -1,7 +1,5 @@
 {{- $uuid := index .Params 0 -}}
 {{- $title := index .Params 1 -}}
 {{- range where $.Site.Pages "Params.uid" $uuid -}}
-    <p class="m-0 p-0">
-        <a href="{{- .Permalink -}}">{{ $title }}</a>
-    </p>    
+    <a class="d-block" href="{{- .Permalink -}}">{{ $title }}</a>
 {{- end -}}

--- a/course/layouts/shortcodes/resource_link.html
+++ b/course/layouts/shortcodes/resource_link.html
@@ -1,5 +1,7 @@
 {{- $uuid := index .Params 0 -}}
 {{- $title := index .Params 1 -}}
 {{- range where $.Site.Pages "Params.uid" $uuid -}}
-    <a href="{{- .Permalink -}}">{{ $title }}</a>
+    <p class="m-0 p-0">
+        <a href="{{- .Permalink -}}">{{ $title }}</a>
+    </p>    
 {{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- Closes https://github.com/mitodl/ocw-hugo-themes/issues/302

#### What's this PR do?
- Adds display block class to resource link shortcode so it renders with a link break
- Note: TBH I'm not confident with this solution as it will also cause the resource_links in a text/paragraph to be displayed in a new line which might look a bit odd. Something like this maybe: 
![image](https://user-images.githubusercontent.com/93309234/152802575-ddb4270c-8bd5-4558-9e62-358d9e6f09f3.png)

#### How should this be manually tested?
- Repeat the steps mentioned in the relevant ticket above and verify that the resource links have a line break and they do not render.
- Also verify that the resource links in paragraphs/texts do not look odd as they will be rendered in a new line.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/93309234/152801974-3b7652b6-626c-4032-9e1c-f066e9f13929.png)

