### PR TITLE
fixed resource toggling issue

### DIFF
--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -136,9 +136,8 @@ export default function SearchPage() {
   const toggleResourceSearch = useCallback(
     nextResourceFilterState => async () => {
       if (isResourceFilterActive() === nextResourceFilterState) {
-        //Immediately return in case user clicks
-        // and already active facet.
-        //Githun issue https://github.com/mitodl/ocw-hugo-themes/issues/105
+        // Immediately return in case the user clicks and already active facet.
+        // Github issue https://github.com/mitodl/ocw-hugo-themes/issues/105
         return
       }
       const toggledFacets: [string, string, boolean][] = [

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -135,6 +135,7 @@ export default function SearchPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const toggleResourceSearch = useCallback(
     toggleOn => async () => {
+      if (isActiveFacet(toggleOn)) return
       const toggledFacets: [string, string, boolean][] = [
         ["type", LearningResourceType.ResourceFile, toggleOn],
         ["type", LearningResourceType.Course, !toggleOn]
@@ -156,6 +157,14 @@ export default function SearchPage() {
     },
     [toggleFacets, activeFacets]
   )
+
+  const isActiveFacet = (toggleOn: boolean): boolean => {
+    const activeType = activeFacets.type ?? []
+    return (
+      activeType &&
+      activeType.includes(LearningResourceType.ResourceFile) === toggleOn
+    )
+  }
 
   const isResourceSearch = (activeFacets.type ?? []).includes(
     LearningResourceType.ResourceFile

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -134,16 +134,21 @@ export default function SearchPage() {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const toggleResourceSearch = useCallback(
-    toggleOn => async () => {
-      if (isActiveFacet(toggleOn)) return
+    nextResourceFilterState => async () => {
+      if (isResourceFilterActive() === nextResourceFilterState) {
+        //Immediately return in case user clicks
+        // and already active facet.
+        //Githun issue https://github.com/mitodl/ocw-hugo-themes/issues/105
+        return
+      }
       const toggledFacets: [string, string, boolean][] = [
-        ["type", LearningResourceType.ResourceFile, toggleOn],
-        ["type", LearningResourceType.Course, !toggleOn]
+        ["type", LearningResourceType.ResourceFile, nextResourceFilterState],
+        ["type", LearningResourceType.Course, !nextResourceFilterState]
       ]
       // Remove any facets not relevant to the new search type
       const newFacets: Map<string, string> = new Map(
         // @ts-ignore
-        toggleOn ? RESOURCE_FACETS : COURSE_FACETS
+        nextResourceFilterState ? RESOURCE_FACETS : COURSE_FACETS
       )
 
       Object.entries(activeFacets).forEach(([key, list]) => {
@@ -158,12 +163,9 @@ export default function SearchPage() {
     [toggleFacets, activeFacets]
   )
 
-  const isActiveFacet = (toggleOn: boolean): boolean => {
+  const isResourceFilterActive = (): boolean => {
     const activeType = activeFacets.type ?? []
-    return (
-      activeType &&
-      activeType.includes(LearningResourceType.ResourceFile) === toggleOn
-    )
+    return activeType && activeType.includes(LearningResourceType.ResourceFile)
   }
 
   const isResourceSearch = (activeFacets.type ?? []).includes(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
   - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #105 

#### What's this PR do?
Adds and immediate return in `toggleResourceSearch` on clicking an already active facet.

#### How should this be manually tested?
Go to `/search` and verify the following 
- On clicking `Resource` it switches to resource search .
- On clicking again nothing happens and it stays on Resource Search
- On clicking to `Course` it switches to Course search
- On clicking again nothing happens and it stays on Course search
