### PR TITLE
Better search results for course numbers

### DIFF
--- a/www/assets/js/lib/search.test.tsx
+++ b/www/assets/js/lib/search.test.tsx
@@ -56,6 +56,15 @@ describe("search library", () => {
           }
         },
         {
+          wildcard: {
+            coursenum: {
+              boost:   100,
+              rewrite: "constant_score",
+              value:   "DOGS ARE THE BEST*"
+            }
+          }
+        },
+        {
           nested: {
             path:  "runs",
             query: {

--- a/www/assets/js/lib/search.ts
+++ b/www/assets/js/lib/search.ts
@@ -88,7 +88,6 @@ const COURSE_QUERY_FIELDS = [
   "topics",
   "platform",
   "course_id",
-  "coursenum^5",
   "offered_by",
   "department_name",
   "course_feature_tags"
@@ -190,6 +189,15 @@ export const buildSearchQuery = ({
               },
               type === LearningResourceType.Course
                 ? [
+                    {
+                      wildcard: {
+                        coursenum: {
+                          value: `${text.toUpperCase()}*`,
+                          boost: 100.0,
+                          rewrite: "constant_score"
+                        }
+                      }
+                    },
                     {
                       nested: {
                         path: "runs",

--- a/www/assets/js/lib/search.ts
+++ b/www/assets/js/lib/search.ts
@@ -187,17 +187,17 @@ export const buildSearchQuery = ({
                   fields: searchFields(type as LearningResourceType)
                 }
               },
+              {
+                wildcard: {
+                  coursenum: {
+                    value: `${text.toUpperCase()}*`,
+                    boost: 100.0,
+                    rewrite: "constant_score"
+                  }
+                }
+              },
               type === LearningResourceType.Course
                 ? [
-                    {
-                      wildcard: {
-                        coursenum: {
-                          value: `${text.toUpperCase()}*`,
-                          boost: 100.0,
-                          rewrite: "constant_score"
-                        }
-                      }
-                    },
                     {
                       nested: {
                         path: "runs",


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #506 
Closes #507 

#### What's this PR do?
Modifies the elasticsearch query parameters to give better results when the query text is a course number.

#### How should this be manually tested?
- Set  `SEARCH_API_URL=https://discussions-rc.odl.mit.edu/api/v0/search/` in your .env file and then `source .env`
- [Start Chrome with CORS disabled](https://alfilatov.com/posts/run-chrome-without-cors/).
- Run `npm run start:www`
- All these queries should return three 6.042J courses as the top results:
  - http://localhost:3000/search/?q=6.042
  - http://localhost:3000/search/?q=6.042j
  - http://localhost:3000/search/?q=6.042J
- These queries should return courses starting with `WGS.<x>` as the top results: 
  - http://localhost:3000/search/?q=wgs.1
  - http://localhost:3000/search/?q=WGS.1
  - http://localhost:3000/search/?q=wgs.6
- Other queries that don't resemble course numbers should return results as before, for example:
  - http://localhost:3000/search/?q=mechanical%20engineers
  - http://localhost:3000/search/?q="mechanical%20engineers"


#### Any background context you want to provide?
I originally tried changing the elasticsearch index type for `coursenum` from `keyword` (case sensitive) to `text` in open-discussions.  This solved #507 but just marginally improved #506.   Adding a separate wildcard query parameter for `coursenum` using the uppercase version of the text seems to solve both problems.


