### PR TITLE
feat: Home SEO

### DIFF
--- a/base-theme/layouts/partials/footer.html
+++ b/base-theme/layouts/partials/footer.html
@@ -6,7 +6,7 @@
         href="https://openlearning.mit.edu/"
         target="_blank"
       >
-        <img src="/images/mit-ol.png" alt="" />
+        <img src="/images/mit-ol.png" alt="MIT Open Learning" />
       </a>
     </div>
     <div
@@ -40,7 +40,7 @@
       <p class="font-weight-bold">
         PROUD MEMBER OF :
         <a href="https://www.oeglobal.org/" target="_blank"
-          ><img class="oeg-logo" src="/images/oeg_logo.png" alt=""
+          ><img class="oeg-logo" src="/images/oeg_logo.png" alt="Open Education Global"
         /></a>
       </p>
     </div>

--- a/base-theme/layouts/partials/footer.html
+++ b/base-theme/layouts/partials/footer.html
@@ -6,7 +6,7 @@
         href="https://openlearning.mit.edu/"
         target="_blank"
       >
-        <img src="/images/mit-ol.png" />
+        <img src="/images/mit-ol.png" alt="" />
       </a>
     </div>
     <div
@@ -40,7 +40,7 @@
       <p class="font-weight-bold">
         PROUD MEMBER OF :
         <a href="https://www.oeglobal.org/" target="_blank"
-          ><img class="oeg-logo" src="/images/oeg_logo.png"
+          ><img class="oeg-logo" src="/images/oeg_logo.png" alt=""
         /></a>
       </p>
     </div>

