### PR TITLE
make sure base_url is not blank before writing a sitemap into the index

### DIFF
--- a/www/layouts/sitemap.xml
+++ b/www/layouts/sitemap.xml
@@ -15,10 +15,13 @@
     {{- $sites := .sites -}}
     {{- if $sites -}}
       {{ range $index, $courseItem := $sites }}
-        {{- $url :=  printf "https://%v/%v/sitemap.xml" $sitemapDomain (strings.TrimPrefix "/" (strings.TrimSuffix "/" $courseItem.base_url)) -}}
+        {{- $path := strings.TrimPrefix "/" (strings.TrimSuffix "/" $courseItem.base_url) -}}
+        {{- if not (eq $path "") -}}
+          {{- $url :=  printf "https://%v/%v/sitemap.xml" $sitemapDomain $path -}}
   <sitemap>
     <loc>{{ $url }}</loc>
   </sitemap>
+        {{- end -}}
       {{ end }}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/686

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/679 we added a sitemap to the `www` theme that writes a `sitemapindex` including all of the sites returned by a call to the `ocw-studio` API.  This PR adds a check in the `www` sitemap index template that makes sure the `base_url` property on the site returned by the `ocw-studio` API is not blank before including it in the index.

#### How should this be manually tested?
 - Set the following in your `.env`:
   - `API_BEARER_TOKEN=<get value from Heroku production ocw-studio`
   - `OCW_STUDIO_BASE_URL=https://ocw-studio.odl.mit.edu/`
   - `SITEMAP_DOMAIN=ocw.mit.edu`
 - Run `npm run start:www`
 - Visit http://localhost:3000/sitemap.xml and verify that you don't see:
```
      <sitemap>
    <loc>https://ocw.mit.edu//sitemap.xml</loc>
  </sitemap>
```
