### PR TITLE
CSS fix for errant empty paragraphs in table cells

### DIFF
--- a/course/assets/css/course-content.scss
+++ b/course/assets/css/course-content.scss
@@ -8,6 +8,13 @@
   height: 5.7em;
 }
 
+th,
+td {
+  > p:empty {
+    display: none;
+  }
+}
+
 td {
   h3 {
     font-weight: normal !important;


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

see https://github.com/mitodl/ocw-studio/issues/1074

#### What's this PR do?

I just merged a chance in studio which will result in some empty paragraph tags when content is rendered in Hugo. This just sets some CSS to put `display: none` on those tags.

#### How should this be manually tested?

Use Studio to create a table w/ some content w/ line breaks inside of table cells. Then render that content as course content over here and make sure that

1. there are some empty `<p>` tags inside of the table cells (just ensuring that things are working as I expect)
2. they all have `display: none` set on them and therefore don't cause any layout issues

If you like you can also confirm that on the main branch they currently _do_ cause some spacing issues.