### PR TITLE
removes give now heading from www homepage

### DIFF
--- a/www/layouts/home.html
+++ b/www/layouts/home.html
@@ -96,7 +96,6 @@
   <div class="give-now-wrapper">
     <div class="give-now my-5 d-flex justify-content-center">
       <div class="d-flex flex-column justify-content-center">
-        <h2>Give Now</h2>
         <h2>Your Donation Makes a Difference</h2>
         <div class="font-weight-normal h4">
           <a href="/pages/why-give">Learn more</a> about how you can help MIT OpenCourseWare share knowledge with the world.


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/661

#### What's this PR do?
- Removes `Give Now` text/heading from donation section in www home page

#### How should this be manually tested?
- Go to www homepage -> donation/give now section.
- Verify that there is no "Give now" text/heading.

#### Screenshots (if appropriate)
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/93309234/167416950-7afd9b5b-b067-4211-95cf-19828a8e4606.png">

<img width="593" alt="image" src="https://user-images.githubusercontent.com/93309234/167417084-7d75bbce-3a6e-4204-a296-aa731c6fad64.png">

<img width="307" alt="image" src="https://user-images.githubusercontent.com/93309234/167417032-6f4d63d8-5e49-4a4f-8afd-b869b3e696cc.png">

