### PR TITLE
fixed spacing issue with h3

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -80,6 +80,10 @@ h3 {
   color: $black;
 }
 
+a + h3 {
+  margin-top: 1rem;
+}
+
 @include media-breakpoint-down(xs) {
   h3 {
     font-size: 18px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #479

#### What's this PR do?
Adds margin top to headings immediately followed by an anchor tag.

#### How should this be manually tested?
Verify spacing around h3 is consistent

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2022-02-25 at 4 24 24 PM" src="https://user-images.githubusercontent.com/87968618/155707661-bfc37165-e8b7-47ed-a039-813868c28a29.png">
<img width="1440" alt="Screenshot 2022-02-25 at 4 24 39 PM" src="https://user-images.githubusercontent.com/87968618/155707703-04627690-ecdb-4423-8b43-cbff4cdd4410.png">

