### PR TITLE
Added a bit more space to handle double/triple line titles

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -394,5 +394,5 @@ article.content {
 
 // selector for appzi button
 div[data-appzi-dom] {
-  top: 30% !important;
+  top: 40% !important;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Hot fix

#### What's this PR do?
Increases top spacing to better handle large title courses

#### How should this be manually tested?
Verify button does not overlap with large title courses

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2022-03-30 at 8 10 34 PM" src="https://user-images.githubusercontent.com/87968618/160869532-2b1438b2-c086-4476-87e9-341b9e618a59.png">