### PR TITLE
fixed video urls not linking to archive.org

### DIFF
--- a/base-theme/layouts/partials/resource_url.html
+++ b/base-theme/layouts/partials/resource_url.html
@@ -6,13 +6,9 @@
 
   The RESOURCE_BASE_URL env variable is prefixed before the URL. That way for local
   development, you can set this to the S3 URL you expect the resources to be available at.
-
-  If the URL is for archive.org then we skip the above mentioneds steps.
 */}}
-{{- if not (hasPrefix $url "https://archive.org") -}}
-  {{- $prefix := getenv "RESOURCE_BASE_URL" | default "" -}}
-  {{- $url := printf "%s%s" (strings.TrimSuffix "/" $prefix) (urls.Parse $url).Path -}}
-{{- end -}}
+{{- $prefix := getenv "RESOURCE_BASE_URL" | default "" -}}
+{{- $url := printf "%s%s" (strings.TrimSuffix "/" $prefix) (urls.Parse $url).Path -}}
 {{- if hasPrefix $url "http" -}}
   {{- return $url -}}
 {{- else -}}

--- a/base-theme/layouts/partials/resource_url.html
+++ b/base-theme/layouts/partials/resource_url.html
@@ -6,11 +6,16 @@
 
   The RESOURCE_BASE_URL env variable is prefixed before the URL. That way for local
   development, you can set this to the S3 URL you expect the resources to be available at.
+
+  If the URL is for archive.org then we skip the above mentioneds steps.
 */}}
-{{- $prefix := getenv "RESOURCE_BASE_URL" | default "" -}}
-{{- $url := printf "%s%s" (strings.TrimSuffix "/" $prefix) (urls.Parse $url).Path -}}
+{{- if not (hasPrefix $url "https://archive.org") -}}
+  {{- $prefix := getenv "RESOURCE_BASE_URL" | default "" -}}
+  {{- $url := printf "%s%s" (strings.TrimSuffix "/" $prefix) (urls.Parse $url).Path -}}
+{{- end -}}
 {{- if hasPrefix $url "http" -}}
   {{- return $url -}}
 {{- else -}}
   {{- partial "site_root_url.html" $url -}}
 {{- end -}}
+

--- a/course/layouts/partials/video.html
+++ b/course/layouts/partials/video.html
@@ -4,6 +4,8 @@
 {{ $downloadLink := .Params.file }}
 {{ if (eq $downloadLink nil) }}
 {{ $downloadLink = .Params.video_files.archive_url }}
+{{ else }}
+{{ $downloadLink =  partial "resource_url" $downloadLink  }}
 {{ end }}
 
 <div class="video-page">
@@ -19,7 +21,7 @@
 	{{end}}
 	{{ if  $downloadLink }}
 	  <div class="video-download-container">
-	    <a class="download-file video-download-button" href="{{ partial "resource_url" $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
+	    <a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
 	  </div>
 	{{end}}
 	</div>

--- a/course/layouts/partials/video_embed.html
+++ b/course/layouts/partials/video_embed.html
@@ -4,6 +4,8 @@
 {{ $downloadLink := .Params.file }}
 {{ if (eq $downloadLink nil) }}
 {{ $downloadLink = .Params.video_files.archive_url }}
+{{ else }}
+{{ $downloadLink =  partial "resource_url" $downloadLink  }}
 {{ end }}
 
 {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation) }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
    - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #443 

#### What's this PR do?
Adds conditional in resource_link partial to skip processing links to archive.org. 

#### How should this be manually tested?
- Open video lectures for course `22.01-fall-2016`
- Click `Download Video` and verify they it opens archive.org download page.
- Verify videos from s3 bucket behave as it is