### PR TITLE
feat: support links in resource (image) short codes

### DIFF
--- a/course/layouts/partials/image_resource.html
+++ b/course/layouts/partials/image_resource.html
@@ -1,8 +1,9 @@
 {{- $imageHref := "" -}}
-{{- if .Params.href -}}
-    {{- $imageHref = .Params.href -}}
-{{- else if .Params.href_uuid -}}
-    {{- range where $.Site.Pages "Params.uid" .Params.href_uuid -}}
+
+{{- if .href -}}
+    {{- $imageHref = .href -}}
+{{- else if .href_uuid -}}
+    {{- range where .context.Site.Pages "Params.uid" .href_uuid -}}
         {{- $imageHref = .Permalink -}}
     {{- end -}}
 {{- end -}}
@@ -10,8 +11,8 @@
 {{- if $imageHref -}}
     <a href="{{- $imageHref -}}" target="_blank">
 {{- end -}}
-{{- $metadata := .Params.image_metadata | default dict -}}
-<img src="{{ partial "resource_url" .Params.file }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
+{{- $metadata := .context.Params.image_metadata | default dict -}}
+<img src="{{ partial "resource_url" .context.Params.file }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
 {{- if $imageHref -}}
     </a>
 {{- end -}}

--- a/course/layouts/partials/image_resource.html
+++ b/course/layouts/partials/image_resource.html
@@ -1,0 +1,17 @@
+{{- $imageHref := "" -}}
+{{- if .Params.href -}}
+    {{- $imageHref = .Params.href -}}
+{{- else if .Params.href_uuid -}}
+    {{- range where $.Site.Pages "Params.uid" .Params.href_uuid -}}
+        {{- $imageHref = .Permalink -}}
+    {{- end -}}
+{{- end -}}
+
+{{- if $imageHref -}}
+    <a href="{{- $imageHref -}}" target="_blank">
+{{- end -}}
+{{- $metadata := .Params.image_metadata | default dict -}}
+<img src="{{ partial "resource_url" .Params.file }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
+{{- if $imageHref -}}
+    </a>
+{{- end -}}

--- a/course/layouts/shortcodes/resource.html
+++ b/course/layouts/shortcodes/resource.html
@@ -1,9 +1,28 @@
 {{- $uuid := index .Params 0 -}}
+{{- $imageHref := "" -}}
 {{- range $.Site.Pages -}}
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
     {{- if eq .Params.resourcetype "Image" -}}
-      {{- $metadata := .Params.image_metadata | default dict -}}
-      <img src="{{ partial "resource_url" .Params.file }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
+
+      {{- if .Params.href_uuid -}}
+        {{- range where $.Site.Pages "Params.uid" .Params.href_uuid -}}
+          {{ $imageHref = .Permalink }}
+        {{- end -}}
+      {{- end -}}
+
+      {{- if .Params.href -}}
+        {{$imageHref = .Params.href }}
+      {{- end -}}
+
+      {{- if $imageHref -}}
+        <a href="{{ $imageHref }}" target="_blank">
+      {{- end -}}
+        {{- $metadata := .Params.image_metadata | default dict -}}
+        <img src="{{ partial "resource_url" .Params.file }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
+      {{- if $imageHref -}}
+        </a>
+      {{- end -}}
+
     {{- else if eq .Params.resourcetype "Video" -}}
       {{ partial "video_embed.html" . }}
     {{- else -}}

--- a/course/layouts/shortcodes/resource.html
+++ b/course/layouts/shortcodes/resource.html
@@ -1,9 +1,16 @@
-{{- $uuid := index .Params 0 -}}
+{{- $uuid := default "" (.Get "uuid") -}}
+{{- $href := default "" (.Get "href") -}}
+{{- $href_uuid := default "" (.Get "href_uuid") -}}
+
+{{- if not $uuid -}}
+  {{- $uuid = index .Params 0 -}}
+{{- end -}}
+
 
 {{- range $.Site.Pages -}}
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
     {{- if eq .Params.resourcetype "Image" -}}
