### PR TITLE
add single template for subfields

### DIFF
--- a/fields/layouts/subfields/single.html
+++ b/fields/layouts/subfields/single.html
@@ -1,0 +1,23 @@
+{{ define "main" }}
+{{- $courselist := . -}}
+<div>
+  {{ block "header" . }}
+  {{ partialCached "header" . }}
+  {{ end }}
+  <div class="container standard-width mx-auto mt-5">
+    {{ partial "course_list" . }}
+  </div>
+  {{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+  <script>
+    {{- $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" | default "https://ocw.mit.edu"  -}}
+    {{- $courseListData := dict -}}
+    {{- range $courselist.Params.courses -}}
+        {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" .id "/data.json") "" -}}
+        {{- $data := getJSON $url -}}
+        {{- $courseListData = merge $courseListData (dict .id $data) -}}
+    {{- end -}}
+    {{- $courseListsData := dict $courselist.Params.uid $courseListData -}}
+    window.courseListsData = JSON.parse("{{ $courseListsData | jsonify }}");
+  </script>
+</div>
+{{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/676

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/670, we added a new theme called `fields` to the repo that can be used for creating a standalone page for a field of study.  A template was left out for displaying a single subfield, and this PR adds that in.

#### How should this be manually tested?
 - Go to https://ocw-studio-rc.odl.mit.edu and create a site using the `mit-fields` starter, making sure you add subfields and associate them with your field and publish your site.
 - Make sure you have `ocw-hugo-projects` cloned locally
 - Find your repo at https://github.mit.edu/ocw-content-rc and clone it locally
 - Set the following env variables in your `.env`:
   - `FIELDS_HUGO_CONFIG_PATH=/path/to/ocw-hugo-projects/mit-fields/config.yaml`
   - `FIELDS_CONTENT_PATH=/path/to/<your test site repo>/`
 - Start the site with `npm run start:fields`
 - Verify that when you click the "see all" button, you are presented with a course list

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/167445345-9a5fbd09-7055-44fc-9939-ff2e786fe101.png)
![image](https://user-images.githubusercontent.com/12089658/167445456-c78f9e4e-e5ab-4876-88dd-8253f291ae13.png)

