### PR TITLE
video player design update

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -257,6 +257,10 @@ table {
   background-color: $blue;
 }
 
+.bg-dark-gray {
+  background-color: $dark-gray;
+}
+
 .bg-white-desktop {
   @include media-breakpoint-up(lg) {
     background-color: $white !important;

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -7,14 +7,6 @@ $enable-responsive-font-sizes: true;
 $headings-font-weight: 600;
 $table-cell-padding: 0.5rem;
 $offcanvas-width: 85vw;
-$transparent: #ffffff00;
-$white: #ffffff;
-$black: #000000;
-$transparent-black: #00000080;
-$light-gray: #f5f5f5;
-$medium-light-gray: #e9e9e9;
-$medium-gray: #9c9d9e;
-$dark-gray: #3d3d3d;
 $partial-collapse-height: 6em;
 
 // full-color design
@@ -24,6 +16,15 @@ $blue: #126f9a;
 $link-blue: #32c5ff;
 $success-message-color: #569a5a;
 $tab-border-color: #32a8d1;
+$transparent: #ffffff00;
+$white: #ffffff;
+$black: #000000;
+$pink: #F63767;
+$transparent-black: #00000080;
+$light-gray: #f5f5f5;
+$medium-light-gray: #e9e9e9;
+$medium-gray: #9c9d9e;
+$dark-gray: #3d3d3d;
 
 // home page
 $max-home-width: 1280px;

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -19,7 +19,7 @@ $tab-border-color: #32a8d1;
 $transparent: #ffffff00;
 $white: #ffffff;
 $black: #000000;
-$pink: #F63767;
+$pink: #f63767;
 $transparent-black: #00000080;
 $light-gray: #f5f5f5;
 $medium-light-gray: #e9e9e9;

--- a/base-theme/layouts/partials/video.html
+++ b/base-theme/layouts/partials/video.html
@@ -20,7 +20,7 @@
     {{ .Content }}
   </div>
   {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime)}}
-  <div class="video-buttons-container">
+  <div class="video-buttons-container mt-5">
 	{{ if $transcriptPdfLocation }}
 	  <div class="video-download-container">
 	    <a class="download-file video-download-button" href="{{ $transcriptPdfLocation }}"><span class="material-icons">file_download</span> Download Transcript</a>

--- a/base-theme/layouts/partials/video.html
+++ b/base-theme/layouts/partials/video.html
@@ -20,7 +20,31 @@
     {{ .Content }}
   </div>
   {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime)}}
-  <div class="video-buttons-container mt-5">
+	<!-- [start] transcript toggleable section -->
+	{{ if $captionsLocation }}
+		<div class="bg-dark-gray white-color mb-3">
+			<div class="transcript-tab-section-toggle pointer"
+					data-target=".transcript" 
+					data-toggle="collapse"
+					aria-controls="transcript"
+					aria-expanded=""
+					>
+				<div class="transcript-tab-header">
+					<span>
+						Transcript
+					</span>
+					<div class="float-right">
+						<i class="material-icons md-18"></i>
+					</div>
+				</div>
+			</div>
+			<div class="container collapse transcript">
+			</div>
+		</div>
+	{{end}}
+	<!-- [end] transcript toggleable section -->
+
+  <!-- <div class="video-buttons-container">
 	{{ if $transcriptPdfLocation }}
 	  <div class="video-download-container">
 	    <a class="download-file video-download-button" href="{{ $transcriptPdfLocation }}"><span class="material-icons">file_download</span> Download Transcript</a>
@@ -31,11 +55,8 @@
 	    <a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
 	  </div>
 	{{end}}
-	</div>
+	</div> -->
 
-  {{ if $captionsLocation }}
-    {{ partial "video-expandable-tab.html" (dict "tabClass" "transcript" "tabTitle" "Transcript" "tabContent" "") }}
-  {{end}}
   {{ if $relatedResourses }}
   	{{ partial "video-expandable-tab.html" (dict "tabClass" "related-resource" "tabTitle" "Related Resources" "tabContent" $relatedResourses) }}
   {{end}}

--- a/base-theme/layouts/partials/video.html
+++ b/base-theme/layouts/partials/video.html
@@ -22,7 +22,7 @@
   {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime)}}
 	<!-- [start] transcript toggleable section -->
 	{{ if $captionsLocation }}
-		<div class="bg-dark-gray white-color mb-3">
+		<div class="bg-dark-gray white-color">
 			<div class="transcript-tab-section-toggle pointer"
 					data-target=".transcript" 
 					data-toggle="collapse"