-      {{ partial "image_resource.html" . }}
+      {{ partial "image_resource.html" (dict "context" . "href" $href "href_uuid" $href_uuid) }}
     {{- else if eq .Params.resourcetype "Video" -}}
       {{ partial "video_embed.html" . }}
     {{- else -}}

--- a/course/layouts/shortcodes/resource.html
+++ b/course/layouts/shortcodes/resource.html
@@ -1,28 +1,9 @@
 {{- $uuid := index .Params 0 -}}
-{{- $imageHref := "" -}}
+
 {{- range $.Site.Pages -}}
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
     {{- if eq .Params.resourcetype "Image" -}}
-
-      {{- if .Params.href_uuid -}}
-        {{- range where $.Site.Pages "Params.uid" .Params.href_uuid -}}
-          {{ $imageHref = .Permalink }}
-        {{- end -}}
-      {{- end -}}
-
-      {{- if .Params.href -}}
-        {{$imageHref = .Params.href }}
-      {{- end -}}
-
-      {{- if $imageHref -}}
-        <a href="{{ $imageHref }}" target="_blank">
-      {{- end -}}
-        {{- $metadata := .Params.image_metadata | default dict -}}
-        <img src="{{ partial "resource_url" .Params.file }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
-      {{- if $imageHref -}}
-        </a>
-      {{- end -}}
-
+      {{ partial "image_resource.html" . }}
     {{- else if eq .Params.resourcetype "Video" -}}
       {{ partial "video_embed.html" . }}
     {{- else -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/523

#### What's this PR do?
- Since we have to pass `href` or `href_uuid` to resource shortcode so now our resource shortcodes will have `named` parameters unlike before (having only 1 positional parameter i.e: UUID).
- So this PR checks and get named parameters which are/can be:
    - UUID (required)
    - href (optional)
    - href_uuid (optional) 
But since all the previous resource shortcodes have 1 positional parameter (UUID) so its support is also there hence if UUID is not found as a named parameter then it is assumed that it will be a positional parameter and it is fetched as a positional parameter.
- Default values (empty) values are set for named parameters.
- Images resource partial is created which does the following:
    - For all the image resources, a check is placed for parameters: `href` and `href_uuid`, if any one of them is found, then the image resource is wrapped up with an anchor tag, redirecting to the href value
    - `href` where the value is set to a full or partial URL. When set, the resource (typically an image) would be wrapped in an anchor tag with an `href` attribute, with the value set to the passed value. 
    - `href_uuid` where the value to set to the uuid of another resource (typically a page, or a resource). When set, the resource would be wrapped in an anchor tag, with an `href` attribute, with the value set to a URL for the resource. 
    - having both parameters set is not supported. It's OK to use the `href` value in this case. 

#### How should this be manually tested?
- Go to any course which has image resources and run it locally. [example](https://github.mit.edu/ocw-content-rc/1.252j-fall-2016/blob/main/content/resources/south_end-compressor.md)
-Pass a parameter to any image resource: `href` and set its value to any URL: (e.g: `{{< resource  uuid="4b2d6fb6-96a3-3b08-c576-8653fb9e1a07" href="https://google.com" >}}`)
     - Verify that now image is clickable and redirects to this URL.
- Replace this `href` with `href_uuid` and set it's value to UID of any resource: (e.g: `{{< resource  uuid="4b2d6fb6-96a3-3b08-c576-8653fb9e1a07" href_uuid="**uuid of any other resource**" >}}`)
     - Verify that now image is clickable and redirects to this resource (whose UID has been set)
- Add both parameters, `href` and `href_uuid` with their respective values: (e.g: `{{< resource  uuid="4b2d6fb6-96a3-3b08-c576-8653fb9e1a07" href="https://google.com" href_uuid="**uuid of any other resource**" >}}`)
     - Verify that image is clickable and redirects to `href` value
- Remove both parameters:
     - Verify that now image is not clickable
- Verify old resources which have 1 positional parameter (e.g: `{{< resource  4b2d6fb6-96a3-3b08-c576-8653fb9e1a07 >}}`) and verify that it is also working smoothly.
- Any other use-case which I have missed.
