### PR TITLE
fix: testimonials images should squish

### DIFF
--- a/www/assets/css/testimonials.scss
+++ b/www/assets/css/testimonials.scss
@@ -15,6 +15,7 @@ $row-max-height: 200px;
     img {
       width: $row-max-height;
       height: $row-max-height;
+      object-fit: cover;
     }
 
     .detail {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/574

#### What's this PR do?
Fix testimonials images squish by `object-fit: cover;`

#### How should this be manually tested?
- Go to testimonials page and verify that the images does not squish

#### Screenshots (if appropriate)
**Before:**
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/93309234/161246894-20bf6456-d295-4b29-9e33-b044f90d64b2.png">


**After:**
<img width="1289" alt="image" src="https://user-images.githubusercontent.com/93309234/161246959-9727b758-d9b4-417a-82df-8c46b5313550.png">

