### PR TITLE
fix: browse course material button styling

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -369,6 +369,10 @@ article.content {
 
 .course-section-title-container {
   max-width: 795px;
+
+  @include media-breakpoint-up(lg) {
+    border-bottom: 1px solid $medium-gray;
+  }
 }
 
 .download-file {

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -369,7 +369,6 @@ article.content {
 
 .course-section-title-container {
   max-width: 795px;
-  border-bottom: 1px solid $medium-gray;
 }
 
 .download-file {

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -53,7 +53,9 @@
                             {{ end }}
                           </div>
                         </div>
-                        {{ partial "mobile_nav_toggle.html" . }}
+                        <div class="medium-and-below-only pl-3 py-3">
+                          {{ partial "mobile_nav_toggle.html" . }}
+                        </div>
                         <!-- the number here is a estimate, a count of 5 lines of characters on a sample course at minimum browser width -->
                         {{ $shouldCollapseDescription := gt (len $courseData.course_description) 320 }}
                         <div class="col-lg-8 course-description">

--- a/course/layouts/partials/mobile_nav_toggle.html
+++ b/course/layouts/partials/mobile_nav_toggle.html
@@ -1,12 +1,12 @@
 <div class="mobile-course-nav-toggle medium-and-below-only mb-2">
   <div
     id="mobile-course-nav-toggle"
-    class="btn bg-light pl-5 d-inline-flex align-items-center rounded-0 navbar-toggle offcanvas-toggle"
+    class="btn bg-blue white-color d-inline-flex align-items-center rounded-0 navbar-toggle offcanvas-toggle"
     data-toggle="offcanvas"
     data-target="#mobile-course-nav"
   >
+    <i class="material-icons pr-2">arrow_back</i>
     <span class="text-uppercase font-weight-bold pr-2">browse course material</span>
     <i class="material-icons pr-2">library_books</i>
-    <i class="material-icons">arrow_forward</i>
   </div>
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/606

#### What's this PR do?
- Changes the style of `browse course material` button according to issue ticket and invision design
- Removes the borderline for medium and below screens making the button a separator, but on large or above screens, borderline will be shown.
- Adds some space around the button on course home page 

#### How should this be manually tested?
- Checkout this branch
- Build any course(s) locally
- Go to a smaller screen size (tablet or less)
- Verify that the style `browse course material` button is correct.

#### Screenshots (if appropriate)

<img width="865" alt="image" src="https://user-images.githubusercontent.com/93309234/161949604-7f73b56b-da9d-4c31-b1e2-a5123e921f0a.png">

<img width="873" alt="image" src="https://user-images.githubusercontent.com/93309234/161949567-e788e7b7-0021-4620-93e0-5945fecb5f14.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/93309234/161949481-92d13f14-b450-44f6-bf34-0192b48f9b55.png">

<img width="384" alt="image" src="https://user-images.githubusercontent.com/93309234/161949380-0635fab6-af90-4bcb-a448-2c27172a3279.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/93309234/161949354-0b370821-659c-4445-957c-1ccf85ebede0.png">