@@ -44,7 +44,7 @@
 	{{end}}
 	<!-- [end] transcript toggleable section -->
 
-  <!-- <div class="video-buttons-container">
+  <div class="video-buttons-container">
 	{{ if $transcriptPdfLocation }}
 	  <div class="video-download-container">
 	    <a class="download-file video-download-button" href="{{ $transcriptPdfLocation }}"><span class="material-icons">file_download</span> Download Transcript</a>
@@ -55,7 +55,7 @@
 	    <a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
 	  </div>
 	{{end}}
-	</div> -->
+	</div>
 
   {{ if $relatedResourses }}
   	{{ partial "video-expandable-tab.html" (dict "tabClass" "related-resource" "tabTitle" "Related Resources" "tabContent" $relatedResourses) }}

--- a/base-theme/layouts/partials/video_embed.html
+++ b/base-theme/layouts/partials/video_embed.html
@@ -12,15 +12,16 @@
 
 {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime) }}
 {{- range where $.Site.Pages "Params.uid" $uid -}}
-	<div class="video-buttons-container">
-    <div class='video-page-link'>
-      <a href="{{- .Permalink -}}">View Video Page</a>
-      <i class="material-icons video-page-link-icon">chevron_right</i>
+	
+<div class="video-buttons-container">
+    <div class='video-page-link-section' onclick="window.location='{{- .Permalink -}}';">
+      <div class="video-page-link">View video page</div>
+			<i class="material-icons video-page-link">chevron_right</i>
     </div>
-   	{{ if  $downloadLink }}
-	  <div class="video-download-container">
-	    <a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
-	  </div>
-	{{end}}
+   	<!-- {{ if  $downloadLink }}
+			<div class="video-download-container">
+				<a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
+			</div>
+		{{end}} -->
   </div>
 {{- end -}}

--- a/base-theme/layouts/partials/video_embed.html
+++ b/base-theme/layouts/partials/video_embed.html
@@ -18,10 +18,10 @@
       <div class="video-page-link">View video page</div>
 			<i class="material-icons video-page-link">chevron_right</i>
     </div>
-   	<!-- {{ if  $downloadLink }}
+   	{{ if  $downloadLink }}
 			<div class="video-download-container">
 				<a class="download-file video-download-button" href="{{ $downloadLink }}"><span class="material-icons">file_download</span> Download Video</a>
 			</div>
-		{{end}} -->
+		{{end}}
   </div>
 {{- end -}}

--- a/base-theme/layouts/partials/youtube_player.html
+++ b/base-theme/layouts/partials/youtube_player.html
@@ -12,7 +12,7 @@
   <video
     id="video-player-{{ .youtubeKey }}-{{ $random }}"
     class="video-js vjs-default-skin vjs-big-play-centered vjs-ocw"
-    controls="true"
+    controls
     data-setup='{
     "fluid": true,
     "techOrder": ["youtube"],

--- a/base-theme/layouts/partials/youtube_player.html
+++ b/base-theme/layouts/partials/youtube_player.html
@@ -16,6 +16,8 @@
     data-setup='{
     "fluid": true,
     "techOrder": ["youtube"],
+    "inactivityTimeout": 0,
+    "iconsColor": "#FFFFFF",
     "sources": [{"type": "video/youtube", "src": "https://www.youtube.com/embed/{{ .youtubeKey }}"}]
     {{$youtubeParams}} }'
   >

--- a/base-theme/layouts/partials/youtube_player.html
+++ b/base-theme/layouts/partials/youtube_player.html
@@ -8,7 +8,7 @@
 {{$youtubeParams =  delimit (slice `, "youtube": { "end": ` .endTime `}`) "" }}
 {{end}}
 
-<div class="video-container mb-6">
+<div class="video-container embedded-video-container">
   <video
     id="video-player-{{ .youtubeKey }}-{{ $random }}"
     class="video-js vjs-default-skin vjs-big-play-centered vjs-ocw"

--- a/base-theme/layouts/partials/youtube_player.html
+++ b/base-theme/layouts/partials/youtube_player.html
@@ -8,16 +8,15 @@
 {{$youtubeParams =  delimit (slice `, "youtube": { "end": ` .endTime `}`) "" }}
 {{end}}
 
-<div class="video-container">
+<div class="video-container mb-6">
   <video
     id="video-player-{{ .youtubeKey }}-{{ $random }}"
     class="video-js vjs-default-skin vjs-big-play-centered vjs-ocw"
