### PR TITLE
fixed bug with boldsymbol not rendering

### DIFF
--- a/base-theme/assets/webpack/webpack.common.js
+++ b/base-theme/assets/webpack/webpack.common.js
@@ -139,8 +139,8 @@ module.exports = {
 
     new CopyWebpackPlugin([
       {
-        from:    "./node_modules/mathjax/es5/",
-        to:      "mathjax/"
+        from: "./node_modules/mathjax/es5/",
+        to:   "mathjax/"
       }
     ]),
 

--- a/base-theme/assets/webpack/webpack.common.js
+++ b/base-theme/assets/webpack/webpack.common.js
@@ -140,8 +140,7 @@ module.exports = {
     new CopyWebpackPlugin([
       {
         from:    "./node_modules/mathjax/es5/",
-        to:      "mathjax/",
-        flatten: true
+        to:      "mathjax/"
       }
     ]),
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
   - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #424 

#### What's this PR do?
Fixes second level imports for MathJax

#### How should this be manually tested?
- Verify MathJax is rendering properly in 18.065

#### Any background context you want to provide?
The main reason MathJax was not rendering properly was it was trying to load boldsymbol from mathjax/input/tex/extensions/  which gave a 404  we had flatten the folder structure while bundling.

#### Screenshots (if appropriate)
<img width="1349" alt="Screenshot 2022-02-10 at 3 55 58 PM" src="https://user-images.githubusercontent.com/87968618/153393899-11437061-b94c-4320-b337-c242f4521d4b.png">