--- a/base-theme/layouts/partials/head.html
+++ b/base-theme/layouts/partials/head.html
@@ -1,4 +1,6 @@
 {{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
+{{- $metaDataDescription := "MIT OpenCourseWare is a web-based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
+{{- $metaDataKeywords := "MIT, OpenCourseWare, OCW, MIT activity, Online Education" -}}
 <head>
   {{ block "extrahead" . }}{{ end }}
   {{ if $gtmId }}
@@ -11,8 +13,25 @@
     <!-- End Google Tag Manager -->
   {{ end }}
   <meta charset="utf-8">
+  <meta name="description" content="{{- $metaDataDescription -}}">
+  <meta name="keywords" content="{{- $metaDataKeywords -}}">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   {{ block "title" . }}{{ end }}
+  <!-- [start] Google structured data -->
+  <script type="application/ld+json">
+    {
+      "@context": "http://schema.org/",
+      "@type" : "WebPage",
+      "name": "MIT OpenCourseWare",
+      "description": "{{- $metaDataDescription -}}",
+      "license": "http://creativecommons.org/licenses/by-nc-sa/4.0/", 
+      "publisher": {
+        "@type": "CollegeOrUniversity",
+        "name": "MIT OpenCourseWare"
+       }
+    }
+  </script>
+  <!-- [end] Google structured data -->
   {{ $theme := .Site.Data.webpack.main }}
   <link href="{{ partial "webpack_url.html" $theme.css }}" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">

--- a/base-theme/layouts/partials/head.html
+++ b/base-theme/layouts/partials/head.html
@@ -1,6 +1,5 @@
 {{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
-{{- $metaDataDescription := "MIT OpenCourseWare is a web-based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
-{{- $metaDataKeywords := "MIT, OpenCourseWare, OCW, MIT activity, Online Education" -}}
+
 <head>
   {{ block "extrahead" . }}{{ end }}
   {{ if $gtmId }}
@@ -13,25 +12,9 @@
     <!-- End Google Tag Manager -->
   {{ end }}
   <meta charset="utf-8">
-  <meta name="description" content="{{- $metaDataDescription -}}">
-  <meta name="keywords" content="{{- $metaDataKeywords -}}">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  {{ block "seo" . }}{{ end }}
   {{ block "title" . }}{{ end }}
-  <!-- [start] Google structured data -->
-  <script type="application/ld+json">
-    {
-      "@context": "http://schema.org/",
-      "@type" : "WebPage",
-      "name": "MIT OpenCourseWare",
-      "description": "{{- $metaDataDescription -}}",
-      "license": "http://creativecommons.org/licenses/by-nc-sa/4.0/", 
-      "publisher": {
-        "@type": "CollegeOrUniversity",
-        "name": "MIT OpenCourseWare"
-       }
-    }
-  </script>
-  <!-- [end] Google structured data -->
   {{ $theme := .Site.Data.webpack.main }}
   <link href="{{ partial "webpack_url.html" $theme.css }}" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">

--- a/base-theme/layouts/partials/seo.html
+++ b/base-theme/layouts/partials/seo.html
@@ -1,0 +1,25 @@
+{{ define "seo" }}
+  <!-- these are the default values of metadata description and keywords -->
+  {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web-based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
+  {{- $defaultMetadataKeywords := "opencourseware,MIT OCW,courseware,MIT opencourseware,Free Courses,class notes,class syllabus,class materials,tutorials,online courses,MIT courses" -}}
+  
+  {{- $metaDataDescription := .Params.metadataDescription | default $defaultMetadataDescription -}}
+  {{- $metaDataKeywords := .Params.metadataKeywords | default $defaultMetadataKeywords -}}
+
+  <meta name="description" content="{{- $metaDataDescription -}}">
+  <meta name="keywords" content="{{- $metaDataKeywords -}}">
+
+  <script type="application/ld+json">
+      {
+        "@context": "http://schema.org/",
+        "@type" : "WebPage",
+        "name": "MIT OpenCourseWare",
+        "description": "{{- $metaDataDescription -}}",
+        "license": "http://creativecommons.org/licenses/by-nc-sa/4.0/", 
+        "publisher": {
+          "@type": "CollegeOrUniversity",
+          "name": "MIT OpenCourseWare"
+        }
+      }
+  </script>
+{{ end }}

--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -1,10 +1,12 @@
 ---
 renderSearchIcon: false
 homePageCourseCollectionsUrls:
-- /pages/open-learning-library
-- /pages/introductory-programming
-- /pages/energy
-- /pages/entrepreneurship
-- /pages/environment
-- /pages/transportation
+  - /pages/open-learning-library
+  - /pages/introductory-programming
+  - /pages/energy
+  - /pages/entrepreneurship
+  - /pages/environment
+  - /pages/transportation
+metaDataDescription: MIT OpenCourseWare is a web-based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity
+metadataKeywords: opencourseware,MIT OCW,courseware,MIT opencourseware,Free Courses,class notes,class syllabus,class materials,tutorials,online courses,MIT courses
 ---

--- a/www/layouts/home.html
+++ b/www/layouts/home.html
@@ -9,7 +9,7 @@
   <div class="banner-contents-container mx-auto d-flex justify-content-start justify-content-md-around w-100 align-items-center h-100">
     <div class="first-column m-md-2 d-flex flex-column">
       <div class="discover font-weight-bold pb-2 md-and-above-only">
-        Discover courses, materials, &amp; teaching resources
+        HelloDiscover courses, materials, &amp; teaching resources
       </div>
       <div class="w-100 d-flex align-items-center search-box-wrapper">
         <form action="/search" method="GET" class="home-search-box">

--- a/www/layouts/home.html
+++ b/www/layouts/home.html
@@ -9,7 +9,7 @@
   <div class="banner-contents-container mx-auto d-flex justify-content-start justify-content-md-around w-100 align-items-center h-100">
     <div class="first-column m-md-2 d-flex flex-column">
       <div class="discover font-weight-bold pb-2 md-and-above-only">
-        HelloDiscover courses, materials, &amp; teaching resources
+        Discover courses, materials, &amp; teaching resources
       </div>
       <div class="w-100 d-flex align-items-center search-box-wrapper">
         <form action="/search" method="GET" class="home-search-box">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/351

#### What's this PR do?
- Creates a block in `head`
- Creates a partial (`seo.html`) in base-theme.
- Defines the block in this partial and the following are added:
    - Metadata description and keywords added.
    - Google structured data added.
- Default value of description and keywords is defined in the partial in case they are not found in page params
- `metadataDescription` and `metadataKeywords` can be defined in content of different pages so metadata is different for different pages
- Adds alt text for some images

#### How should this be manually tested?
Verify the following: 
- [ ] Title Element: `MIT OpenCourseWare | Free Online Course Materials` 
- [ ] meta description: `MIT OpenCourseWare is a web-based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity.`
- [ ] alt text for image ocw_logo_white.png => "MIT OpenCourseWare"
- [ ] alt text for image /images/envelope.svg => "" (i.e. it's decorative)
- [ ] Since it looks like the sponsors will be hard-coded, we should give them each an alt tag with the corporate name. 
- [ ] Add structured data (see [results of structured data tool](https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Focwnext.odl.mit.edu%2F))
- [ ] Test the results with Lighthouse
