### PR TITLE
change resource_link to be a markdown based shortcode

### DIFF
--- a/base-theme/layouts/shortcodes/resource_link.html
+++ b/base-theme/layouts/shortcodes/resource_link.html
@@ -2,5 +2,5 @@
 {{- $title := index .Params 1 -}}
 {{- $anchor_id := index .Params 2 | default ""}}
 {{- range where $.Site.Pages "Params.uid" $uuid -}}
-    <a href="{{- .Permalink -}}{{- $anchor_id -}}">{{ $title }}</a>
+    [{{ $title }}]({{- .Permalink -}}{{- $anchor_id -}})
 {{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-studio/issues/1066

#### What's this PR do?
This PR changes the `resource_link.html` to return a markdown link instead of an HTML link.

#### How should this be manually tested?
This should be tested as part of [this PR](https://github.com/mitodl/ocw-studio/pull/1067)
