### PR TITLE
remove the old coursemedia hack

### DIFF
--- a/base-theme/layouts/partials/course_carousel_card.html
+++ b/base-theme/layouts/partials/course_carousel_card.html
@@ -14,11 +14,6 @@
 <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 .itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
   <div class="course-card card bg-white">
     <a href="/courses/{{ .courseId }}" aria-hidden="true" tabindex="-1">
-      {{/* The following is a temporary hack that should be removed following the decommissioning of the EC2 OCW Next build servers */}}
-      {{ $courseBaseUrl := getenv "COURSE_BASE_URL" | default "" }}
-      {{ if in $courseBaseUrl "ocwnext" }}
-        {{ $courseImageSrc = replace $courseImageSrc "/courses" "/coursemedia" }}
-      {{ end }}
       <img src="{{ $courseImageSrc }}" alt=""/>
     </a>
     <div class="course-card-content pt-1 px-3 pb-3">

--- a/base-theme/layouts/partials/course_carousel_card.html
+++ b/base-theme/layouts/partials/course_carousel_card.html
@@ -14,7 +14,7 @@
 <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 .itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
   <div class="course-card card bg-white">
     <a href="/courses/{{ .courseId }}" aria-hidden="true" tabindex="-1">
-      <img src="{{ $courseImageSrc }}" alt=""/>
+      <img src="{{ partial "resource_url.html" $courseImageSrc }}" alt=""/>
     </a>
     <div class="course-card-content pt-1 px-3 pb-3">
       <div class="course-level">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/265

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/264, we added in a hack to rewrite the course carousel URLs and replace instances of `coursemedia` with `courses` in the image URL.  This was necessary due to the way we were deploying the site with a custom EC2 server directly from `ocw-to-hugo` output, but is no longer necessary now that the EC2 servers have been deprecated.

#### How should this be manually tested?
 - Set the following env variables:
```
OCW_STUDIO_BASE_URL=https://ocw-studio.odl.mit.edu/
STATIC_API_BASE_URL=https://ocw.mit.edu/
RESOURCE_BASE_URL=https://ocw.mit.edu/
OCW_IMPORT_STARTER_SLUG=ocw-course
```
 - Run `npm run start:www`
 - Visit http://localhost:3000
 - You should see the featured courses carousel and the images should load.  If you inspect the image sources, you should notice that the URLs are fully qualified, prefixed with what we have set on `RESOURCE_BASE_URL`, for example: `https://ocw.mit.edu/courses/res-8-007-cosmic-origin-of-the-chemical-elements-fall-2019/5aa51be2c9a31a5bd87adaa05a6eca61_RES.8-007f19.jpg`
 - Comment out `RESOURCE_BASE_URL` in your `.env` and restart the dev server
 - Visit http://localhost:3000 again
 - Notice that the images now fail to load.  Inspect one of them and you should see a relative URL like `/courses/res-8-007-cosmic-origin-of-the-chemical-elements-fall-2019/5aa51be2c9a31a5bd87adaa05a6eca61_RES.8-007f19.jpg`.  This is the default and expected behavior for the deployed OCW site where static resources will be deployed alongside the HTML.

#### Screenshots (if appropriate)
![Screenshot_20220513_120632](https://user-images.githubusercontent.com/12089658/168323529-05bb26dc-1a3b-41f2-953a-f9cb4d6e755f.png)
![Screenshot_20220513_120748](https://user-images.githubusercontent.com/12089658/168323661-311e9f39-748a-4b2a-9629-7eebfadeac68.png)