-    controls
+    controls="true"
     data-setup='{
     "fluid": true,
     "techOrder": ["youtube"],
     "inactivityTimeout": 0,
-    "iconsColor": "#FFFFFF",
     "sources": [{"type": "video/youtube", "src": "https://www.youtube.com/embed/{{ .youtubeKey }}"}]
     {{$youtubeParams}} }'
   >

--- a/course/assets/course.js
+++ b/course/assets/course.js
@@ -12,6 +12,7 @@ import { initDivToggle } from "./js/div_toggle"
 import { initCourseInfoExpander } from "./js/course_expander"
 import { initVideoTranscriptTrack } from "./js/video_transcript_track"
 import { initPlayBackSpeedButton } from "./js/video_playback_speed"
+import { initVideoFullscreenToggle } from "./js/video_fullscreen_toggle"
 import {
   clearSolution,
   checkAnswer,
@@ -28,4 +29,5 @@ $(function() {
   clearSolution()
   checkAnswer()
   showSolution()
+  initVideoFullscreenToggle()
 })

--- a/course/assets/css/video-transcript.scss
+++ b/course/assets/css/video-transcript.scss
@@ -29,10 +29,27 @@
 }
 
 .transcript-line:hover {
-  background-color: #f6f7f9;
+  background-color: $medium-gray;
 }
 
 .transcript-line.is-active {
   font-weight: bold;
-  color: #a31f34;
+  color: $orange;
+}
+
+.transcript-tab-header {
+  padding: 5px 15px 5px;
+  margin-bottom: 10px;
+}
+
+.transcript-tab-section-toggle {
+  i:after {
+    content: "keyboard_arrow_down";
+  }
+}
+
+.transcript-tab-section-toggle[aria-expanded="true"] {
+  i:after {
+    content: "keyboard_arrow_up" !important;
+  }
 }

--- a/course/assets/css/video-transcript.scss
+++ b/course/assets/css/video-transcript.scss
@@ -39,7 +39,7 @@
 
 .transcript-tab-header {
   padding: 5px 15px 5px;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
 }
 
 .transcript-tab-section-toggle {

--- a/course/assets/css/video.scss
+++ b/course/assets/css/video.scss
@@ -55,12 +55,17 @@
   }
 }
 
