### PR TITLE
fix: open learning button redirection

### DIFF
--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -358,7 +358,7 @@
               Open Learning Library is always open for self-guided learning, and 
               does not include live support, discussion forums, or certificates of completion.
             </p>
-            <a class="red-btn" href="/pages/open-learning-library/">Explore Open Learning Library courses </a>
+            <a class="red-btn" href="/collections/mit-open-learning-library/">Explore Open Learning Library courses </a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
No ticket :) 

#### What's this PR do?
Fixes this button redirection on about us page:
<img width="645" alt="image" src="https://user-images.githubusercontent.com/93309234/161082235-b69dd62d-279b-44e5-9151-ee635ce8a9da.png">
 

#### How should this be manually tested?
- Go to about us page and verify that this button works fine
