### PR TITLE
feat: error handling for localstorage

### DIFF
--- a/base-theme/assets/index.ts
+++ b/base-theme/assets/index.ts
@@ -10,6 +10,7 @@ import "shifty"
 import "hammerjs"
 import "imagesloaded"
 import "screenfull"
+import "./js/utils"
 
 import { initSentry } from "./js/sentry"
 

--- a/base-theme/assets/js/utils.ts
+++ b/base-theme/assets/js/utils.ts
@@ -1,0 +1,41 @@
+export const setLocalStorageItem = (key: string, value: any) => {
+  return setOrGetLocalStorageItemHelper("set", key, value)
+}
+
+export const getLocalStorageItem = (key: string): any => {
+  return setOrGetLocalStorageItemHelper("get", key)
+}
+
+/**
+ * depending upon action, either set or get a value in localstorage with validation/checks to avoid error/exception
+ *
+ * @param {string} action either "set" or "get"
+ * @param {string} key The key against which the data is/will be stored
+ * @param {any} value actual data/value to store, if any
+ * @return {any} data fetched from localstorage
+ */
+const setOrGetLocalStorageItemHelper = (
+  action: string,
+  key: string,
+  value: any = null
+): any => {
+  try {
+    // checking browser support for localStorage
+    if (typeof Storage !== "undefined") {
+      if (action === "set") {
+        localStorage.setItem(key, value)
+        return true
+      } else {
+        return localStorage.getItem(key)
+      }
+    }
+    console.log("This browser has no web storage support.")
+    return false
+  } catch (e) {
+    console.log(
+      "An exception occurred while storing/fetching data in/from localstorage: ",
+      e
+    )
+    return false
+  }
+}

--- a/www/assets/js/notification.js
+++ b/www/assets/js/notification.js
@@ -1,3 +1,8 @@
+import {
+  getLocalStorageItem,
+  setLocalStorageItem
+} from "../../../base-theme/assets/js/utils"
+
 /*
   If there are notifications that have not been dismissed, display them
 */
@@ -5,7 +10,7 @@ const initNotifications = () => {
   $(".notification-close").on("click", onNotificationClose)
   const notifications = document.getElementsByClassName("notification")
   for (const notification of Array.from(notifications)) {
-    if (localStorage.getItem(`${notification.id}_dismissed`) !== "true") {
+    if (getLocalStorageItem(`${notification.id}_dismissed`) !== "true") {
       notification.classList.remove("d-none")
     }
   }
@@ -18,7 +23,7 @@ const onNotificationClose = () => {
   const notifications = document.getElementsByClassName("notification")
   for (const notification of Array.from(notifications)) {
     notification.classList.add("d-none")
-    localStorage.setItem(`${notification.id}_dismissed`, "true")
+    setLocalStorageItem(`${notification.id}_dismissed`, "true")
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/645

#### What's this PR do?
- Add utils for setting and getting data from local storage with checks and error handling so in case an exception is thrown, that exception is caught silently and a message is shown in the console.
- Some more info:
    - I think this type of error can occur when the user has blocked cookies and we try to access cookies either via local storage or any other way. 
    - We are accessing local storage in `notifications.js` and this PR fixes it by using the util in which we are catching all exceptions.
    - But I think cookies are also being accessed in third-party libraries like `pdfjs` and `youtube.js` and this error can occur there too if a user has blocked cookies. So for this, I think we'll have to figure out a good approach to handle this.


#### How should this be manually tested?
- Go to chrome settings -> Cookies and other site data and block all cookies.
- Go to ocw-www, add notification in content so a notification banner is shown, close the banner.
- Open console and you will be seeing this type of error: `Failed to read the 'localStorage' property from 'Window': Access is denied for this document.`  
- Now checkout this branch and repeat the above steps and verify that now no error is shown. Only a normal `console log` will be shown regarding the error.
