### PR TITLE
properly format urls passed into `resource_file.html`

### DIFF
--- a/course/layouts/shortcodes/resource_file.html
+++ b/course/layouts/shortcodes/resource_file.html
@@ -1,4 +1,4 @@
 {{- $uuid := index .Params 0 -}}
 {{- range where $.Site.Pages "Params.uid" $uuid -}}
-{{- .Params.file -}}
+{{- partial "resource_url.html" .Params.file -}}
 {{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/433

#### What's this PR do?
This PR takes the `file` attribute that `resource_file.html` returns and passes the value through `resource_url.html` before returning it.  This ensures that even if a fully qualified S3 URL is stored in `file`, by default a root relative URL will be returned. `If RESOURCE_BASE_URL` is set, then the URL will be returned prefixed with this value.

#### How should this be manually tested?
 - Clone https://github.mit.edu/ocw-content-rc/wgs.s10-fall-2017
 - Configure your environment to point at the course and spin it up with `npm run start:course`
 - Go to http://localhost:3000/pages/instructor-insights/ and you should see a missing image at the top of the page.  Inspect it and you should see a root relative URL.
 - Stop the site and set `RESOURCE_BASE_URL` to https://ocw-live-qa.global.ssl.fastly.net/courses and then spin it up again
 - Go back to Go to http://localhost:3000/pages/instructor-insights/ and you should see the image
