### PR TITLE
replace uses of Page.URL with Page.RelPermalink

### DIFF
--- a/course/layouts/partials/course_banner.html
+++ b/course/layouts/partials/course_banner.html
@@ -6,7 +6,7 @@
     {{ $courseHomePage := .Site.GetPage "/" }}
     <a
       class="{{ $bannerClass }}"
-      href="{{ $courseHomePage.URL }}"
+      href="{{ $courseHomePage.RelPermalink }}"
     >{{ $courseData.course_title }}</a>
   </div>
 </div>

--- a/course/layouts/partials/video-gallery-item.html
+++ b/course/layouts/partials/video-gallery-item.html
@@ -1,5 +1,5 @@
 <div class="mb-2 border-gray rounded video-gallery-card">
-  <a class="video-link" href="{{- .URL -}}">
+  <a class="video-link" href="{{- .RelPermalink -}}">
     <div class="inner-container">
       <div class="left-col">
         {{- if isset .Params.video_files "video_thumbnail_file" -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/680

#### What's this PR do?
This PR replaces calls to the [deprecated](https://discourse.gohugo.io/t/pages-url-is-deprecated/20645) `Page.URL` property and replaces it with `Page.RelPermalink`.  

#### How should this be manually tested?
 - Clone any course repo from the `mitocwcontent` organization locally and point to it using the instructions in the readme
 - Attempt to spin up the course on `main` with `npm run start:course`, it should fail
 - Try the same thing on this branch (`cg/page-url-deprecated`) and the build should succeed
