### PR TITLE
fix: style of h3 in td, name of an id changed

### DIFF
--- a/course/assets/css/course-content.scss
+++ b/course/assets/css/course-content.scss
@@ -7,3 +7,11 @@
 #course-title.collapsing {
   height: 5.7em;
 }
+
+td {
+  h3 {
+    font-weight: normal !important;
+    font-style: italic !important;
+    font-family: arial, helvetica, sans-serif !important;
+  }
+}

--- a/course/assets/css/instructor-insights.scss
+++ b/course/assets/css/instructor-insights.scss
@@ -1,5 +1,5 @@
 @import "../../../base-theme/assets/css/variables.scss";
-#main-section {
+#course-content-section {
   h2 {
     margin-bottom: 1.25rem !important;
   }

--- a/course/layouts/partials/course_content.html
+++ b/course/layouts/partials/course_content.html
@@ -29,6 +29,6 @@
   </header>
   {{ partial "mobile_nav_toggle.html" . }}
   <article class="content pt-3 mt-1">
-    <main id="main-section">{{- .Content -}}</main>
+    <main id="course-content-section">{{- .Content -}}</main>
   </article>
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/448

#### What's this PR do?
- Gives some css style of `h3` inside `td`
- Rename an html entity id to something more relevant

#### How should this be manually tested?
- Build/run any course which has `h3` tags inside `td` of `table` tag
- Verify the following CSS is applied to it
```
font-weight: normal;
font-style: italic;
font-family: arial, helvetica, sans-serif;
``` 
- Also verify that this CSS has NO side-effects (It is not applied anywhere else)

#### Screenshots (if appropriate)
<img width="671" alt="image" src="https://user-images.githubusercontent.com/93309234/154667448-f4971229-8437-4156-8b0f-aa34da5a139a.png">

<img width="342" alt="image" src="https://user-images.githubusercontent.com/93309234/154667518-02dc0b7a-76e2-4cc5-bf6f-08fde34a72d1.png">

