### PR TITLE
Fixed  typo which is causing link to be broken

### DIFF
--- a/base-theme/layouts/partials/footer.html
+++ b/base-theme/layouts/partials/footer.html
@@ -30,7 +30,7 @@
           <ul>
             <li><a href="https://accessibility.mit.edu">Accessibility</a></li>
             <li><a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons License</a></li>
-            <li><a href="pages/privacy-and-terms-of-use/">Terms and Conditions</a></li>
+            <li><a href="/pages/privacy-and-terms-of-use/">Terms and Conditions</a></li>
           </ul>
         </div>
         <div class="horizontal-list">


### PR DESCRIPTION
I missed a typo which causes the link to be broken on some pages this PR fixes those issues.
