### PR TITLE
return relative url for course images

### DIFF
--- a/course/layouts/index.coursedata.json
+++ b/course/layouts/index.coursedata.json
@@ -1,5 +1,7 @@
 {{- $courseData := .Site.Data.course -}}
+{{- $courseImageUrl := index (partial "course-image-url.html" .) 0 -}}
 {{- $courseImageMetadata := index (partial "course-image-url.html" .) 1 -}}
+
 {
   "course_title": {{- $courseData.course_title | jsonify -}},
   "course_description": {{- $courseData.course_description | jsonify -}},
@@ -31,7 +33,7 @@
   "term":  {{- $courseData.term | jsonify -}},
   "year":  {{- $courseData.year | jsonify -}},
   "level":  {{- $courseData.level | jsonify -}},
-  "image_src": {{- $courseImageMetadata.Params.file | jsonify -}},
+  "image_src": {{- $courseImageUrl | jsonify -}},
   "course_image_metadata": {{- $courseImageMetadata.Params | jsonify -}}
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3513

#### What's this PR do?
Course images are broken in search because they point to an s3 folder that has changed. This changes the image_src for the course to point to a relative url.

#### How should this be manually tested?
run `npm run start:course` for any course

Go to http://localhost:3000/data.json

Verify that the image_src is a relative url, for example "/7-01sc-fundamentals-of-biology-fall-2011/533499c2943939be949d7aed93782793_7-01scf11.jpg"