-.video-page {
+.embedded-video-container {
+  // this padding will be applied when video is embedded
+  padding-bottom: 44px;
   background-color: $light-gray;
+}
 
+.video-page {
   .video-container {
     height: 0;
-    padding-bottom: 56%;
+    padding-bottom: 56% !important;
+    margin-bottom: 44px;
     position: relative;
     max-width: 100%;
   }
@@ -75,9 +80,10 @@
 }
 
 .video-buttons-container {
-  background-color: #f6f7f9;
+  background-color: $light-gray;
   overflow: hidden;
   margin-bottom: 35px;
+  border-top: 0.5px solid $medium-gray;
 }
 
 .video-download-container {
@@ -97,13 +103,20 @@ a.video-download-button:visited {
   color: white;
 }
 
-.video-page-link {
-  text-transform: uppercase;
-  padding-top: 35px;
-  padding-bottom: 25px;
-  padding-left: 10px;
-  font-weight: bold;
+.video-page-link-section {
+  padding: 5px 15px 5px;
   display: inline-flex;
+}
+
+.video-page-link {
+  text-decoration: none;
+  color: $black !important;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.video-page-link:hover {
+  text-decoration: none !important;
 }
 
 #main-content a.download-file.video-download-button:link {
@@ -121,12 +134,6 @@ a.video-download-button:visited {
     padding-right: 15px;
   }
   .video-download-container:first-child {
-    padding-bottom: 0px;
-  }
-
-  .video-page-link {
-    float: right;
-    padding-top: 15px;
     padding-bottom: 0px;
   }
 }

--- a/course/assets/css/video.scss
+++ b/course/assets/css/video.scss
@@ -56,6 +56,8 @@
 }
 
 .video-page {
+  background-color: $light-gray;
+
   .video-container {
     height: 0;
     padding-bottom: 56%;

--- a/course/assets/css/video.scss
+++ b/course/assets/css/video.scss
@@ -83,7 +83,6 @@
   background-color: $light-gray;
   overflow: hidden;
   margin-bottom: 35px;
-  border-top: 0.5px solid $medium-gray;
 }
 
 .video-download-container {

--- a/course/assets/css/videojs_player.scss
+++ b/course/assets/css/videojs_player.scss
@@ -1,3 +1,8 @@
+// color variables
+$control-item-color: $dark-gray;
+$control-item-bg-color: $light-gray;
+$slider-color: $pink;
+
 .vjs-ocw.video-js {
   .ytp-chrome-top-buttons {
     display: none;
@@ -12,8 +17,14 @@
 
   .vjs-control-bar {
     height: 4.4em;
-    background-color: #2b333f;
+    background-color: $control-item-bg-color;
+    color: $control-item-color;
     transition: visibility 2s, opacity 0.1s;
+    bottom: auto;
+  }
+
+  .vjs-menu-content{
+    background-color: $control-item-bg-color !important;
   }
 
   .vjs-volume-bar {
@@ -28,6 +39,11 @@
     min-width: 50px;
   }
 
+  .vjs-volume-level{
+    background-color: $control-item-color;
+  }
+
+
   .vjs-progress-control {
     position: absolute;
     bottom: 37px;
@@ -39,13 +55,13 @@
     .vjs-progress-holder {
       margin-left: 18px;
       margin-right: 18px;
-      color: $blue;
+      color: $slider-color;
       font-size: 1.5em;
     }
 
     .vjs-play-progress,
     .vjs-slider-bar {
-      background-color: $blue;
+      background-color: $slider-color;
     }
 
     .vjs-progress-holder,

--- a/course/assets/css/videojs_player.scss
+++ b/course/assets/css/videojs_player.scss
@@ -21,6 +21,7 @@ $slider-color: $pink;
     color: $control-item-color;
     transition: visibility 2s, opacity 0.1s;
     bottom: auto;
+    display: flex;
   }
 
   .vjs-menu-content {

--- a/course/assets/css/videojs_player.scss
+++ b/course/assets/css/videojs_player.scss
@@ -23,7 +23,7 @@ $slider-color: $pink;
     bottom: auto;
   }
 
-  .vjs-menu-content{
+  .vjs-menu-content {
     background-color: $control-item-bg-color !important;
   }
 
@@ -39,10 +39,9 @@ $slider-color: $pink;
     min-width: 50px;
   }
 
-  .vjs-volume-level{
+  .vjs-volume-level {
     background-color: $control-item-color;
   }
-
 
   .vjs-progress-control {
     position: absolute;

--- a/course/assets/js/video_fullscreen_toggle.js
+++ b/course/assets/js/video_fullscreen_toggle.js
@@ -1,0 +1,22 @@
+// @ts-nocheck
+
+export const initVideoFullscreenToggle = () => {
+  // this fixes the issue of control bar going to the top on fullscreen
+  $(document).on(
+    "mozfullscreenchange webkitfullscreenchange fullscreenchange",
+    function() {
+      const fullscreenElement =
+        document.fullscreenElement ||
+        document.mozFullScreenElement ||
+        document.webkitFullscreenElement ||
+        document.msFullscreenElement
+      if (fullscreenElement) {
+        // entering full screen
+        $(".vjs-control-bar").css("bottom", 0)
+      } else {
+        // exiting full screen
+        $(".vjs-control-bar").css("bottom", "auto")
+      }
+    }
+  )
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/658

#### What's this PR do?
- Updates the styling according to the new [design](https://projects.invisionapp.com/d/main?origin=v7#/console/21537330/461529499/comments?scrollOffset=576).
- Moves player controls below the video player and make them permanently visible, instead of displaying on hover
- Attaches the transcript widget to the video player
- Link the youtube button to the youtube page for the current video
- **Note:** A separate [issue](https://github.com/mitodl/ocw-hugo-themes/issues/731) has been created for moving download buttons to in video control bar. 
 
#### How should this be manually tested?
- Verify the points mentioned above.
- Test any use-case that needs to be tested.

#### Screenshots (if appropriate)
<img width="610" alt="image" src="https://user-images.githubusercontent.com/93309234/167835150-69c5f1be-46f5-4118-aef2-99e25a51d649.png">

<img width="610" alt="image" src="https://user-images.githubusercontent.com/93309234/167835267-2eb6f232-4017-48fa-88a7-d9c408adabe5.png">

Embedded video player:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/93309234/167835437-bf9928e7-6e7f-4858-b334-4f394c994223.png">

When the page loads and the video has not started yet: 

<img width="627" alt="image" src="https://user-images.githubusercontent.com/93309234/168023823-13f2ea82-4ff4-4213-95d1-e0d7657736ce.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/93309234/168023930-31afa113-46a3-4f5c-8715-9f9e81e747c3.png">

