### PR TITLE
fix: change in jquery ready handler

### DIFF
--- a/course/assets/course.js
+++ b/course/assets/course.js
@@ -17,7 +17,7 @@ import {
   showSolution
 } from "./js/quiz_multiple_choice"
 
-$(document).ready(() => {
+$(function() {
   initPdfViewers()
   initDesktopCourseInfoToggle()
   initCourseInfoExpander(document)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/651

#### What's this PR do?
- Updates jQuery ready handler from `$(document).ready(() => ` to `$(function() {` as it seems like that `ready` is deprecated now
- Note: I was unable to reproduce the error locally so I'm not very sure whether this will fix the issue or not but since `ready` is deprecated and usually the cause of `something not defined` error is due to it's usage before it's initialisation/declaration. And `$(function() {` is also the recommended way as stated [here](https://api.jquery.com/ready/)

#### How should this be manually tested?
- Try to reproduce the issue locally
- Checkout to this branch
- Check whether the issue is reproduced again or not
