### PR TITLE
Updated course collection dashboard to link to course lists

### DIFF
--- a/www/layouts/partials/home_course_collections.html
+++ b/www/layouts/partials/home_course_collections.html
@@ -6,14 +6,12 @@
       collections. Below are some topics available for you to explore:
     </p>
     <div class="course-collection-section d-flex flex-row m-0 flex-wrap">
-      {{ range $url := .Params.homePageCourseListsUrls}}
-        {{ with $.Site.GetPage $url }}
-          <a href="{{ .Permalink }}">
-            <div class="collection-item">
-              <p>{{ .Title }}</p>
-            </div>
-          </a>
-        {{ end }}
+      {{ range where .Site.Pages "Type" "course-lists" }}
+        <a href="{{.Permalink}}">
+          <div class="collection-item">
+            <p>{{.Title}}</p>
+          </div>
+        </a>
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #554 

#### What's this PR do?
Updates course_collection section to point towards course_lists.

#### How should this be manually tested?
- Verify course_collection items link to correct course list.

#### Screenshots (if appropriate)
<img width="1433" alt="Screenshot 2022-03-24 at 2 13 33 PM" src="https://user-images.githubusercontent.com/87968618/159886790-2baefd39-693e-4f7e-b7c1-b8c373896aff.png">

