### PR TITLE
add topic to resource search

### DIFF
--- a/www/assets/js/components/SearchPage.test.tsx
+++ b/www/assets/js/components/SearchPage.test.tsx
@@ -180,7 +180,10 @@ describe("SearchPage component", () => {
           text: parameters.text,
           from: 0,
           size: SEARCH_PAGE_SIZE,
-          activeFacets: defaultResourceFacets,
+          activeFacets: {
+            ...defaultResourceFacets,
+            ...{ topics: ["mathematics"] }
+          },
           sort: null
         }
       ]

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -29,7 +29,8 @@ const COURSE_FACETS: FacetManifest = [
 ]
 
 const RESOURCE_FACETS: FacetManifest = [
-  ["resource_type", "Resource Types", true]
+  ["resource_type", "Resource Types", true],
+  ["topics", "Topics", true]
 ]
 
 interface Result {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
<img width="1614" alt="Screen Shot 2022-03-11 at 1 48 17 PM" src="https://user-images.githubusercontent.com/1934992/157933032-97b41020-a4d5-4b1f-9939-c7c8de6bbc3d.png">

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/515

#### What's this PR do?
This PR adds topics as a facet to resource search.

#### How should this be manually tested?
Run `npm run start:www` verify that you see topics as a filter for resources and it works correctly