### PR TITLE
anchor tag in video tab toggle/collapse replaced with div

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -391,3 +391,7 @@ article.content {
 .aspect-ratio-16-9 {
   aspect-ratio: 16/9 !important;
 }
+
+.pointer {
+  cursor: pointer;
+}

--- a/course/layouts/partials/video-expandable-tab.html
+++ b/course/layouts/partials/video-expandable-tab.html
@@ -1,6 +1,6 @@
 <div class="pb-2">
-	<a class="video-tab-section-toggle text-decoration-none"
-      href=".{{- .tabClass -}}"
+	<div class="video-tab-section-toggle pointer"
+			data-target=".{{- .tabClass -}}" 
 			data-toggle="collapse"
 			aria-controls="{{- .tabClass -}}"
 			aria-expanded=""
@@ -13,7 +13,7 @@
 				<i class="material-icons md-18"></i>
 			</div>
 		</div>
-	</a>
+	</div>
 	<div class="container collapse {{ .tabClass }}">
 		{{- .tabContent | markdownify -}}
 	</div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/605

#### What's this PR do?
- Previously href in anchor tag was used for bootstrap expand/collapse and in result the class/ID in href became bad/broken link.
- This PR replaces `anchor tag` with `div` and `href` with `data-target` hence now we don't have any href hence no bad/broken links.

#### How should this be manually tested?
- Checkout this branch
- Build course(s) which has/have video tabs (`transcript`, `related-resource`, `optional-tab`) in video lectures.
- Verify that for all the tabs, expand/collapse works accurately and smoothly.
- Using a link-checking tool, verify that there is no broken/bad/dead link (Not sure if this is required as href has been completely removed)
