### PR TITLE
fix: cleaning font-sizes, replacing px with rem

### DIFF
--- a/base-theme/assets/css/footer.scss
+++ b/base-theme/assets/css/footer.scss
@@ -17,12 +17,10 @@
   .support-link-column {
     width: 55%;
     font-weight: bold;
-    font-size: 14px;
   }
 
   .support-link-container {
     font-weight: bold;
-    font-size: 14px;
     a {
       padding-left: 10px;
     }
@@ -36,7 +34,6 @@
   }
 
   p {
-    font-size: 14px;
     line-height: 24px;
     margin: 0px;
   }

--- a/base-theme/assets/css/header.scss
+++ b/base-theme/assets/css/header.scss
@@ -69,7 +69,7 @@
       }
 
       a {
-        font-size: $header-link-font;
+        font-size: $font-sm;
         text-transform: uppercase;
 
         &.give-button-header {

--- a/base-theme/assets/css/header.scss
+++ b/base-theme/assets/css/header.scss
@@ -15,7 +15,7 @@
     padding-bottom: 0;
 
     .material-icons {
-      font-size: 1.75rem;
+      font-size: $material-icon-font-lg;
     }
   }
 }
@@ -64,12 +64,12 @@
         color: $orange;
 
         .material-icons {
-          font-size: 1.75rem;
+          font-size: $material-icon-font-lg;
         }
       }
 
       a {
-        font-size: 14px;
+        font-size: $header-link-font;
         text-transform: uppercase;
 
         &.give-button-header {

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -69,6 +69,18 @@ a {
   }
 }
 
+p {
+  font-size: $normal-text-font-size;
+}
+
+ul li {
+  font-size: $normal-text-font-size;
+}
+
+table {
+  font-size: $normal-text-font-size;
+}
+
 h1 {
   font-size: 36px;
   color: $black;
@@ -116,10 +128,6 @@ a + h3 {
   h3 {
     font-size: 18px;
   }
-}
-
-p {
-  font-size: 18px;
 }
 
 @include media-breakpoint-down(xs) {
@@ -370,7 +378,7 @@ article.content {
 }
 
 .course-title-section {
-  font-size: 18px;
+  font-size: $normal-text-font-size;
 }
 
 .course-section-title-container {

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -45,7 +45,7 @@ a.coming-soon {
 
 body {
   font-family: "Helvetica";
-  font-size: 16px;
+  font-size: $font-normal;
 }
 
 .underline {
@@ -69,33 +69,21 @@ a {
   }
 }
 
-p {
-  font-size: $normal-text-font-size;
-}
-
-li {
-  font-size: $normal-text-font-size;
-}
-
-table {
-  font-size: $normal-text-font-size;
-}
-
 h1 {
-  font-size: 36px;
+  font-size: $heading-one-font-lg;
   color: $black;
 
   @include media-breakpoint-down(xs) {
-    font-size: 32px;
+    font-size: $heading-one-font-xs;
   }
 }
 
 h2 {
-  font-size: 28px;
+  font-size: $heading-two-font-lg;
   color: $black;
 
   @include media-breakpoint-down(xs) {
-    font-size: 24px;
+    font-size: $heading-two-font-xs;
   }
 
   &.branded {
@@ -109,14 +97,8 @@ h2 {
   }
 }
 
-@include media-breakpoint-down(xs) {
-  h2 {
-    font-size: 24px;
-  }
-}
-
 h3 {
-  font-size: 24px;
+  font-size: $heading-three-font-lg;
   color: $black;
 }
 
@@ -126,13 +108,7 @@ a + h3 {
 
 @include media-breakpoint-down(xs) {
   h3 {
-    font-size: 18px;
-  }
-}
-
-@include media-breakpoint-down(xs) {
-  p {
-    font-size: 16px;
+    font-size: $heading-three-font-xs;
   }
 }
 
@@ -297,6 +273,24 @@ table {
 .material-icons {
   @include icon-styles;
   font-family: "Material Icons";
+  font-weight: normal;
+  font-style: normal;
+  font-size: $material-icon-font-normal;
+  display: inline-block;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+
+  /* Support for all WebKit browsers. */
+  -webkit-font-smoothing: antialiased;
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .material-icons-round {
@@ -368,17 +362,9 @@ article.content {
 
       td {
         border: none;
-
-        p {
-          font-size: 1rem;
-        }
       }
     }
   }
-}
-
-.course-title-section {
-  font-size: $normal-text-font-size;
 }
 
 .course-section-title-container {

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -45,7 +45,7 @@ a.coming-soon {
 
 body {
   font-family: "Helvetica";
-  font-size: $font-normal;
+  font-size: $font-root;
 }
 
 .underline {
@@ -328,7 +328,7 @@ table {
 }
 
 article.content {
-  font-size: 1rem;
+  font-size: $font-normal;
 
   h2 {
     color: $highlight-red;

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -73,7 +73,7 @@ p {
   font-size: $normal-text-font-size;
 }
 
-ul li {
+li {
   font-size: $normal-text-font-size;
 }
 

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -17,6 +17,7 @@ $medium-light-gray: #e9e9e9;
 $medium-gray: #9c9d9e;
 $dark-gray: #3d3d3d;
 $partial-collapse-height: 6em;
+$normal-text-font-size: 18px;
 
 // full-color design
 $highlight-red: #a31f34;

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -17,7 +17,6 @@ $medium-light-gray: #e9e9e9;
 $medium-gray: #9c9d9e;
 $dark-gray: #3d3d3d;
 $partial-collapse-height: 6em;
-$normal-text-font-size: 18px;
 
 // full-color design
 $highlight-red: #a31f34;
@@ -46,3 +45,23 @@ $about-red: #a92d41;
 
 // footer partials
 $footer-background-color: #f6f7f9;
+
+// font sizes
+
+// default (root) font size.
+$font-normal: 16px;
+// rem value = element font size / 16px (root font size) 
+// h1
+$heading-one-font-lg: 2.25rem;
+$heading-one-font-xs: 2rem;
+// h2
+$heading-two-font-lg: 1.75rem;
+$heading-two-font-xs: 1.5rem;
+// h3
+$heading-three-font-lg: 1.5rem;
+$heading-three-font-xs: 1.125rem;
+// material icon
+$material-icon-font-normal: 1.5rem; /* Preferred icon size = 24px */
+$material-icon-font-lg: 1.75rem;
+
+$header-link-font: 0.875rem;

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -3,15 +3,15 @@ $max-content-width: 1447px;
 $desktop-header-height: 116px;
 $desktop-header-max-width: 1664px;
 $extra-small-screen-width: 400px;
-$enable-responsive-font-sizes: true;
-$font-size-base: 0.8rem;
-$headings-font-weight: 600;
-$table-cell-padding: 0.5rem;
-$offcanvas-width: 85vw;
-$transparent: #ffffff00;
+$enable-responsive-font-sizes: true; /* not found */
+$font-size-base: 0.8rem; /* not found */
+$headings-font-weight: 600; /* not found */
+$table-cell-padding: 0.5rem; /* not found */
+$offcanvas-width: 85vw; /* not found */
+$transparent: #ffffff00; /* not found */
 $white: #ffffff;
 $black: #000000;
-$transparent-black: #00000080;
+$transparent-black: #00000080; /* not found */
 $light-gray: #f5f5f5;
 $medium-light-gray: #e9e9e9;
 $medium-gray: #9c9d9e;
@@ -46,22 +46,25 @@ $about-red: #a92d41;
 // footer partials
 $footer-background-color: #f6f7f9;
 
-// font sizes
+// font sizes rem value = element font size / 16px (root font size)
+// Changing values of these variables is not recommended as it will have a quite widespread/large impact.
+$font-root: 16px;
 
-// default (root) font size.
-$font-normal: 16px;
-// rem value = element font size / 16px (root font size) 
+$font-xl: 1.5rem; /* 24px == 1.5 x 16 */
+$font-lg: 1.25rem; /* 20px */
+$font-md: 1.125rem; /* 18px */
+$font-normal: 1rem; /* 16px */
+$font-sm: 0.875rem; /* 14px */
+$font-xs: 0.75rem; /* 12px */
 // h1
-$heading-one-font-lg: 2.25rem;
-$heading-one-font-xs: 2rem;
+$heading-one-font-lg: 2.25rem; /* 36px */
+$heading-one-font-xs: 2rem; /* 32px */
 // h2
-$heading-two-font-lg: 1.75rem;
-$heading-two-font-xs: 1.5rem;
+$heading-two-font-lg: 1.75rem; /* 28px */
+$heading-two-font-xs: 1.5rem; /* 24px */
 // h3
-$heading-three-font-lg: 1.5rem;
-$heading-three-font-xs: 1.125rem;
+$heading-three-font-lg: 1.5rem; /* 24px */
+$heading-three-font-xs: 1.125rem; /* 18px */
 // material icon
 $material-icon-font-normal: 1.5rem; /* Preferred icon size = 24px */
-$material-icon-font-lg: 1.75rem;
-
-$header-link-font: 0.875rem;
+$material-icon-font-lg: 1.75rem; /* 28px */

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -13,7 +13,7 @@ $black: #000000;
 $transparent-black: #00000080;
 $light-gray: #f5f5f5;
 $medium-light-gray: #e9e9e9;
-$medium-gray: #395066;
+$medium-gray: #9c9d9e;
 $dark-gray: #3d3d3d;
 $partial-collapse-height: 6em;
 

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -3,11 +3,17 @@ $max-content-width: 1447px;
 $desktop-header-height: 116px;
 $desktop-header-max-width: 1664px;
 $extra-small-screen-width: 400px;
+$enable-responsive-font-sizes: true;
+$headings-font-weight: 600;
+$table-cell-padding: 0.5rem;
+$offcanvas-width: 85vw;
+$transparent: #ffffff00;
 $white: #ffffff;
 $black: #000000;
+$transparent-black: #00000080;
 $light-gray: #f5f5f5;
 $medium-light-gray: #e9e9e9;
-$medium-gray: #9c9d9e;
+$medium-gray: #395066;
 $dark-gray: #3d3d3d;
 $partial-collapse-height: 6em;
 

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -3,15 +3,8 @@ $max-content-width: 1447px;
 $desktop-header-height: 116px;
 $desktop-header-max-width: 1664px;
 $extra-small-screen-width: 400px;
-$enable-responsive-font-sizes: true; /* not found */
-$font-size-base: 0.8rem; /* not found */
-$headings-font-weight: 600; /* not found */
-$table-cell-padding: 0.5rem; /* not found */
-$offcanvas-width: 85vw; /* not found */
-$transparent: #ffffff00; /* not found */
 $white: #ffffff;
 $black: #000000;
-$transparent-black: #00000080; /* not found */
 $light-gray: #f5f5f5;
 $medium-light-gray: #e9e9e9;
 $medium-gray: #9c9d9e;

--- a/course/assets/css/course-home.scss
+++ b/course/assets/css/course-home.scss
@@ -42,7 +42,7 @@
   h4.course-description-title {
     color: $highlight-red;
     text-transform: uppercase;
-    font-size: 1rem;
+    font-size: $font-normal;
   }
 
   .course-home-section {

--- a/course/assets/css/course-home.scss
+++ b/course/assets/css/course-home.scss
@@ -42,7 +42,7 @@
   h4.course-description-title {
     color: $highlight-red;
     text-transform: uppercase;
-    font-size: 16px;
+    font-size: 1rem;
   }
 
   .course-home-section {

--- a/course/assets/css/course-info.scss
+++ b/course/assets/css/course-info.scss
@@ -144,8 +144,6 @@
 
 .course-description {
   .description {
-    font-size: 1rem;
-
     p:last-child {
       margin-bottom: 0;
     }

--- a/course/assets/css/course-nav.scss
+++ b/course/assets/css/course-nav.scss
@@ -1,7 +1,7 @@
 .course-nav {
   a {
     text-decoration: none;
-    font-size: 0.875rem;
+    font-size: $font-sm;
 
     &.active {
       font-weight: 600;
@@ -18,11 +18,11 @@
 
 .mobile-course-nav-toggle {
   *:not(i) {
-    font-size: 1rem;
+    font-size: $font-normal;
   }
 
   i {
-    font-size: 1.25rem;
+    font-size: $font-lg;
   }
 }
 
@@ -51,7 +51,7 @@
 }
 
 .course-nav-list-item-child {
-  font-size: 0.7rem;
+  font-size: $font-xs;
 }
 
 .course-nav-section-toggle {

--- a/course/assets/css/course-nav.scss
+++ b/course/assets/css/course-nav.scss
@@ -1,7 +1,7 @@
 .course-nav {
   a {
     text-decoration: none;
-    font-size: 14px;
+    font-size: 0.875rem;
 
     &.active {
       font-weight: 600;
@@ -22,7 +22,7 @@
   }
 
   i {
-    font-size: 20px;
+    font-size: 1.25rem;
   }
 }
 

--- a/course/assets/css/instructor-insights.scss
+++ b/course/assets/css/instructor-insights.scss
@@ -5,7 +5,7 @@
   }
 
   h3 {
-    font-size: 1rem !important;
+    font-size: $font-normal !important;
   }
 
   p {

--- a/course/assets/css/video-transcript.scss
+++ b/course/assets/css/video-transcript.scss
@@ -44,7 +44,7 @@
 
 .tab-header {
   background-color: #f6f7f9;
-  font-size: 23px;
+  font-size: $font-xl;
   padding-left: 20px;
   padding-bottom: 5px;
   padding-top: 10px;

--- a/course/assets/css/video.scss
+++ b/course/assets/css/video.scss
@@ -87,7 +87,7 @@
 
 .video-download-button {
   float: right;
-  font-size: 0.875rem;
+  font-size: $font-sm;
   color: white;
 }
 

--- a/course/assets/css/video.scss
+++ b/course/assets/css/video.scss
@@ -49,7 +49,6 @@
           position: absolute;
           top: 50%;
           transform: translateY(-50%);
-          font-size: 16px;
         }
       }
     }
@@ -88,7 +87,7 @@
 
 .video-download-button {
   float: right;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: white;
 }
 
@@ -96,8 +95,7 @@ a.video-download-button:visited {
   color: white;
 }
 
-.video_page_link {
-  font-size: 16px;
+.video-page-link {
   text-transform: uppercase;
   padding-top: 35px;
   padding-bottom: 25px;
@@ -124,7 +122,7 @@ a.video-download-button:visited {
     padding-bottom: 0px;
   }
 
-  .video_page_link {
+  .video-page-link {
     float: right;
     padding-top: 15px;
     padding-bottom: 0px;

--- a/course/layouts/partials/video_embed.html
+++ b/course/layouts/partials/video_embed.html
@@ -11,7 +11,7 @@
 {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation) }}
 {{- range where $.Site.Pages "Params.uid" $uid -}}
 	<div class="video-buttons-container">
-    <div class='video_page_link'>
+    <div class='video-page-link'>
       <a href="{{- .Permalink -}}">View Video Page</a>
       <i class="material-icons video-page-link-icon">chevron_right</i>
     </div>

--- a/www/assets/css/about.scss
+++ b/www/assets/css/about.scss
@@ -221,7 +221,7 @@
 
     li:before {
       content: "\2013";
-      font-size: 24px;
+      font-size: $material-icon-font-normal;
       position: absolute;
       left: 5px;
       top: -8px;
@@ -279,6 +279,7 @@
 
       h1 {
         font-size: 3.75em;
+        color: $white;
       }
 
       #president-image {
@@ -293,7 +294,7 @@
 
       #presidents-message {
         p {
-          font-size: 24px;
+          font-size: 1.5rem;
         }
 
         @include media-breakpoint-down(md) {

--- a/www/assets/css/about.scss
+++ b/www/assets/css/about.scss
@@ -294,7 +294,7 @@
 
       #presidents-message {
         p {
-          font-size: 1.5rem;
+          font-size: $font-xl;
         }
 
         @include media-breakpoint-down(md) {

--- a/www/assets/css/card.scss
+++ b/www/assets/css/card.scss
@@ -14,7 +14,7 @@
   }
 
   .title {
-    font-size: 1.125rem;
+    font-size: $font-md;
     font-weight: 400;
     margin: 10px 0 7px 10px;
   }

--- a/www/assets/css/card.scss
+++ b/www/assets/css/card.scss
@@ -14,7 +14,7 @@
   }
 
   .title {
-    font-size: 18px;
+    font-size: 1.125rem;
     font-weight: 400;
     margin: 10px 0 7px 10px;
   }

--- a/www/assets/css/carousel.scss
+++ b/www/assets/css/carousel.scss
@@ -36,11 +36,10 @@
       align-items: center;
       margin-left: 8px;
       padding: 6px;
-      font-size: 16px;
       height: 38px;
 
       @include media-breakpoint-down(xs) {
-        font-size: 12px;
+        font-size: 0.75rem;
       }
 
       span {

--- a/www/assets/css/carousel.scss
+++ b/www/assets/css/carousel.scss
@@ -39,7 +39,7 @@
       height: 38px;
 
       @include media-breakpoint-down(xs) {
-        font-size: 0.75rem;
+        font-size: $font-xs;
       }
 
       span {

--- a/www/assets/css/common.scss
+++ b/www/assets/css/common.scss
@@ -30,7 +30,7 @@
 @media (max-width: 900px) {
   h2#ocw-20-text {
     padding: 1rem 0 0 1rem;
-    font-size: 1.125rem;
+    font-size: $font-md;
   }
   #about-us #ocw-at-20 #ocw-20-text {
     line-height: 1.8rem;
@@ -40,7 +40,7 @@
   }
   #about-us h1,
   #educator-main-section h1 {
-    font-size: 1.5rem;
+    font-size: $font-xl;
   }
   #about-us #ocw-at-20 {
     padding-right: 0 !important;
@@ -56,7 +56,7 @@
     padding: 0rem 0rem 0rem 0rem !important;
   }
   #presidents-message p {
-    font-size: 1.125rem !important;
+    font-size: $font-md !important;
   }
   #educator-main-section {
     border: 1px solid red;
@@ -66,7 +66,7 @@
     padding: 0 1rem !important;
   }
   #educator-main-section h1 {
-    font-size: 1.5rem !important;
+    font-size: $font-xl !important;
   }
   #educator-main-section h3 {
     line-height: 1.4rem;

--- a/www/assets/css/common.scss
+++ b/www/assets/css/common.scss
@@ -30,7 +30,7 @@
 @media (max-width: 900px) {
   h2#ocw-20-text {
     padding: 1rem 0 0 1rem;
-    font-size: 18px;
+    font-size: 1.125rem;
   }
   #about-us #ocw-at-20 #ocw-20-text {
     line-height: 1.8rem;
@@ -40,7 +40,7 @@
   }
   #about-us h1,
   #educator-main-section h1 {
-    font-size: 24px;
+    font-size: 1.5rem;
   }
   #about-us #ocw-at-20 {
     padding-right: 0 !important;
@@ -50,13 +50,13 @@
     margin: 0 auto;
   }
   #about-us #president-dean-messages .container h1 {
-    font-size: 2.4rem;
+    font-size: 2.4rem !important;
   }
   #beyond-course-materials {
     padding: 0rem 0rem 0rem 0rem !important;
   }
   #presidents-message p {
-    font-size: 18px;
+    font-size: 1.125rem !important;
   }
   #educator-main-section {
     border: 1px solid red;
@@ -66,7 +66,7 @@
     padding: 0 1rem !important;
   }
   #educator-main-section h1 {
-    font-size: 24px;
+    font-size: 1.5rem !important;
   }
   #educator-main-section h3 {
     line-height: 1.4rem;

--- a/www/assets/css/course-collection.scss
+++ b/www/assets/css/course-collection.scss
@@ -19,7 +19,6 @@
 
       p {
         margin: 0;
-        font-size: 16px;
       }
     }
   }

--- a/www/assets/css/educator.scss
+++ b/www/assets/css/educator.scss
@@ -62,7 +62,6 @@
 
   #cadogan-quote h2 {
     letter-spacing: 0 !important;
-    font-size: 2.2rem;
     max-width: 80%;
     margin: 0 auto;
   }

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -19,7 +19,6 @@ $searchbox-height: 50px;
 
 .view-all-link {
   color: $blue;
-  font-size: 16px;
 }
 
 .home-banner {
@@ -64,7 +63,6 @@ $searchbox-height: 50px;
 
       .discover {
         color: white;
-        font-size: 16px;
       }
 
       div {
@@ -87,7 +85,6 @@ $searchbox-height: 50px;
 
         button,
         a {
-          font-size: 16px;
           border: none;
         }
 
@@ -121,7 +118,7 @@ $searchbox-height: 50px;
           width: 50px;
           color: white;
           text-align: center;
-          font-size: 14px;
+          font-size: 0.875rem;
         }
 
         a.explore {
@@ -150,13 +147,11 @@ $searchbox-height: 50px;
 
       span {
         color: white;
-        font-size: 16px;
       }
 
       a {
         text-decoration: underline;
         color: $link-blue;
-        font-size: 16px;
       }
     }
 
@@ -166,30 +161,22 @@ $searchbox-height: 50px;
       flex-shrink: 0;
 
       .unlocking {
-        font-size: 28px;
         text-transform: uppercase;
         line-height: 40px;
 
         @include media-breakpoint-down(sm) {
-          font-size: 20px;
           line-height: 22px;
         }
       }
 
       .free {
-        font-size: 16px;
         line-height: 19px;
-
-        @include media-breakpoint-down(sm) {
-          font-size: 16px;
-          line-height: 19px;
-        }
       }
 
       .learn-more {
         text-transform: uppercase;
-        font-size: 15px;
         padding-top: 10px;
+        font-size: 1rem;
       }
     }
   }
@@ -236,10 +223,6 @@ $searchbox-height: 50px;
       padding: $spacer3 $spacer5;
     }
 
-    h1 {
-      font-size: 28px;
-    }
-
     img {
       height: 30px;
     }
@@ -266,7 +249,7 @@ $searchbox-height: 50px;
   .social-card {
     .h5 {
       padding-bottom: $spacer1;
-      font-size: 16px;
+      
     }
 
     .social-icon-row {
@@ -318,16 +301,10 @@ $searchbox-height: 50px;
 
   .course-card {
     border: 1px solid $medium-gray;
-
     $radius: 10px;
-
     border-radius: $radius;
     height: 381px;
     width: 100%;
-
-    h5 {
-      font-size: 16px;
-    }
 
     img {
       width: 100%;
@@ -342,7 +319,7 @@ $searchbox-height: 50px;
     }
 
     .course-card-content {
-      font-size: 12px;
+      font-size: 0.75rem;
 
       .card-label {
         color: $dark-gray;
@@ -367,7 +344,7 @@ $searchbox-height: 50px;
     background-size: cover;
 
     .name {
-      font-size: 20px;
+      font-size: 1.25rem;
     }
 
     .occupation-location {
@@ -379,10 +356,7 @@ $searchbox-height: 50px;
     }
 
     .name-occ {
-      .name {
-        font-size: 16px;
-      }
-
+    
       .occupation-location {
         font-size: 14px;
         text-overflow: ellipsis;

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -118,7 +118,7 @@ $searchbox-height: 50px;
           width: 50px;
           color: white;
           text-align: center;
-          font-size: 0.875rem;
+          font-size: $font-sm;
         }
 
         a.explore {
@@ -176,7 +176,6 @@ $searchbox-height: 50px;
       .learn-more {
         text-transform: uppercase;
         padding-top: 10px;
-        font-size: 1rem;
       }
     }
   }
@@ -249,7 +248,6 @@ $searchbox-height: 50px;
   .social-card {
     .h5 {
       padding-bottom: $spacer1;
-      
     }
 
     .social-icon-row {
@@ -270,12 +268,7 @@ $searchbox-height: 50px;
     .newsletter-form {
       .btn {
         background-color: $highlight-red;
-        font-size: 0.75rem;
-
-        @include media-breakpoint-down(md) {
-          font-size: 1rem;
-          font-weight: bold;
-        }
+        font-weight: bold;
       }
 
       @include media-breakpoint-down(lg) {
@@ -319,7 +312,7 @@ $searchbox-height: 50px;
     }
 
     .course-card-content {
-      font-size: 0.75rem;
+      font-size: $font-xs;
 
       .card-label {
         color: $dark-gray;
@@ -344,21 +337,17 @@ $searchbox-height: 50px;
     background-size: cover;
 
     .name {
-      font-size: 1.25rem;
-    }
-
-    .occupation-location {
-      font-size: 18px;
+      font-size: $font-lg;
     }
 
     .on-hover {
       display: none;
     }
 
+    // class not found
     .name-occ {
-    
       .occupation-location {
-        font-size: 14px;
+        font-size: $font-sm;
         text-overflow: ellipsis;
         overflow: hidden;
       }
@@ -379,7 +368,7 @@ $searchbox-height: 50px;
     align-items: end;
 
     a {
-      font-size: 20px;
+      font-size: $font-lg;
       line-height: 24px;
       font-weight: bold;
     }
@@ -436,7 +425,7 @@ $promo-carousel-height: 200px;
   a {
     cursor: pointer;
     .material-icons {
-      font-size: 60px;
+      font-size: 3.75rem;
       font-weight: 200;
       color: $dark-gray;
     }
@@ -505,16 +494,6 @@ $promo-carousel-height: 200px;
 
     .promo-info {
       width: 70%;
-
-      @include media-breakpoint-down(sm) {
-        h2 {
-          font-size: 20px;
-        }
-
-        h3 {
-          font-size: 18px;
-        }
-      }
 
       @include media-breakpoint-down(xs) {
         width: 100%;

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -344,7 +344,6 @@ $searchbox-height: 50px;
       display: none;
     }
 
-    // class not found
     .name-occ {
       .occupation-location {
         font-size: $font-sm;

--- a/www/assets/css/learning-resource-card.scss
+++ b/www/assets/css/learning-resource-card.scss
@@ -106,14 +106,14 @@
       flex-direction: column;
 
       &.lr-subheader {
-        font-size: 16px;
+        font-size: $font-normal;
       }
 
       .subtitle {
         margin-bottom: 5px;
 
         .lr-subtitle {
-          font-size: 14px;
+          font-size: $font-sm;
           width: 100%;
           display: flex;
 
@@ -142,7 +142,7 @@
 
     &.resource-type-audience-certificates {
       .resource-type {
-        font-size: 14px;
+        font-size: $font-sm;
         color: $dark-gray;
         text-transform: uppercase;
         font-weight: 400;
@@ -158,7 +158,7 @@
       margin: 10px 0;
       margin-top: 2px;
       min-height: 62px;
-      font-size: 18px;
+      font-size: $font-md;
       color: black;
       font-weight: 500;
       cursor: pointer;
@@ -169,12 +169,12 @@
       margin-top: 25px;
 
       .start-date {
-        font-size: 12px;
+        font-size: $font-xs;
         padding-right: 10px;
         cursor: default;
 
         i {
-          font-size: 12px;
+          font-size: $font-xs;
           margin-right: 4px;
           padding: 2px;
         }
@@ -187,7 +187,7 @@
 
         i {
           color: $blue;
-          font-size: 14px;
+          font-size: $font-sm;
           padding: 2px;
         }
       }

--- a/www/assets/css/learning-resource-icon.scss
+++ b/www/assets/css/learning-resource-icon.scss
@@ -11,7 +11,7 @@
     text-align: center;
     border-radius: 6px;
     padding: 5px 0;
-    font-size: 12px;
+    font-size: $font-xs;
 
     position: absolute;
     z-index: 1;

--- a/www/assets/css/newsletter.scss
+++ b/www/assets/css/newsletter.scss
@@ -1,10 +1,9 @@
 #mc_embed_signup {
   background: #fff;
   clear: left;
-  font: 14px Helvetica, Arial, sans-serif;
 
-  h1 {
-    font-size: 24px;
+  h2 {
+    font-size: $heading-two-font-lg !important;
   }
 
   form {
@@ -16,7 +15,7 @@
 
   label {
     margin-bottom: 11px !important;
-    font-size: 16px !important;
+    font-size: $font-normal !important;
   }
 
   input:not([type="submit"]) {
@@ -43,7 +42,7 @@
     height: 58px !important;
     width: 40% !important;
     max-width: 211px !important ;
-    font-size: 18px !important;
+    font-size: $font-md !important;
     font-weight: bold !important;
 
     @include media-breakpoint-down(sm) {

--- a/www/assets/css/search-filter.scss
+++ b/www/assets/css/search-filter.scss
@@ -35,7 +35,7 @@
 }
 
 .filter-section-title {
-  font-size: 18px;
+  font-size: $font-md;
   font-weight: 600;
   margin-bottom: 10px;
   cursor: pointer;
@@ -67,7 +67,7 @@
     flex-direction: row;
     align-items: center;
     height: 25px;
-    font-size: 14px;
+    font-size: $font-sm;
     margin-right: 6px;
     cursor: pointer;
 
@@ -100,7 +100,7 @@
   .facet-more-less {
     cursor: pointer;
     color: $search-gray;
-    font-size: 14px;
+    font-size: $font-sm;
     text-align: right;
   }
 }
@@ -116,7 +116,7 @@
   margin-bottom: 10px;
 
   .clear-all-filters {
-    font-size: 18px;
+    font-size: $font-md;
     color: $blue;
     font-weight: normal;
     text-decoration: underline;
@@ -126,7 +126,7 @@
     margin: 0px 5px 9px 0px;
     background-color: $light-gray;
     padding: 6px 10px;
-    font-size: 14px;
+    font-size: $font-sm;
     display: inline-flex;
     align-items: center;
     flex-wrap: nowrap;
@@ -139,7 +139,7 @@
       cursor: pointer;
 
       i {
-        font-size: 18px;
+        font-size: $font-md;
       }
     }
   }

--- a/www/assets/css/search.scss
+++ b/www/assets/css/search.scss
@@ -21,18 +21,18 @@
       font-weight: bold;
     }
 
-    font-size: 1rem;
+    font-size: $font-normal;
     text-decoration: none !important;
     text-transform: uppercase;
   }
 
   .search-box-description {
-    font-size: 1rem;
+    font-size: $font-normal;
     letter-spacing: 0.8px;
   }
 
   .results-total {
-    font-size: 14px;
+    font-size: $font-sm;
   }
 
   form.search-box {
@@ -51,7 +51,7 @@
       border-radius: 0 5px 5px 0;
       color: white;
       font-weight: bold;
-      font-size: 1rem;
+      font-size: $font-normal;
     }
   }
 
@@ -91,10 +91,6 @@
         padding: 13px;
       }
     }
-
-    h1 {
-      font-size: 34px;
-    }
   }
 
   .search-toggle {
@@ -130,7 +126,7 @@
       i {
         margin-right: 18px;
         margin-top: 18px;
-        font-size: 33px;
+        font-size: 2rem;
         cursor: pointer;
       }
     }
@@ -140,7 +136,7 @@
 
       button {
         width: 100%;
-        font-size: 20px;
+        font-size: $font-lg;
       }
     }
   }
@@ -149,10 +145,10 @@
     display: flex;
     align-items: center;
     cursor: pointer;
-    font-size: 16px;
+    font-size: $font-normal;
 
     i.material-icons {
-      font-size: 36px;
+      font-size: 2.25rem;
     }
   }
 

--- a/www/assets/css/testimonials.scss
+++ b/www/assets/css/testimonials.scss
@@ -4,8 +4,6 @@ $row-max-height: 200px;
 
 .testimonial-section,
 .testimonial-single {
-  font-size: 16px;
-
   .full-testimonial {
     border-bottom: $border-style;
   }
@@ -43,11 +41,7 @@ $row-max-height: 200px;
       height: 100%;
       width: 100%;
       content: "";
-      background: linear-gradient(
-        to top,
-        rgba(255, 255, 255, 1) 0%,
-        rgba(255, 255, 255, 0) 10%
-      );
+      background: linear-gradient(to top, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 10%);
       pointer-events: none; /* so the text is still selectable */
     }
 
@@ -63,7 +57,7 @@ $row-max-height: 200px;
 
 .testimonial-single {
   .summary {
-    font-size: 20px;
+    font-size: $font-lg;
     font-weight: 600;
     font-style: italic;
     color: $medium-gray;

--- a/www/assets/css/testimonials.scss
+++ b/www/assets/css/testimonials.scss
@@ -41,7 +41,11 @@ $row-max-height: 200px;
       height: 100%;
       width: 100%;
       content: "";
-      background: linear-gradient(to top, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 10%);
+      background: linear-gradient(
+        to top,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 0) 10%
+      );
       pointer-events: none; /* so the text is still selectable */
     }
 

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -452,7 +452,7 @@
       <div class="row">
         <div class="col-12">
           <div class="text-center">
-            <h1 class="font-cardo-italic mx-auto pb-7">
+            <h1 class="font-cardo-bold mx-auto pb-7">
               A Message from the Dean
             </h1>
             <iframe

--- a/www/layouts/home.html
+++ b/www/layouts/home.html
@@ -54,11 +54,11 @@
       </div>
     </div>
     <div class="unlock d-flex flex-column py-4 px-4 px-sm-7 m-2">
-      <h1 class="unlocking font-weight-bold text-white">
+      <h2 class="unlocking font-weight-bold text-white">
         Unlocking knowledge,
         <br />
         Empowering Minds.
-      </h1>
+      </h2>
       <span class="text-white free pt-3">
         Free lecture notes, exams, and videos from MIT.<br>No registration required.
       </span>

--- a/www/layouts/newsletter/section.html
+++ b/www/layouts/newsletter/section.html
@@ -29,7 +29,7 @@
       novalidate
     >
       <div id="mc_embed_signup_scroll">
-        <h1>Be informed</h1>
+        <h2>Be informed</h2>
         <div class="indicates-required">
           <span class="asterisk">*</span> indicates required
         </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/472

#### What's this PR do?
- Cleans up almost all font sizes.
- Root `font size` set to `16px`
- Font sizes variables created (`font-lg`, `font-md`) with `REM` values.
- Above created variables are used/re-used wherever required.
- Few font-sizes with `16px` value have been removed as they will inherit root's font size which is already `16px`.
- Few other tweaks in CSS to maintain font-sizes uniformity across the app (though there are still places which can be improved too)

#### How should this be manually tested?
- This might not sound good for the tester :) but all the **sections** on all the **pages** of **www** and **courses** need to be tested and verified that `font-size` content is clean, smooth, and consistent. 
- Verify that all the content of **www** and **courses** is looking fine and easy to read with respect to consistent `font-size`.
- [Preview netlify app here](https://ocw-hugo-themes-pr-474--ocw-next.netlify.app/) which can be compared with [ocwnext RC](https://ocwnext-rc.odl.mit.edu/)

