### PR TITLE
added optional anchor id to resource link

### DIFF
--- a/course/layouts/shortcodes/resource_link.html
+++ b/course/layouts/shortcodes/resource_link.html
@@ -1,5 +1,6 @@
 {{- $uuid := index .Params 0 -}}
 {{- $title := index .Params 1 -}}
+{{- $anchor_id := index .Params 2 | default ""}}
 {{- range where $.Site.Pages "Params.uid" $uuid -}}
-    <a href="{{- .Permalink -}}">{{ $title }}</a>
+    <a href="{{- .Permalink -}}{{- $anchor_id -}}">{{ $title }}</a>
 {{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #429 

#### What's this PR do?
Adds an optional anchor_id parameter to link to document fragments

#### How should this be manually tested?
- Verify resource_links work as it is
- Add HUGO anchor_ids to resource_links and verify they link to the proper page

#### Any background context you want to provide?
So I did some RnD on Hugo and HUGO automatically generates anchor id's for heading and we can link to them using relref or rel shortcodes [as explained here](https://gohugobrasil.netlify.app/content-management/cross-references/#:~:text=When%20using%20Markdown%20document%20types,and%20across%20the%20entire%20site.) I have added an option for these anchors in resource_links but we will not be able to extract the unique identifier in this case.

#### Screenshots (if appropriate)
(Optional)

https://user-images.githubusercontent.com/87968618/154076786-d7acb3eb-8183-4aa3-8ccc-af081cb3f971.mov




