### PR TITLE
remove description from video-gallery partial

### DIFF
--- a/course/layouts/partials/video-gallery.html
+++ b/course/layouts/partials/video-gallery.html
@@ -1,9 +1,4 @@
 {{- $ctx := . -}}
-{{ if isset .Params "description" }}
-<div class="pb-5">
-{{ $ctx.RenderString .Params.description }}
-</div>
-{{ end }}
 {{- range .Params.videos.content -}}
   {{- $uuid := . -}}
   {{- range $ctx.Site.Pages -}}


### PR DESCRIPTION
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets? https://github.com/mitodl/ocw-studio/issues/1080

#### What's this PR do?
We use the markdown body for descriptions, not the description field. This is safe to remove:

- there were 9 video galleries with descriptions on RC, all in test courses... I moved them all markdown body via admin panel.
- there are 0 video galleries with descriptions on prod (of 218 video galleries)

#### How should this be manually tested?
Open a video gallery and check that it still works.

For example, http://localhost:3000/video_galleries/derivatives/ in `res.18-005-spring-2010`. But any video gallery would do.
