### PR TITLE
update theme to use url_path

### DIFF
--- a/base-theme/layouts/partials/course_carousel_card.html
+++ b/base-theme/layouts/partials/course_carousel_card.html
@@ -13,7 +13,7 @@
 {{ end }}
 <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 .itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
   <div class="course-card card bg-white">
-    <a href="{{ .urlPath }}" aria-hidden="true" tabindex="-1">
+    <a href="{{ partial "site_root_url.html" .urlPath }}" aria-hidden="true" tabindex="-1">
       <img src="{{ partial "resource_url.html" $courseImageSrc }}" alt=""/>
     </a>
     <div class="course-card-content pt-1 px-3 pb-3">
@@ -22,7 +22,7 @@
       </div>
       <div class="pt-1">
         <div class="h5">
-          <a href="{{ .urlPath }}">{{ $courseTitle }}</a>
+          <a href="{{ partial "site_root_url.html" .urlPath }}">{{ $courseTitle }}</a>
         </div>
       </div>
       <div class="pt-1">

--- a/base-theme/layouts/partials/course_carousel_card.html
+++ b/base-theme/layouts/partials/course_carousel_card.html
@@ -13,7 +13,7 @@
 {{ end }}
 <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 .itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
   <div class="course-card card bg-white">
-    <a href="/courses/{{ .courseId }}" aria-hidden="true" tabindex="-1">
+    <a href="{{ .urlPath }}" aria-hidden="true" tabindex="-1">
       <img src="{{ partial "resource_url.html" $courseImageSrc }}" alt=""/>
     </a>
     <div class="course-card-content pt-1 px-3 pb-3">
@@ -22,7 +22,7 @@
       </div>
       <div class="pt-1">
         <div class="h5">
-          <a href="/courses/{{ .courseId }}">{{ $courseTitle }}</a>
+          <a href="{{ .urlPath }}">{{ $courseTitle }}</a>
         </div>
       </div>
       <div class="pt-1">

--- a/base-theme/layouts/partials/featured_course_cards.html
+++ b/base-theme/layouts/partials/featured_course_cards.html
@@ -21,9 +21,10 @@
           </div>
           <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
             {{ range $index, $courseItem := $courses }}
-              {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.id "/data.json") "" -}}
+              {{- $urlPath := partial "site_root_url.html" $courseItem.id -}}
+              {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) $urlPath "/data.json") "" -}}
               {{- $courseData := getJSON $url -}}
-              {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "urlPath" $courseItem.id "numCourses" (len $courses))}}
+              {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "urlPath" $urlPath "numCourses" (len $courses))}}
             {{ end }}
           </div>
         </div>

--- a/base-theme/layouts/partials/featured_course_cards.html
+++ b/base-theme/layouts/partials/featured_course_cards.html
@@ -21,9 +21,9 @@
           </div>
           <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
             {{ range $index, $courseItem := $courses }}
-              {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" .id "/data.json") "" -}}
+              {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.id "/data.json") "" -}}
               {{- $courseData := getJSON $url -}}
-              {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "courseId" $courseItem.id "numCourses" (len $courses))}}
+              {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "urlPath" $courseItem.id "numCourses" (len $courses))}}
             {{ end }}
           </div>
         </div>

--- a/fields/layouts/home.html
+++ b/fields/layouts/home.html
@@ -35,8 +35,9 @@
       {{- $subfield := index (where $.Site.Pages ".Params.uid" .) 0 -}}
       {{- $subfield_data := dict -}}
       {{- range (first 5 $subfield.Params.courses) -}}
