### PR TITLE
new course carousel fix

### DIFF
--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -25,7 +25,7 @@
           {{ range $index, $courseItem := $resultsSlice  }}
             {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" $courseItem.name "/data.json") "" -}}
             {{- $courseData := getJSON $url -}}
-            {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "courseId" $courseItem.id "numCourses" (len $resultsSlice))}}
+            {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "courseId" $courseItem.name "numCourses" (len $resultsSlice))}}
           {{ end }}
         </div>
       </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
none

#### What's this PR do?
A bug in https://github.com/mitodl/ocw-hugo-themes/pull/630 breaks course links

#### How should this be manually tested?
run npm run start:www
Go to http://localhost:3000/
Verify that when you click on a new course it goes to the correct url for the course. You will still see "404 page not found" locally

Also the previous/next buttons arn't broken ocw-studio-rc just currently returns exactly four new courses because a bunch of courses were accidently deleted from rc