### PR TITLE
fix: removing extra whitespace in sub and sup shortcodes

### DIFF
--- a/base-theme/layouts/shortcodes/sub.html
+++ b/base-theme/layouts/shortcodes/sub.html
@@ -1,1 +1,1 @@
-<sub>{{ .Get 0 | markdownify }}</sub>
+<sub>{{- .Get 0 | markdownify -}}</sub>{{- "" -}}

--- a/base-theme/layouts/shortcodes/sup.html
+++ b/base-theme/layouts/shortcodes/sup.html
@@ -1,1 +1,1 @@
-<sup>{{ .Get 0 | markdownify }}</sup>
+<sup>{{- .Get 0 | markdownify -}}</sup>{{- "" -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/461

#### What's this PR do?
- Following is done for `sub` and `sup` shortcodes: 
    - Adds `-` with `{{` and `}}` to remove the extra white space, if any, surrounding the variable. ([reference](https://gohugo.io/templates/introduction/#whitespace))
    - Adds `{{- "" -}}` to remove the whitespace caused by `sub` and `sup` html elements. ([reference](https://discourse.gohugo.io/t/solved-extra-space-after-shortcode-output/6736/4))

#### How should this be manually tested?
- Go to any course which has `sub` or `sup` shortcode. 
- Verify that there is no extra whitespace.

#### Screenshots (if appropriate)
Before: 
![image](https://user-images.githubusercontent.com/93309234/155683353-ddb2e8c5-4ec8-416e-88e7-a4136a5968bb.png)

![image](https://user-images.githubusercontent.com/93309234/155683378-c7d69391-8920-44da-ab60-440dc0ac44f8.png)


After: 
![image](https://user-images.githubusercontent.com/93309234/155683272-431e1815-b621-4359-aab0-ae1cbb384387.png)

![image](https://user-images.githubusercontent.com/93309234/155683303-d8aea093-c728-4e53-bdaa-b98cef455a7d.png)

