### PR TITLE
fix for videos with start time but not end time

### DIFF
--- a/course/layouts/partials/youtube_player.html
+++ b/course/layouts/partials/youtube_player.html
@@ -1,8 +1,13 @@
 {{ $random := delimit (shuffle (split (md5 "seed") "" )) "" }}
 {{$youtubeParams:=""}}
-{{if ne .startTime ""}}
+{{if and (ne .startTime "") (ne .endTime "")}}
 {{$youtubeParams =  delimit (slice `, "youtube": { "start": ` .startTime `, "end":`  .endTime  `}`) "" }}
+{{else if ne .startTime ""}}
+{{$youtubeParams =  delimit (slice `, "youtube": { "start": ` .startTime `}`) "" }}
+{{else if ne .endTime ""}}
+{{$youtubeParams =  delimit (slice `, "youtube": { "end": ` .endTime `}`) "" }}
 {{end}}
+
 <div class="video-container">
   <video
     id="video-player-{{ .youtubeKey }}-{{ $random }}"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Matt found a course with start times but not end times. The start/end time changes broke videos for that course

https://ocw-draft-qa.global.ssl.fastly.net/courses/res-3-003-learn-to-build-your-own-videogame-with-the-unity-game-engine-and-microsoft-kinect-january-iap-2017/resources/long-project-2-mini-world/

#### How should this be manually tested?
Run ocw-to-hugo with  18-01sc-single-variable-calculus-fall-2010 (start times and end times), 
res-3-003-learn-to-build-your-own-videogame-with-the-unity-game-engine-and-microsoft-kinect-january-iap-2017 (just start times set to 0)
and 14-01sc-principles-of-microeconomics-fall-2011 (neither start times or end times)

Run ocw-hugo-themes pointed to those courses. Verify that videos work in all three cases
