### PR TITLE
fixed extar tab in course collection

### DIFF
--- a/www/layouts/partials/home_course_collections.html
+++ b/www/layouts/partials/home_course_collections.html
@@ -6,7 +6,7 @@
       collections. Below are some topics available for you to explore:
     </p>
     <div class="course-collection-section d-flex flex-row m-0 flex-wrap">
-      {{ range where .Site.Pages "Type" "collections" }}
+      {{ range where .Site.RegularPages ".Params.content_type" "course-collection" }}
         <a href="{{ .Permalink }}">
           <div class="collection-item">
             <p>{{.Title}}</p>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket. Hot fix

#### What's this PR do?
Updated the course collection filter to be more robust

#### How should this be manually tested?
- Pull the latest changes from ocw-www main branch
- Verify only pages in the `collections` directory of ocw-www show up in course collection home page


#### Any background context you want to provide?
For some reason, I was not getting the `Collections` on my local until I pulled the latest changes for ocw-www content.
I believe there might have been a change which caused the Collections tab to show up.However I have updated the filter to be more robust in any case. 

#### Screenshots (if appropriate)
<img width="1389" alt="Screenshot 2022-03-30 at 10 43 38 AM" src="https://user-images.githubusercontent.com/87968618/160760312-2d910334-a091-4131-b1db-8e70e346ffef.png">

