### PR TITLE
display &nbsp in quotes correctly

### DIFF
--- a/base-theme/layouts/shortcodes/quote.html
+++ b/base-theme/layouts/shortcodes/quote.html
@@ -5,8 +5,8 @@
 {{ $quoteOpen := "/images/quote_open.png" }}
 {{ $quoteClose := "/images/quote_close.png" }}
 <figure class="quotewrapper py-3">
-  <blockquote class="quote">"{{ .Get 0 }}"</blockquote>
+  <blockquote class="quote">"{{- .Get 0 | markdownify -}}"</blockquote>
   <div class="sigwrapper">
-    <figcaption class="sig">{{ .Get 1 }}</figcaption>
+    <figcaption class="sig">{{- .Get 1 | markdownify -}}</figcaption>
   </div>
 </figure>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
<img width="649" alt="Screen Shot 2022-03-10 at 4 57 42 PM" src="https://user-images.githubusercontent.com/1934992/157761622-3a4bc3c4-88a6-4968-85ef-a6d94a17fe6f.png">

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-studio/issues/1106

#### What's this PR do?
This pr displays &nsbp in the quote shortcodes as a space. This is needed because the ocw-studio editor saves leading spaces in the quote shortcode as `&nsbp` when the page is saved

#### How should this be manually tested?
Update the course_json_examples/example_courses.json file in ocw-to-hugo with
```
    "courses": [
        "15-es718-global-health-innovation-delivering-targeted-advice-to-an-organization-in-the-field-spring-2015"
    ]
```
Run
`node . -i private/input -o private/output -c course_json_examples/example_courses.json --download`

Go to private/output/15-es718-global-health-innovation-delivering-targeted-advice-to-an-organization-in-the-field-spring-2015/content/pages/instructor-insights/teaching-in-real-world-contexts.md

and replace "`  —Dr. Anjali Sastry`" with "`&nbsp;—Dr. Anjali Sastry`" in the two `quote` shortcodes

Set
OCW_TEST_COURSE=15-es718-global-health-innovation-delivering-targeted-advice-to-an-organization-in-the-field-spring-2015
and
COURSE_CONTENT_PATH=<your_path>/ocw-to-hugo/private/output/

in ocw-hugo-themes

Run

`npm run start:course`

go to

http://localhost:3000/pages/instructor-insights/teaching-in-real-world-contexts/

and verify that you don't see `&NBSP;` printed out

