### PR TITLE
Fix testimonial carousel

### DIFF
--- a/www/layouts/partials/home_testimonials.html
+++ b/www/layouts/partials/home_testimonials.html
@@ -11,7 +11,9 @@
       <div id="{{ $carouselId }}" class="carousel slide" data-interval="false" data-touch="true" data-ride="carousel">
         <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold">
           <h2>OpenCourseWare Stories</h2>
+          {{ if gt (len $testimonials) 4 }}
           {{ partial "carousel_controls.html" $carouselId }}
+          {{ end }}
         </div>
         <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
           {{ range $index, $testimonial := $testimonials  }}

--- a/www/layouts/partials/home_testimonials.html
+++ b/www/layouts/partials/home_testimonials.html
@@ -1,76 +1,43 @@
 {{- $testimonials := where .Site.RegularPages "Type" "==" "testimonials" -}}
 {{- $testimonialSection := .Site.GetPage "section" "testimonials" -}}
+{{- $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 2 "class" "d-none d-md-flex d-lg-none") "lg" (dict "size" 3 "class" "d-none d-lg-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) -}}
 <div class="home-testimonials standard-width container mx-auto my-3">
-  <h2 class="mb-3">
-    OpenCourseWare Testimonies
-  </h2>
-  <div class="d-flex flex-row justify-content-between xl-and-above-only" >
-    {{ range $testimonial := $testimonials }}
-      {{ partial "testimonial_card.html" $testimonial }}
-    {{ end }}
-  </div>
-  <div class="d-flex d-md-none">
-    {{- $carouselId := "testimonial-carousel-xs-sm" -}}
-    <div id="{{ $carouselId }}" class="carousel slide">
-      <div class="carousel-header d-flex flex-row justify-content-end font-weight-bold text-uppercase">
-        {{ partial "carousel_controls.html" $carouselId }}
-      </div>
-      <div class="carousel-inner d-flex mt-2 px-0">
-        {{- range $index, $testimonial := (first 4 $testimonials) -}}
-          <div class="carousel-item {{ if eq $index 0 }}active{{ end }}">
-            <div class="item-wrapper w-100 d-flex justify-content-center">
-              {{ partial "testimonial_card.html" $testimonial }}
-            </div>
-          </div>
-        {{ end }}
+  {{ range $breakpoint, $carouselInfo := $breakdowns }}
+    {{ $itemsInCarousel := index $carouselInfo "size" }}
+    {{ $breakpointVisibilityClass := index $carouselInfo "class" }}
+    {{ $isMobile := (eq $itemsInCarousel 1) }}
+    {{ $carouselId := (printf "testimonial-carousel-%v" $breakpoint) }}
+    <div class="{{ $breakpointVisibilityClass }}">
+      <div id="{{ $carouselId }}" class="carousel slide" data-interval="false" data-touch="true" data-ride="carousel">
+        <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold">
+          <h2>OpenCourseWare Stories</h2>
+          {{ partial "carousel_controls.html" $carouselId }}
+        </div>
+        <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
+          {{ range $index, $testimonial := $testimonials  }}
+            {{ with $testimonial }}
+              {{ $modulo := (mod $index $itemsInCarousel) }}
+              {{ $group := (div $index $itemsInCarousel) }}
+              {{ if eq $modulo 0 }}
+              <div class="carousel-item {{ if not $isMobile }}row{{end}} {{ if eq $group 0 }}active{{ end }}">
+              {{ end }}
+                <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
+                  <div class="item-wrapper w-100 d-flex justify-content-center">
+                    {{ partial "testimonial_card.html" $testimonial }}
+                  </div>
+                </div>
+              {{ if (or (eq $modulo (sub $itemsInCarousel 1)) (eq $index (sub (len $testimonials) 1))) }}
+              </div>
+              {{ end }}
+            {{ end }}
+          {{ end }}
+        </div>
       </div>
     </div>
-  </div>
-  <div class="d-none d-md-flex d-lg-none">
-    {{- $carouselId := "testimonial-carousel-md" -}}
-    <div id="{{ $carouselId }}" class="carousel slide">
-      <div class="carousel-header d-flex flex-row justify-content-end font-weight-bold text-uppercase">
-        {{ partial "carousel_controls.html" $carouselId }}
-      </div>
-      <div class="carousel-inner d-flex container mt-2 px-0">
-        {{- range $index, $testimonial := (first 4 $testimonials) -}}
-          {{ if (or ( eq $index 0) (eq $index 2)) }}
-          <div class="carousel-item row {{ if eq $index 0 }}active{{ end }}">
-          {{ end }}
-            <div class="item-wrapper col-6 w-100 d-flex justify-content-center">
-              {{ partial "testimonial_card.html" $testimonial }}
-            </div>
-          {{ if (or ( eq $index 1) (eq $index 3)) }}
-          </div>
-          {{ end }}
-        {{ end }}
-      </div>
-    </div>
-  </div>
-  <div class="d-none d-lg-flex d-xl-none">
-    {{- $carouselId := "testimonial-carousel-lg" -}}
-    <div id="{{ $carouselId }}" class="carousel slide">
-      <div class="carousel-header d-flex flex-row justify-content-end font-weight-bold text-uppercase">
-        {{ partial "carousel_controls.html" $carouselId }}
-      </div>
-      <div class="carousel-inner d-flex container mt-2 px-0">
-        {{- range $index, $testimonial := (first 4 $testimonials) -}}
-          {{ if (or ( eq $index 0) (eq $index 3)) }}
-          <div class="carousel-item row {{ if eq $index 0 }}active{{ end }}">
-          {{ end }}
-            <div class="item-wrapper col-4 w-100 d-flex justify-content-center">
-              {{ partial "testimonial_card.html" $testimonial }}
-            </div>
-          {{ if (or ( eq $index 2) (eq $index 3)) }}
-          </div>
-          {{ end }}
-        {{ end }}
-      </div>
-    </div>
-  </div>
+  {{ end }}
   <div class="d-flex py-4">
       <div class="ml-auto">
-          <a class="view-all-link" href="{{ $testimonialSection.RelPermalink }}">View All OCW Testimonials</a>
+          <a class="view-all-link" href="{{ $testimonialSection.RelPermalink }}">View All OCW Stories</a>
       </div>
   </div>
 </div>

--- a/www/layouts/testimonials/list.html
+++ b/www/layouts/testimonials/list.html
@@ -6,7 +6,7 @@
   {{ partialCached "header" . }}
   {{end}}
   <div class="testimonial-section container standard-width mx-auto mt-5">
-    <h1>OCW Testimonies</h1>
+    <h1>OCW Stories</h1>
     <h3>Share your OCW story.</h3>
     <p>
       We'd love to hear from you! Please share your story about how OCW has made an impact in your life. Find out how.

--- a/www/layouts/testimonials/single.html
+++ b/www/layouts/testimonials/single.html
@@ -5,7 +5,7 @@
   {{ partialCached "header" . }}
   {{ end }}
   <div class="testimonial-single container standard-width mx-auto mt-5">
-    <h1>OCW Testimonies</h1>
+    <h1>OCW Stories</h1>
     <div class="testimonials">
       <div class="testimonial d-flex flex-wrap flex-sm-nowrap">
         <div class="img-container">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/568

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/commit/554ef4bfcc56b8b6c627f4f4cc9a95fae940136e, in the transition to `ocw-hugo-themes` from `ocw-course-hugo-theme` we updated the version of bootstrap used by the project which changed the way carousels work.  Since the example testimonial data has only ever included 4 testimonials, it wasn't clear that the testimonials are also supposed to use a carousel if there are more than 4 of them.  This PR sets up testimonials to render in a carousel in the same way the new course cards at the top of the homepage do, showing only the amount of testimonial cards that can be displayed based on the screen width.  This PR also changes the labeling of testimonials to refer to them as "stories."  A future PR will rename the template / variable names.

#### How should this be manually tested?
 - Clone `ocw-www` from `ocw-content-rc`: https://github.mit.edu/ocw-content-rc/ocw-www
 - Clone `ocw-hugo-themes` on this branch and make sure you set `WWW_CONTENT_PATH` to the path of the repo you cloned above and set `RESOURCE_BASE_URL=https://ocwnext-rc.odl.mit.edu` if you want images to work
 - Spin up `ocw-www` by running `npm run start:www`
 - Visit http://localhost:3000 in a maximized browser window and scroll to the bottom of the page.  You should see previous / next buttons above the testimonials and they should function as expected
 - Scale the window horizontally, making it smaller, and verify that the carousel size adjusts accordingly and the buttons still work

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/160677409-c76e53dd-259d-4f6f-bad1-8fb9425aaf11.png)
![image](https://user-images.githubusercontent.com/12089658/160677705-4ee328c2-cf70-454c-92c5-024b02df438f.png)

