### PR TITLE
update code block style to work w/ hugo's syntax highlighting support

### DIFF
--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -38,8 +38,6 @@ $transparency-gray-light: rgba(246, 246, 246, 0.71);
 // course pages
 $course-content-link-unclicked: #115f83;
 $course-content-link-hover-clicked: #355b6b;
-$one-liner-code: #333;
-$code-block-background: #eeeeee;
 
 // about page
 $timeline-spacing: 128px;

--- a/course/assets/css/course.scss
+++ b/course/assets/css/course.scss
@@ -72,13 +72,7 @@ div[class^="reveal"],
   margin: 10px;
 }
 
-code {
-  color: $one-liner-code !important;
-  font-family: Courier New, Courier !important;
-}
-
 pre {
-  padding: 15px 0px 15px 15px !important;
-  background-color: $code-block-background !important;
-  border: thin dotted $highlight-red !important;
+  padding: 10px;
+  border: 1px solid $medium-gray;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #500 

#### What's this PR do?

Just set things up so we can lean on Hugo's built in syntax highlighting support. I basically removed our stuff setting background colors and whatnot, and adding a simple border w/ even padding around `pre` tags. I think it makes it super clear where a code block starts and ends.

#### How should this be manually tested?

This needs to be paired with a config change, over here: https://github.com/mitodl/ocw-hugo-projects/pull/136

You can try rendering some markdown that you create manually, or you can try with CKEditor's output by checking out htis PR: https://github.com/mitodl/ocw-studio/pull/1088 

#### Screenshots (if appropriate)

Here are examples for a few different programming languages:

<img width="578" alt="Screen Shot 2022-03-04 at 12 11 58 PM" src="https://user-images.githubusercontent.com/6207644/156809920-6556289d-4190-4437-96e4-5e4742dce2e4.png">

_**note**: the actually display for the text inside the `<code>` tags will depend on what fonts are available on your environment - the screenshot above is firefox on macOS_