-          {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" .id "/data.json") "" -}}
+          {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" .id "/data.json") "" -}}
           {{- $data := getJSON $url -}}
+          {{- $data = merge $data (dict "url_path" .id) -}}
           {{- $subfield_data = merge $subfield_data (dict .id $data) -}}
       {{- end -}}
       {{- $subfields_data = merge $subfields_data (dict $subfield.Params.uid $subfield_data) -}}

--- a/fields/layouts/subfields/single.html
+++ b/fields/layouts/subfields/single.html
@@ -12,8 +12,9 @@
     {{- $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" | default "https://ocw.mit.edu"  -}}
     {{- $courseListData := dict -}}
     {{- range $courselist.Params.courses -}}
-        {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" .id "/data.json") "" -}}
+        {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" .id "/data.json") "" -}}
         {{- $data := getJSON $url -}}
+        {{- $data = merge $data (dict "url_path" .id) -}}
         {{- $courseListData = merge $courseListData (dict .id $data) -}}
     {{- end -}}
     {{- $courseListsData := dict $courselist.Params.uid $courseListData -}}

--- a/www/assets/js/LearningResources.ts
+++ b/www/assets/js/LearningResources.ts
@@ -81,6 +81,7 @@ export interface CourseJSON {
   level: Level
   image_src: string
   course_image_metadata: CourseImageMetadata
+  url_path: string
 }
 
 /**

--- a/www/assets/js/LearningResources.ts
+++ b/www/assets/js/LearningResources.ts
@@ -81,7 +81,6 @@ export interface CourseJSON {
   level: Level
   image_src: string
   course_image_metadata: CourseImageMetadata
-  url_path: string
 }
 
 /**

--- a/www/assets/js/components/SearchResult.tsx
+++ b/www/assets/js/components/SearchResult.tsx
@@ -120,7 +120,7 @@ export function LearningResourceDisplay(props: SRProps) {
   const maxTags = 3
   const runSlug = object.run_slug
   const url = runSlug
-    ? `${runSlug.includes("courses/") ? "/" : "/courses"}${runSlug}`
+    ? `${runSlug.includes("courses/") ? "/" : "/courses/"}${runSlug}`
     : ""
 
   if (isResource(object)) {

--- a/www/assets/js/components/SearchResult.tsx
+++ b/www/assets/js/components/SearchResult.tsx
@@ -118,6 +118,10 @@ function isResource(object: LearningResource): boolean {
 export function LearningResourceDisplay(props: SRProps) {
   const { object, id } = props
   const maxTags = 3
+  const runSlug = object.run_slug
+  const url = runSlug
+    ? `${runSlug.includes("courses/") ? "/" : "/courses"}${runSlug}`
+    : ""
 
   if (isResource(object)) {
     return (
@@ -133,7 +137,7 @@ export function LearningResourceDisplay(props: SRProps) {
         >
           <div className="lr-row resource-header">
             <div className="resource-type">
-              <a href={`/courses/${object.run_slug}`}>
+              <a href={url}>
                 <Dotdotdot clamp={3}>
                   {`${object.coursenum} | ${object.run_title}`}
                 </Dotdotdot>
@@ -156,11 +160,7 @@ export function LearningResourceDisplay(props: SRProps) {
               <div className="subtitles">
                 <Dotdotdot clamp={3}>{object.description}</Dotdotdot>
               </div>
-              <Topics
-                object={object}
-                maxTags={maxTags}
-                moreUrl={`/courses/${object.run_slug}`}
-              />
+              <Topics object={object} maxTags={maxTags} moreUrl={url} />
             </div>
           </div>
         </div>

--- a/www/assets/js/lib/search.test.tsx
+++ b/www/assets/js/lib/search.test.tsx
@@ -571,11 +571,14 @@ describe("search library", () => {
     })
   })
 
-  it("should let you convert a CourseJSON record to a LearningResource", () => {
-    const lr = courseJSONToLearningResource(
-      "courses/course-name-i-made-up",
-      makeCourseJSON()
-    )
-    expect(lr.url).toBe("/courses/course-name-i-made-up/")
+  //
+  ;["courses/", ""].forEach(prefix => {
+    it("should let you convert a CourseJSON record to a LearningResource", () => {
+      const lr = courseJSONToLearningResource(
+        `${prefix}course-name-i-made-up`,
+        makeCourseJSON()
+      )
+      expect(lr.url).toBe("/courses/course-name-i-made-up/")
+    })
   })
 })

--- a/www/assets/js/lib/search.test.tsx
+++ b/www/assets/js/lib/search.test.tsx
@@ -573,7 +573,7 @@ describe("search library", () => {
 
   it("should let you convert a CourseJSON record to a LearningResource", () => {
     const lr = courseJSONToLearningResource(
-      "course-name-i-made-up",
+      "courses/course-name-i-made-up",
       makeCourseJSON()
     )
     expect(lr.url).toBe("/courses/course-name-i-made-up/")

--- a/www/assets/js/lib/search.ts
+++ b/www/assets/js/lib/search.ts
@@ -537,7 +537,7 @@ export const courseJSONToLearningResource = (
   run_title: null,
   run_slug: null,
   content_type: null,
-  url: `/courses/${name}/`,
+  url: courseData.url_path,
   short_url: null,
   course_id: courseData.site_uid || courseData.legacy_uid,
   coursenum: courseData.primary_course_number,

--- a/www/assets/js/lib/search.ts
+++ b/www/assets/js/lib/search.ts
@@ -537,7 +537,8 @@ export const courseJSONToLearningResource = (
   run_title: null,
   run_slug: null,
   content_type: null,
-  url: `/${name}/`,
+  // a temporary hack to handle runs possibly including the "courses" prefix
+  url: name.includes("courses/") ? `/${name}/` : `/courses/${name}/`,
   short_url: null,
   course_id: courseData.site_uid || courseData.legacy_uid,
   coursenum: courseData.primary_course_number,
@@ -652,13 +653,15 @@ export const getCourseUrl = (result: CourseResult) => {
     return null
   }
   const publishedRuns = result.runs.filter(run => run.published)
-  return !emptyOrNil(publishedRuns)
-    ? `/courses/${
-        publishedRuns.sort((a, b) =>
-          a.best_start_date < b.best_start_date ? 1 : -1
-        )[0].slug
-      }/`
-    : null
+  if (!emptyOrNil(publishedRuns)) {
+    const publishedRun = publishedRuns.sort((a, b) =>
+      a.best_start_date < b.best_start_date ? 1 : -1
+    )[0].slug
+    // a temporary hack to handle runs possibly including the "courses" prefix
+    return publishedRun.includes("courses/")
+      ? `/${publishedRun}/`
+      : `/courses/${publishedRun}/`
+  } else return null
 }
 
 export const getSectionUrl = (result: LearningResourceResult) => {
@@ -691,7 +694,11 @@ export const getResourceUrl = (result: LearningResourceResult) => {
   ) {
     // parse the url to get section pieces, then construct a new section url
     const sectionUrl = getSectionUrl(result)
-    return `/courses/${result.run_slug}${sectionUrl}`
+    const runSlug = result.run_slug
+    // a temporary hack to handle runs possibly including the "courses" prefix
+    return `${
+      runSlug.includes("courses/") ? "/" : "/courses/"
+    }${runSlug}${sectionUrl}`
   } else {
     // Non-page results should have full URLs, convert to CDN if it's an S3 URL
     try {

--- a/www/assets/js/lib/search.ts
+++ b/www/assets/js/lib/search.ts
@@ -537,7 +537,7 @@ export const courseJSONToLearningResource = (
   run_title: null,
   run_slug: null,
   content_type: null,
-  url: courseData.url_path,
+  url: `/${name}/`,
   short_url: null,
   course_id: courseData.site_uid || courseData.legacy_uid,
   coursenum: courseData.primary_course_number,

--- a/www/layouts/collections/single.html
+++ b/www/layouts/collections/single.html
@@ -34,8 +34,9 @@
       {{- $course_list := index (where $.Site.Pages ".Params.uid" .) 0 -}}
       {{- $course_list_data := dict -}}
       {{- range (first 5 $course_list.Params.courses) -}}
-          {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" .id "/data.json") "" -}}
+          {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" .id "/data.json") "" -}}
           {{- $data := getJSON $url -}}
+          {{- $data = merge $data (dict "url_path" .id) -}}
           {{- $course_list_data = merge $course_list_data (dict .id $data) -}}
       {{- end -}}
       {{- $course_lists_data = merge $course_lists_data (dict $course_list.Params.uid $course_list_data) -}}

--- a/www/layouts/course-lists/single.html
+++ b/www/layouts/course-lists/single.html
@@ -12,8 +12,9 @@
     {{- $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" | default "https://ocwnext.odl.mit.edu"  -}}
     {{- $courseListData := dict -}}
     {{- range $courselist.Params.courses -}}
-        {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" .id "/data.json") "" -}}
+        {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" .id "/data.json") "" -}}
         {{- $data := getJSON $url -}}
+        {{- $data = merge $data (dict "url_path" .id) -}}
         {{- $courseListData = merge $courseListData (dict .id $data) -}}
     {{- end -}}
     {{- $courseListsData := dict $courselist.Params.uid $courseListData -}}

--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -23,9 +23,11 @@
         <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
           {{ $resultsSlice := first 10 $results }}
           {{ range $index, $courseItem := $resultsSlice  }}
-            {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.id "/data.json") "" -}}
-            {{- $courseData := getJSON $url -}}
-            {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "courseId" $courseItem.name "numCourses" (len $resultsSlice))}}
+            {{- if $courseItem.url_path -}}
+              {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.url_path "/data.json") "" -}}
+              {{- $courseData := getJSON $url -}}
+              {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "urlPath" $courseItem.url_path "numCourses" (len $resultsSlice))}}
+            {{- end -}}
           {{ end }}
         </div>
       </div>

--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -23,7 +23,7 @@
         <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
           {{ $resultsSlice := first 10 $results }}
           {{ range $index, $courseItem := $resultsSlice  }}
-            {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" $courseItem.name "/data.json") "" -}}
+            {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.url_path "/data.json") "" -}}
             {{- $courseData := getJSON $url -}}
             {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "courseId" $courseItem.name "numCourses" (len $resultsSlice))}}
           {{ end }}

--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -23,7 +23,7 @@
         <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
           {{ $resultsSlice := first 10 $results }}
           {{ range $index, $courseItem := $resultsSlice  }}
-            {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.url_path "/data.json") "" -}}
+            {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.id "/data.json") "" -}}
             {{- $courseData := getJSON $url -}}
             {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "courseId" $courseItem.name "numCourses" (len $resultsSlice))}}
           {{ end }}

--- a/www/layouts/resource_collections/single.html
+++ b/www/layouts/resource_collections/single.html
@@ -22,20 +22,23 @@
     {{- $resourceURLMap := dict -}}
     {{- range $collection.Params.resources.content -}}
       {{- $itemUUID := index . 0 -}}
-      {{- $courseId := index . 1 -}}
-      {{- if not (isset $contentMap $courseId) -}}
-        {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" $courseId "/content_map.json") "" -}}
+      {{- $urlPath := index . 1 -}}
+      {{- if not (isset $contentMap $urlPath) -}}
+        {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $urlPath "/content_map.json") "" -}}
         {{- $mapData := getJSON $url -}}
-        {{- $contentMap = dict $courseId $mapData | merge $contentMap -}}
+        {{- $mapData = merge $mapData (dict "url_path" $urlPath) -}}
+        {{- $contentMap = dict $urlPath $mapData | merge $contentMap -}}
       {{- end -}}
-      {{- if not (isset $courseJSONMap $courseId) -}}
-        {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/courses/" $courseId "/data.json") "" -}}
+      {{- if not (isset $courseJSONMap $urlPath) -}}
+        {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $urlPath "/data.json") "" -}}
         {{- $data := getJSON $url -}}
-        {{- $courseJSONMap = merge $courseJSONMap (dict $courseId $data) -}}
+        {{- $data = merge $data (dict "url_path" $urlPath) -}}
+        {{- $courseJSONMap = merge $courseJSONMap (dict $urlPath $data) -}}
       {{- end -}}
-      {{- $courseJSONRelpath := index (index $contentMap $courseId) $itemUUID -}}
+      {{- $courseJSONRelpath := index (index $contentMap $urlPath) $itemUUID -}}
       {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) $courseJSONRelpath) "" -}}
       {{- $resourceJSON := getJSON $url -}}
+      {{- $resourceJSON = merge $resourceJSON (dict "url_path" $urlPath) -}}
       {{- $resourceJSONMap = dict $itemUUID $resourceJSON | merge $resourceJSONMap -}}
       {{- $resourceURLMap = dict $itemUUID $url | merge $resourceURLMap -}}
     {{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/699

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1316 and subsequently https://github.com/mitodl/ocw-studio/pull/1371, we added the ability for content authors to customize the URL of their site.  This PR changes the theme so that `url_path` is used where it's available, assuming the `url_path` is already prefixed with `root-url-path`.  It's also assumed that `id` in some relation data is filled with the value of `url_path`.

 #### How should this be manually tested?
 - Clone `ocw-www` from `ocw-content-rc`
 - In your `.env`, set the following:
```
OCW_STUDIO_BASE_URL=https://ocw-studio-rc.odl.mit.edu/
RESOURCE_BASE_URL=https://ocwnext-rc.odl.mit.edu
STATIC_API_BASE_URL=https://ocwnext-rc.odl.mit.edu/
WWW_CONTENT_PATH=/path/to/ocw-content-rc/ocw-www/
```
 - Run `npm run start:www`
 - Scroll down to the new courses section, click any of the courses and replace the domain with `ocwnext-rc.odl.mit.edu` and the course should load
