### PR TITLE
added optional and related resources tab

### DIFF
--- a/course/assets/css/video-transcript.scss
+++ b/course/assets/css/video-transcript.scss
@@ -42,7 +42,7 @@
   margin-right: 15px;
 }
 
-.transcript-header {
+.tab-header {
   background-color: #f6f7f9;
   font-size: 23px;
   padding-left: 20px;
@@ -51,6 +51,13 @@
   margin-bottom: 10px;
 }
 
-.transcript-footer {
+.tab-footer {
   height: 15px;
+}
+
+.tab-content {
+  padding-left: 20px;
+  padding-bottom: 5px;
+  padding-top: 10px;
+  margin-bottom: 10px;
 }

--- a/course/layouts/partials/video.html
+++ b/course/layouts/partials/video.html
@@ -2,6 +2,9 @@
 {{ $captionsLocation := .Params.video_files.video_captions_file }}
 {{ $transcriptPdfLocation := .Params.video_files.video_transcript_file }}
 {{ $downloadLink := .Params.file }}
+{{ $relatedResourses := .Params.related_resources_text | default "" }}
+{{ $optionalTabTitle := .Params.optional_tab_title | default "" }}
+{{ $optionalTabContent := .Params.optional_text | default ""}}
 {{ if (eq $downloadLink nil) }}
 {{ $downloadLink = .Params.video_files.archive_url }}
 {{ else }}
@@ -28,7 +31,7 @@
 
   {{if $captionsLocation}}
   <div class="transcript-box">
-  	<div class="transcript-header">
+  	<div class="tab-header">
 	   	<span>
 	       Transcript
 	    </span>
@@ -40,8 +43,48 @@
 	      <i class="material-icons md-18"></i>
 	    </a>
 	</div>
-	<div class="transcript collapse show"></div>
+	<div class="transcript collapse"></div>
   </div>
-  <div class="transcript-footer"></div>
+  <div class="tab-footer"></div>
+  {{end}}
+  {{if $relatedResourses }}
+  <div class="related-resource-box">
+  	<div class="tab-header">
+	   	<span>
+	       Releated Resources
+	    </span>
+	    <a class="transcript-section-toggle course-nav-section-toggle"
+	      href=".related-resource"
+	      data-toggle="collapse"
+	      aria-controls="related-resource"
+	      aria-expanded="">
+	      <i class="material-icons md-18"></i>
+	    </a>
+	</div>
+	<div class="related-resource  tab-content collapse">
+		{{ .Page.RenderString $relatedResourses}}
+	</div>
+  </div>
+  <div class="tab-footer"></div>
+  {{end}}
+  {{if and $optionalTabTitle $optionalTabContent }}
+  <div class="related-resource-box">
+  	<div class="tab-header">
+	   	<span>
+	       {{ $optionalTabTitle }}
+	    </span>
+	    <a class="transcript-section-toggle course-nav-section-toggle"
+	      href=".related-resource"
+	      data-toggle="collapse"
+	      aria-controls="related-resource"
+	      aria-expanded="">
+	      <i class="material-icons md-18"></i>
+	    </a>
+	</div>
+	<div class="related-resource  tab-content collapse">
+		{{ .Page.RenderString $optionalTabContent}}
+	</div>
+  </div>
+  <div class="tab-footer"></div>
   {{end}}
 </div>

--- a/course/layouts/partials/video.html
+++ b/course/layouts/partials/video.html
@@ -29,7 +29,7 @@
 	{{end}}
 	</div>
 
-  {{if $captionsLocation}}
+  {{ if $captionsLocation}}
   <div class="transcript-box">
   	<div class="tab-header">
 	   	<span>
@@ -47,7 +47,7 @@
   </div>
   <div class="tab-footer"></div>
   {{end}}
-  {{if $relatedResourses }}
+  {{ if $relatedResourses }}
   <div class="related-resource-box">
   	<div class="tab-header">
 	   	<span>
@@ -67,7 +67,7 @@
   </div>
   <div class="tab-footer"></div>
   {{end}}
-  {{if and $optionalTabTitle $optionalTabContent }}
+  {{ if and $optionalTabTitle $optionalTabContent }}
   <div class="related-resource-box">
   	<div class="tab-header">
 	   	<span>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #454 

#### What's this PR do?
 Adds a `related resources` and `optional tab` in video page.

#### How should this be manually tested?
Verify the following
 - When there is content, add a "related resources" section below the Transcript, with a similar UX and with the label "Related Resources". It should default to closed, but can be opened to view the content.
 - When there is content, add an optional section below the video, using the label specified in the page markdown. It should default to closed, but can be opened to view the content.
 - All tabs remain close on page load
 
#### Screenshots (if appropriate)
(Optional)
<img width="1440" alt="Screenshot 2022-02-21 at 6 23 49 PM" src="https://user-images.githubusercontent.com/87968618/154964970-b401ceed-1d74-4b74-8c37-40f50ed86c9f.png">
<img width="1440" alt="Screenshot 2022-02-21 at 6 24 03 PM" src="https://user-images.githubusercontent.com/87968618/154965522-baa1e0ff-c95c-423b-aea9-0126a5668860.png">
<img width="1440" alt="Screenshot 2022-02-21 at 6 25 06 PM" src="https://user-images.githubusercontent.com/87968618/154965645-af0aaac1-41f0-4b05-ab29-a69af3456ddb.png">
<img width="1440" alt="Screenshot 2022-02-21 at 6 25 19 PM" src="https://user-images.githubusercontent.com/87968618/154965711-4ad89e1d-59e1-4b81-be2a-136fc3069149.png">

