### PR TITLE
fix: style added for code elements

### DIFF
--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -38,6 +38,8 @@ $transparency-gray-light: rgba(246, 246, 246, 0.71);
 // course pages
 $course-content-link-unclicked: #115f83;
 $course-content-link-hover-clicked: #355b6b;
+$one-liner-code: #333;
+$code-block-background: #eeeeee;
 
 // about page
 $timeline-spacing: 128px;

--- a/course/assets/css/course.scss
+++ b/course/assets/css/course.scss
@@ -71,3 +71,14 @@ div[class^="reveal"],
 .multiple_choice_buttons {
   margin: 10px;
 }
+
+code {
+  color: $one-liner-code !important;
+  font-family: Courier New, Courier !important;
+}
+
+pre {
+  padding: 15px 0px 15px 15px !important;
+  background-color: $code-block-background !important;
+  border: thin dotted $highlight-red !important;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-to-hugo/issues/464

#### What's this PR do?
- Overrides default css styling of `code` elements

#### How should this be manually tested?
- Checkout to the branch of [this PR](https://github.com/mitodl/ocw-to-hugo/pull/469)
- Run any course through it (course which has one liner codes and code blocks), [example course](https://ocwnext.odl.mit.edu/courses/6-006-introduction-to-algorithms-fall-2011/)
- Build this course in `ocw-hugo-themes` 
- Verify that all the single line codes and code blocks have appropriate styling
- Verify that this change has no `side-effect` anywhere else 
- Repeat this step for multiple courses and multiple browsers

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/93309234/155318478-6a0bcff0-4055-4db5-b8c2-60ea6ed4eaea.png)

![image](https://user-images.githubusercontent.com/93309234/155318541-a51d9a8d-9c01-4fee-96aa-8966ce73de8a.png)

![image](https://user-images.githubusercontent.com/93309234/155318394-294715f9-64d3-4b9a-8586-51364c7b6cc8.png)

