### PR TITLE
fixed styling issues for appzi feedback button

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -391,3 +391,8 @@ article.content {
 .aspect-ratio-16-9 {
   aspect-ratio: 16/9 !important;
 }
+
+// selector for appzi button
+div[data-appzi-dom] {
+  top: 30% !important;
+}

--- a/course/layouts/partials/course_content.html
+++ b/course/layouts/partials/course_content.html
@@ -28,7 +28,7 @@
     </div>
   </header>
   {{ partial "mobile_nav_toggle.html" . }}
-  <article class="content pt-3 mt-1">
+  <article class="content pt-3 mt-1 mr-5">
     <main id="course-content-section">{{- .Content -}}</main>
   </article>
 </div>

--- a/course/layouts/partials/course_content.html
+++ b/course/layouts/partials/course_content.html
@@ -28,7 +28,7 @@
     </div>
   </header>
   {{ partial "mobile_nav_toggle.html" . }}
-  <article class="content pt-3 mt-1 mr-5">
+  <article class="content pt-3 mt-1 mr-5 mr-md-0">
     <main id="course-content-section">{{- .Content -}}</main>
   </article>
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #564 

#### What's this PR do?
Fixes styling issues for Appzi feedback button

#### How should this be manually tested?
Verify the following
- `Hide course info` button does not overlap with `feedback` button
-  `feedback` button does not overlap with content
- `feedback` button possition on ocw-www and ocw-course  is consistant

#### Screenshots (if appropriate)
<img width="232" alt="Screenshot 2022-03-29 at 1 25 45 PM" src="https://user-images.githubusercontent.com/87968618/160572091-ba6b914f-d639-40ad-8cd7-6f916db10379.png">
<img width="1440" alt="Screenshot 2022-03-29 at 1 26 11 PM" src="https://user-images.githubusercontent.com/87968618/160572131-cfc2e07d-3fae-4c27-b6be-11d809b06f59.png">
<img width="1440" alt="Screenshot 2022-03-29 at 1 28 24 PM" src="https://user-images.githubusercontent.com/87968618/160572156-6c8ece6e-7738-4da7-8900-7a97c1e61883.png">
