### PR TITLE
fix: jsonifying instructor fields in layout

### DIFF
--- a/www/layouts/instructors/item.json.json
+++ b/www/layouts/instructors/item.json.json
@@ -1,8 +1,8 @@
 {
-  "title": "{{ .Params.title }}",
-  "first_name": "{{ .Params.first_name }}",
-  "last_name": "{{ .Params.last_name }}",
-  "middle_initial": "{{ .Params.middle_initial }}",
-  "salutation": "{{ .Params.salutation }}",
+  "title": {{- .Params.title | jsonify -}},
+  "first_name": {{- .Params.first_name | jsonify -}},
+  "last_name": {{- .Params.last_name | jsonify -}},
+  "middle_initial": {{- .Params.middle_initial | jsonify -}},
+  "salutation": {{- .Params.salutation | jsonify -}},
   "uid": "{{ .Params.uid }}"
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1150

#### What's this PR do?
- `Jsonify` instructor title, first_name, last_name, middle_initial and salutation so it escapes `"` when built 

#### How should this be manually tested?
- Either in studio RC, or local setup of Studio, edit ocw-www, wrap any instructor title with `""`. e.g: `Dr. "Chengzhao" Zhang`. 
- Publish it and clone.
- Build ocw-www. i.e: `npm run start:www`
- Check the JSON file generated in your content: `public/instructors/*uuid*/index.json`
- Note that `""` are not escaped in title 
- <img width="305" alt="image" src="https://user-images.githubusercontent.com/93309234/163779224-49e5a95a-47ed-4f49-a9db-72dd0ead7f73.png">
- Now checkout this branch
- Repeat the above steps
- Verify that now `""` are escaped in title
- <img width="313" alt="image" src="https://user-images.githubusercontent.com/93309234/163779513-19b46528-4c91-4686-96d9-9fbe73870fb1.png">

#### Screenshots (if appropriate)
<img width="313" alt="image" src="https://user-images.githubusercontent.com/93309234/163779513-19b46528-4c91-4686-96d9-9fbe73870fb1.png">
