### PR TITLE
fix: h4 fontsize overridden and made smaller than h3

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -112,6 +112,15 @@ a + h3 {
   }
 }
 
+h4 {
+  font-size: $heading-four-font-lg;
+  color: $black;
+
+  @include media-breakpoint-down(xs) {
+    font-size: $heading-four-font-xs;
+  }
+}
+
 .standard-width {
   max-width: $max-home-width;
 }

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -63,6 +63,9 @@ $heading-two-font-xs: 1.5rem; /* 24px */
 // h3
 $heading-three-font-lg: 1.5rem; /* 24px */
 $heading-three-font-xs: 1.125rem; /* 18px */
+// h4
+$heading-four-font-lg: 1.25rem; /* 20px */
+$heading-four-font-xs: 1rem; /* 16px */
 // material icon
 $material-icon-font-normal: 1.5rem; /* Preferred icon size = 24px */
 $material-icon-font-lg: 1.75rem; /* 28px */

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -62,7 +62,7 @@ $heading-two-font-lg: 1.75rem; /* 28px */
 $heading-two-font-xs: 1.5rem; /* 24px */
 // h3
 $heading-three-font-lg: 1.5rem; /* 24px */
-$heading-three-font-xs: 1.125rem; /* 18px */
+$heading-three-font-xs: 1.25rem; /* 20px */
 // h4
 $heading-four-font-lg: 1.25rem; /* 20px */
 $heading-four-font-xs: 1rem; /* 16px */


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/633

#### What's this PR do?
- Override font size of `h4` and makes it smaller than `h3`
**`Large Screen:`** 
- h3 = 24px
- h4 = 20px
**`Small Screen:`** 
- h3 = 20px
- h4 = 16px

#### How should this be manually tested?
- Go to any www or course page, where `h3` and `h4` tags have been used
- Verify that `h4` is smaller than `h3` (make sure that any of the tags is NOT specifically overridden for any section on that page.)
- Repeat the above for multiple screen sizes

#### Screenshots (if appropriate)
 Laptop Screen:
<img width="671" alt="Screenshot 2022-04-12 at 3 53 09 PM" src="https://user-images.githubusercontent.com/93309234/162946191-222299c1-ad2a-4d55-988c-017ea767ec02.png">
Mobile Screen:
<img width="372" alt="Screenshot 2022-04-12 at 4 00 14 PM" src="https://user-images.githubusercontent.com/93309234/162946210-837ec517-3bc2-43fc-9257-361e3821c0bd.png">

