### PR TITLE
revert PR 388: instructor insights images scaling

### DIFF
--- a/course/assets/css/instructor-insights.scss
+++ b/course/assets/css/instructor-insights.scss
@@ -60,8 +60,4 @@
       user-select: none;
     }
   }
-
-  img {
-    width: 100%;
-  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/525

#### What's this PR do?
- [x] remove the scaling CSS (reverts https://github.com/mitodl/ocw-hugo-themes/pull/388/)
- [x] include screenshots for the following pages: 
  - [x] https://ocwnext.odl.mit.edu/courses/7-013-introductory-biology-spring-2018/pages/instructor-insights/: Image with caption; no link
  - [x] https://ocwnext.odl.mit.edu/courses/24-908-creole-languages-and-caribbean-identities-spring-2017/pages/instructor-insights/ 
  - [x] https://ocwnext.odl.mit.edu/courses/3-054-cellular-solids-structure-properties-and-applications-spring-2015/pages/instructor-insights/


#### How should this be manually tested?
- Go to instructor insights pages of courses which have images
- Compare the images size with RC or PROD and verify that now images are not scaled (not taking 100% width of section) 

#### Screenshots (if appropriate)
![screencapture-localhost-3000-pages-instructor-insights-2022-03-17-14_42_10](https://user-images.githubusercontent.com/93309234/158783805-aedc3995-bce2-4af1-8a85-d2bbf24f0e30.png)
![screencapture-localhost-3000-pages-instructor-insights-2022-03-17-14_52_03](https://user-images.githubusercontent.com/93309234/158783849-0835a7dd-45dd-4261-a232-1c2b528adc66.png)
![screencapture-localhost-3000-pages-instructor-insights-2022-03-17-14_53_09](https://user-images.githubusercontent.com/93309234/158783857-4df490a5-6b31-4ac3-8497-30f1dd0ad388.png)

