### PR TITLE
styling for course collections and lists

### DIFF
--- a/www/assets/css/course-collection.scss
+++ b/www/assets/css/course-collection.scss
@@ -25,18 +25,69 @@
   }
 }
 
+h1.course-list-title {
+  color: $highlight-red;
+  text-transform: none;
+  font-size: $font-xl;
+  text-transform: uppercase;
+}
+
+.collection-outer-container {
+  h1 {
+    text-transform: uppercase;
+    margin-top: 45px;
+    margin-bottom: 25px;
+    font-size: $heading-two-font-lg;
+    padding: 15px;
+  }
+
+  .collection-description {
+    padding: 15px;
+  }
+
+  .course-list-title {
+    text-transform: none;
+    margin-top: 50px;
+    margin-bottom: 10px;
+  }
+}
+
+.collection-see-all {
+  font-weight: bold;
+}
+
 // this if for content rendered w/ React
 .course-collection-row {
-  height: 90px;
+  min-height: 90px;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.11);
+  background-color: #ffffff;
 
+  h4 {
+    font-size: $font-lg;
+  }
   .card-contents {
     height: 100%;
     padding: 8px !important;
 
+    h4 {
+      font-size: $font-md;
+    }
+
+    .course-title {
+      max-width: 60%;
+      @include breakpoint(phone) {
+        max-width: 70%;
+      }
+    }
+
     img {
-      height: 74px;
-      width: 100px;
+      height: 75.33px;
+      width: 125px;
       object-fit: cover;
+
+      @include breakpoint(phone) {
+        display: none;
+      }
     }
 
     .coursenum,
@@ -50,6 +101,11 @@
 
     .level {
       color: $highlight-red;
+      margin-left: 25px;
+      @include breakpoint(phone) {
+        margin-left: 10px;
+        margin-right: 5px;
+      }
     }
   }
 }

--- a/www/layouts/collections/single.html
+++ b/www/layouts/collections/single.html
@@ -5,11 +5,11 @@
   {{ partialCached "header" . }}
   {{ end }}
   {{ partial "collection_cover_image" $collection }}
-  <div class="container standard-width mx-auto mt-5">
+  <div class="container collection-outer-container standard-width mx-auto mt-5">
     <h1>
       {{ $collection.Title }}
     </h1>
-    <div class="mb-3">
+    <div class="mb-3 collection-description">
       {{ $collection.Description | .RenderString }}
     </div>
     {{- range $collection.Params.courselists.content -}}
@@ -17,7 +17,7 @@
       {{ partial "course_list" $course_list }}
       <div>
       <div class="col-12 col-lg-8 pb-2">
-        <a class="float-right" href="{{ $course_list.RelPermalink }}">See all</a>
+        <a class="float-right collection-see-all" href="{{ $course_list.RelPermalink }}">See all</a>
         </div>
       </div>
     {{- end -}}

--- a/www/layouts/partials/course_list.html
+++ b/www/layouts/partials/course_list.html
@@ -1,8 +1,8 @@
 {{- $course_list := . -}}
-<h1>
+<h1 class="course-list-title col-12 col-lg-8 pb-2">
   {{ $course_list.Title }}
 </h1>
-<div class="mb-3">
+<div class="mb-3 col-12 col-lg-8 pb-2">
   {{ $course_list.Description | $.RenderString }}
 </div>
 <div class="course-collection-container" data-collectionid="{{- $course_list.Params.uid -}}"></div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

Course collection desktop:
<img width="1675" alt="Screen Shot 2022-03-29 at 11 09 45 PM" src="https://user-images.githubusercontent.com/1934992/160744000-5e51d6fb-7bba-4de2-afad-0d2c4f4812b3.png">
<img width="1675" alt="Screen Shot 2022-03-29 at 11 09 56 PM" src="https://user-images.githubusercontent.com/1934992/160744013-4899949a-7776-416d-853e-a097c4c687c9.png">
<img width="1620" alt="Screen Shot 2022-03-30 at 9 09 22 AM" src="https://user-images.githubusercontent.com/1934992/160842098-8e97a491-4d8c-47a3-a810-18ce8d765765.png">


Course collection mobile:
<img width="365" alt="Screen Shot 2022-03-29 at 11 10 08 PM" src="https://user-images.githubusercontent.com/1934992/160744012-a0fc7a54-0b6c-4a0c-afc2-4d3c5b4a67a9.png">
<img width="361" alt="Screen Shot 2022-03-29 at 11 10 21 PM" src="https://user-images.githubusercontent.com/1934992/160744011-d78ecc52-24a0-42d2-8501-cbef19a886c6.png">

Course list desktop:
<img width="1680" alt="Screen Shot 2022-03-29 at 11 10 36 PM" src="https://user-images.githubusercontent.com/1934992/160744009-33d696e0-3b6b-4897-ae1e-0f2ad5b29ae4.png">
Course list mobile:
<img width="365" alt="Screen Shot 2022-03-29 at 11 10 53 PM" src="https://user-images.githubusercontent.com/1934992/160744008-7a208170-d0d3-4027-9957-8b26d0d5a1ac.png">

#### What are the relevant tickets?
None

#### What's this PR do?
This pr improves the styling for course collections and lists

#### How should this be manually tested?
Pull down the latest ocw-www repo.
Set WWW_CONTENT_PATH=<your path>/ocw-www 
Run npm run start:www

View a course collection. One is http://localhost:3000/collections/energy/

Course collections should look like the following design:

https://invis.io/DN12GXJ28MXA#/464971999_Course_Collection_B

There isn't a mobile design or a design for the course list page but both of those should look good.

The cover image doesn't load locally but will work on RC. 
