### PR TITLE
Add cover image to collection page

### DIFF
--- a/base-theme/assets/css/header.scss
+++ b/base-theme/assets/css/header.scss
@@ -92,3 +92,14 @@
     }
   }
 }
+
+#collection-header {
+  width: 100%;
+  height: 300px;
+
+  img {
+    object-fit: cover;
+    width: inherit;
+    height: inherit;
+  }
+}

--- a/www/assets/js/components/CourseListRow.test.tsx
+++ b/www/assets/js/components/CourseListRow.test.tsx
@@ -30,5 +30,5 @@ test("should show the title, coursenum, level", () => {
   const { wrapper, course } = setup()
   expect(wrapper.find("h4").text()).toBe(course.title)
   expect(wrapper.find(".coursenum").text()).toBe(course.coursenum)
-  expect(wrapper.find(".level").text()).toBe(course.level)
+  expect(wrapper.find(".level").text()).toBe(course.level ? course.level : "")
 })

--- a/www/layouts/collections/single.html
+++ b/www/layouts/collections/single.html
@@ -4,6 +4,7 @@
   {{ block "header" . }}
   {{ partialCached "header" . }}
   {{ end }}
+  {{ partial "collection_cover_image" $collection }}
   <div class="container standard-width mx-auto mt-5">
     <h1>
       {{ $collection.Title }}

--- a/www/layouts/partials/collection_cover_image.html
+++ b/www/layouts/partials/collection_cover_image.html
@@ -2,7 +2,6 @@
 {{- $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" | default "https://ocwnext.odl.mit.edu"  -}}
 {{ $collectionImageUuid := index $collection.Params "cover-image"}}
 {{ if  $collectionImageUuid.content }}
-  {{ $collectionImageUid := partial "resource_metadata.html" $collectionImageUuid.content }}
   {{- $collectionImageMetadata := (dict "Params" (dict "file" "None" "metadata" (dict "image_alt" ""))) -}}
   {{- $collectionImageMetadata = partial "resource_metadata.html" $collectionImageUuid.content }}
   {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) $collectionImageMetadata.Params.file) "" -}}

--- a/www/layouts/partials/collection_cover_image.html
+++ b/www/layouts/partials/collection_cover_image.html
@@ -10,4 +10,3 @@
     <img src='{{ partial "resource_url" $url }}' alt='{{ $collectionImageMetadata.Params.metadata.image_alt }}' />
   </div>
 {{ end }}
-<p></p>

--- a/www/layouts/partials/collection_cover_image.html
+++ b/www/layouts/partials/collection_cover_image.html
@@ -1,0 +1,13 @@
+{{- $collection := . -}}
+{{- $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" | default "https://ocwnext.odl.mit.edu"  -}}
+{{ $collectionImageUuid := index $collection.Params "cover-image"}}
+{{ if  $collectionImageUuid.content }}
+  {{ $collectionImageUid := partial "resource_metadata.html" $collectionImageUuid.content }}
+  {{- $collectionImageMetadata := (dict "Params" (dict "file" "None" "metadata" (dict "image_alt" ""))) -}}
+  {{- $collectionImageMetadata = partial "resource_metadata.html" $collectionImageUuid.content }}
+  {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) $collectionImageMetadata.Params.file) "" -}}
+  <div id="collection-header">
+    <img src='{{ partial "resource_url" $url }}' alt='{{ $collectionImageMetadata.Params.metadata.image_alt }}' />
+  </div>
+{{ end }}
+<p></p>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #547

#### What's this PR do?
Displays the cover image for a course collection if there is one.
Fixes a flaky test

#### How should this be manually tested?
In your own local studio instance of the ocw-www site, or on RC's, create a collection and assign a cover image to it.
Git clone the above ocw-www repo and point to it with `WWW_CONTENT_PATH` in your ocw-hugo-themes .env
Run `npm run start:www` and go to the collection page.  You should see the cover image at [100% width and 300px height](https://projects.invisionapp.com/share/DN12GXJ28MXA#/screens/464971999_Course_Collection_B), it should scale appropriately as you change the browser width.
Go to a collection page without a cover image, it should render fine without it.


#### Screenshots (if appropriate)

Narrow:
<img width="680" alt="Screen Shot 2022-03-23 at 4 58 21 PM" src="https://user-images.githubusercontent.com/187676/159794538-2d52eeaf-7140-453d-9528-fcd1067bf2ff.png">

============

Wide:
<img width="1398" alt="Screen Shot 2022-03-23 at 4 58 33 PM" src="https://user-images.githubusercontent.com/187676/159794564-e44e0e22-759f-4150-86f8-b62c02942090.png">

