### PR TITLE
write fully qualified urls into course sitemap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}
           OCW_IMPORT_STARTER_SLUG: ${{ secrets.OCW_IMPORT_STARTER_SLUG }}
+          STATIC_API_BASE_URL: ${{ secrets.STATIC_API_BASE_URL }}
 
       - name: Deploy PR Preview to Netlify
         uses: nwtgck/actions-netlify@v1.1

--- a/course/layouts/sitemap.xml
+++ b/course/layouts/sitemap.xml
@@ -1,0 +1,27 @@
+{{- $sitemapDomain := getenv "SITEMAP_DOMAIN" | default "ocw.mit.edu" -}}
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+    {{- if .RelPermalink -}}
+    {{- $path := strings.TrimPrefix "/" (partial "site_root_url.html" .RelPermalink) -}}
+    {{- $url := printf "https://%v/%v" $sitemapDomain $path -}}
+  <url>
+    <loc>{{ $url }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.Lang }}"
+                href="{{ $url }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.Lang }}"
+                href="{{ $url }}"
+                />{{ end }}
+  </url>
+    {{- end -}}
+  {{ end }}
+</urlset>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Completes one of the tasks in https://github.com/mitodl/ocw-hugo-themes/issues/673

#### What's this PR do?
This PR uses the newly added `SITEMAP_DOMAIN` env variable to construct fully qualified URLs in the `course` theme's sitemap.  This is being done to improve Google search results.

#### How should this be manually tested?
 - If you've never spun up a course locally before, read the readme to learn how to do so and make sure you have your `.env` configured with a course to run
 - Clone the branch of `ocw-hugo-projects` from [this](https://github.com/mitodl/ocw-hugo-projects/pull/171) PR and make sure you point to it using `COURSE_HUGO_CONFIG_PATH`
 - Set `SITEMAP_DOMAIN` in your `.env` file to `ocw.mit.edu`, or anything you want to test with
 - Make a temporary edit to `start_course.sh`, setting the Hugo command at the end to:
```
hugo server \
  -p 3000 \
  --bind 0.0.0.0 \
  --config $COURSE_HUGO_CONFIG_PATH \
  --themesDir $THEMES_PATH \
  --baseUrl /courses/<your test course id> \
  --renderToDisk
```
 - Run `npm run start:course` (note that the course will not actually be accessible though the dev server)
 - Browse to the folder on disk where your course markdown is stored and look in the `public` folder at `sitemap.xml`.  Verify that the locations written within are fully qualified URLs that take into account the `SITEMAP_DOMAIN` we set along with the `baseUrl` setting that we set.
