### PR TITLE
Fixed CSS for image rendering small

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -299,6 +299,13 @@ table {
   img {
     max-width: 100%;
   }
+  td {
+    img {
+      // Incase of img in td setting maxwith to 100% will lead to img
+      // to only have the width of the table column
+      max-width: none;
+    }
+  }
 }
 
 article.content {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
   - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #460 

#### What's this PR do?
Fixes css to images expands to original width

#### How should this be manually tested?
Clone Course with embedded image
- Verify image is rendered correctly 

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2022-02-23 at 3 03 31 PM" src="https://user-images.githubusercontent.com/87968618/155304748-cfbb000a-d916-4be2-80f6-1b2a58a506ab.png">

