### PR TITLE
Added course collection filter based on Title

### DIFF
--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -1,10 +1,10 @@
 ---
 renderSearchIcon: false
 homePageCourseCollectionsUrls:
-- /pages/introductory-programming 
-- /pages/open-learning-library/
-- /pages/open-learning-library/
-- /pages/open-learning-library/
-- /pages/open-learning-library/
-- /pages/open-learning-library/
+- /pages/open-learning-library
+- /pages/introductory-programming
+- /pages/energy
+- /pages/entrepreneurship
+- /pages/environment
+- /pages/transportation
 ---

--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -1,11 +1,10 @@
 ---
 renderSearchIcon: false
-homePageCourseCollections:
-- Open Learning Library
-- Intro Programming
-- Energy
-- Entrepreneurship
-- Environment
-- Life Sciences
-- Transportation 
+homePageCourseCollectionsUrls:
+- /pages/introductory-programming 
+- /pages/open-learning-library/
+- /pages/open-learning-library/
+- /pages/open-learning-library/
+- /pages/open-learning-library/
+- /pages/open-learning-library/
 ---

--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -1,3 +1,11 @@
 ---
 renderSearchIcon: false
+homePageCourseCollections:
+- Open Learning Library
+- Intro Programming
+- Energy
+- Entrepreneurship
+- Environment
+- Life Sciences
+- Transportation 
 ---

--- a/www/layouts/partials/home_course_collections.html
+++ b/www/layouts/partials/home_course_collections.html
@@ -6,12 +6,14 @@
       collections. Below are some topics available for you to explore:
     </p>
     <div class="course-collection-section d-flex flex-row m-0 flex-wrap">
-      {{ range where .Site.Pages "Type" "course_collections" | intersect (where .Site.Pages "Title" "in" .Params.homePageCourseCollections)}}
-      <a href="{{.Permalink}}">
-        <div class="collection-item">
-          <p>{{.Title}}</p>
-        </div>
-      </a>
+      {{ range $url := .Params.homePageCourseCollectionsUrls}}
+        {{ with $.Site.GetPage $url }}
+          <a href="{{ .Permalink }}">
+            <div class="collection-item">
+              <p>{{ .Title }}</p>
+            </div>
+          </a>
+        {{ end }}
       {{ end }}
     </div>
   </div>

--- a/www/layouts/partials/home_course_collections.html
+++ b/www/layouts/partials/home_course_collections.html
@@ -6,7 +6,7 @@
       collections. Below are some topics available for you to explore:
     </p>
     <div class="course-collection-section d-flex flex-row m-0 flex-wrap">
-      {{ range where .Site.Pages "Type" "course_collections" }}
+      {{ range where .Site.Pages "Type" "course_collections" | intersect (where .Site.Pages "Title" "in" .Params.homePageCourseCollections)}}
       <a href="{{.Permalink}}">
         <div class="collection-item">
           <p>{{.Title}}</p>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
   - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #486 

#### What's this PR do?
Adds relevant filter in course collection partial

#### How should this be manually tested?
Verify the following
- All course collection available in ocw-www content are filtered based on `homePageCourseCollections`  param
- If a collection exists in ocw-www content but the title is not in `homePageCourseCollections` it is not rendered

#### Screenshots (if appropriate)
<img width="1425" alt="Screenshot 2022-02-28 at 5 00 15 PM" src="https://user-images.githubusercontent.com/87968618/155980502-35db5271-9acd-43c9-9eb3-284854da2780.png">

