### PR TITLE
get started link conditionally updated

### DIFF
--- a/www/layouts/home.html
+++ b/www/layouts/home.html
@@ -1,4 +1,13 @@
 {{ define "main" }}
+
+{{ $getStartedZendeskPage := "https://mitocw.zendesk.com/hc/en-us/categories/4414679122971-Get-Started-with-MIT-OpenCourseWare" }}
+{{ $getStartedLocalPage := "/pages/get-started" }}
+{{ $getStartedLink := $getStartedZendeskPage }}
+
+{{ with $.Site.GetPage $getStartedLocalPage }}
+  {{ $getStartedLink = $getStartedLocalPage }}
+{{ end }}
+
 <div id="home-header">
   {{ block "header" . }}
   {{ $renderSearchIcon := index .Params "renderSearchIcon" | default true }}
@@ -41,7 +50,7 @@
       <div class="new-or-educator w-100 px-2 px-md-5 mt-md-5 py-4 d-flex flex-column flex-md-row">
         <div class="option bordered d-md-flex flex-md-column pb-3 pb-md-0 pr-md-3">
           <span class="font-weight-bold">Are you new to OCW?</span>
-          <a href="https://mitocw.zendesk.com/hc/en-us/categories/4414679122971-Get-Started-with-MIT-OpenCourseWare" target="_blank">
+          <a href="{{- $getStartedLink -}}">
             Get Started
           </a>
         </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/597

#### What's this PR do?
- Checks if page: `/pages/get-started` exists then `Get Started` link on www homepage is redirected to `/pages/get-started`
- If `/pages/get-started` does **not** exist/found then it redirects to [zendesk get started page](https://mitocw.zendesk.com/hc/en-us/categories/4414679122971-Get-Started-with-MIT-OpenCourseWare)

#### How should this be manually tested?
- Checkout this branch
- Create and publish a `get-started` page or clone/pull `ocw-www` as it already has a `get-started` page.
- Go to www homepage and verify that this link:
<img width="197" alt="image" src="https://user-images.githubusercontent.com/93309234/161518912-67a15905-1d18-402d-9d60-181a7a5b23fe.png">

redirects to `/pages/get-started`
- Remove `get-started` page and now verify that get started link redirects to zendesk get started page.
- Test on all other use-case(s) which is/are not mentioned above.
