### PR TITLE
fix: some margin bottom added below course description

### DIFF
--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -60,7 +60,7 @@
                           <div id="course-description" class="description {{ if $shouldCollapseDescription }}collapse{{ end }}" aria-expanded="false">
                             {{- $courseData.course_description | markdownify -}}
                           </div>
-                          <div class="border-top-gray mt-2">
+                          <div class="border-top-gray mt-2 {{ if not $shouldCollapseDescription }}mb-3{{ end }}">
                             {{ if $shouldCollapseDescription }}
                               <div class="collapse-btn-section float-right">
                                 <a role="button" class="collapsed" data-toggle="collapse" href="#course-description" aria-expanded="false" aria-controls="course-description">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
 Closes https://github.com/mitodl/ocw-hugo-themes/issues/426

#### What's this PR do?
- Adds some margin-bottom below course description only when there is no expand/collapse widget

#### How should this be manually tested?
- Go to course home page for that course whose description doesn't have expand/collapse widget.
- Verify that there is some sufficient space b/w `course description` bottom-border and `course info` heading.

#### Screenshots (if appropriate)
Before: 
![image](https://user-images.githubusercontent.com/93309234/153205780-6979cc62-a605-4204-ab5e-bde92fc303cb.png)

After: 
![image](https://user-images.githubusercontent.com/93309234/153207467-5ffc3695-ae82-4835-8c2d-1e683229c05b.png)

![image](https://user-images.githubusercontent.com/93309234/153207518-435466ae-c1f6-4746-8141-d13bb3d98904.png)

![image](https://user-images.githubusercontent.com/93309234/153207608-44d1eafc-332e-48b8-9b7a-c72a2c1850f1.png)
