### PR TITLE
source resource descriptions from markdown body

### DIFF
--- a/course/layouts/partials/content_header.html
+++ b/course/layouts/partials/content_header.html
@@ -1,0 +1,28 @@
+{{ $shouldCollapseTitle := gt (len .Title) 75 }}
+<header>
+  <div
+    class="course-section-title-container {{ if $shouldCollapseTitle }}collapse{{ end }}"
+    id="course-title"
+  >
+    {{ with .Params.parent_title }}
+    <h3 class="parent-title">{{ . }}</h3>
+    {{ end }}
+    <h1 class="text-uppercase font-weight-bold pb-1 mb-3">{{ .Title }}</h1>
+  </div>
+  <div class="d-flex">
+    {{ if $shouldCollapseTitle }}
+    <div class="collapse-btn-section ml-auto pt-2 px-3">
+      <a
+        role="button"
+        class="collapsed"
+        data-toggle="collapse"
+        href="#course-title"
+        aria-expanded="false"
+        aria-controls="course-title"
+      >
+        <span class="material-icons"></span>
+      </a>
+    </div>
+    {{ end }}
+  </div>
+</header>

--- a/course/layouts/partials/course_content.html
+++ b/course/layouts/partials/course_content.html
@@ -1,32 +1,6 @@
 {{ $shouldCollapseTitle := gt (len .Title) 75 }}
 <div class="rounded mb-2">
-  <header>
-    <div
-      class="course-section-title-container {{ if $shouldCollapseTitle }}collapse{{ end }}"
-      id="course-title"
-    >
-      {{ with .Params.parent_title }}
-      <h3 class="parent-title">{{ . }}</h3>
-      {{ end }}
-      <h1 class="text-uppercase font-weight-bold pb-1 mb-3">{{ .Title }}</h1>
-    </div>
-    <div class="d-flex">
-      {{ if $shouldCollapseTitle }}
-      <div class="collapse-btn-section ml-auto pt-2 px-3">
-        <a
-          role="button"
-          class="collapsed"
-          data-toggle="collapse"
-          href="#course-title"
-          aria-expanded="false"
-          aria-controls="course-title"
-        >
-          <span class="material-icons"></span>
-        </a>
-      </div>
-      {{ end }}
-    </div>
-  </header>
+  {{ partial "content_header.html" . }}
   {{ partial "mobile_nav_toggle.html" . }}
   <article class="content pt-3 mt-1 mr-5 mr-md-0">
     <main id="course-content-section">{{- .Content -}}</main>

--- a/course/layouts/partials/resource_title.html
+++ b/course/layouts/partials/resource_title.html
@@ -1,31 +1,4 @@
-{{ $shouldCollapseTitle := gt (len .Title) 75 }}
 <div class="rounded mb-2">
-  <header>
-    <div
-      class="course-section-title-container {{ if $shouldCollapseTitle }}collapse{{ end }}"
-      id="course-title"
-    >
-      {{ with .Params.parent_title }}
-      <h3 class="parent-title">{{ . }}</h3>
-      {{ end }}
-      <h1 class="text-uppercase font-weight-bold pb-1 mb-3">{{ .Title }}</h1>
-    </div>
-    <div class="d-flex">
-      {{ if $shouldCollapseTitle }}
-      <div class="collapse-btn-section ml-auto pt-2 px-3">
-        <a
-          role="button"
-          class="collapsed"
-          data-toggle="collapse"
-          href="#course-title"
-          aria-expanded="false"
-          aria-controls="course-title"
-        >
-          <span class="material-icons"></span>
-        </a>
-      </div>
-      {{ end }}
-    </div>
-  </header>
+  {{ partial "content_header.html" . }}
   {{ partial "mobile_nav_toggle.html" . }}
 </div>

--- a/course/layouts/partials/resource_title.html
+++ b/course/layouts/partials/resource_title.html
@@ -1,0 +1,31 @@
+{{ $shouldCollapseTitle := gt (len .Title) 75 }}
+<div class="rounded mb-2">
+  <header>
+    <div
+      class="course-section-title-container {{ if $shouldCollapseTitle }}collapse{{ end }}"
+      id="course-title"
+    >
+      {{ with .Params.parent_title }}
+      <h3 class="parent-title">{{ . }}</h3>
+      {{ end }}
+      <h1 class="text-uppercase font-weight-bold pb-1 mb-3">{{ .Title }}</h1>
+    </div>
+    <div class="d-flex">
+      {{ if $shouldCollapseTitle }}
+      <div class="collapse-btn-section ml-auto pt-2 px-3">
+        <a
+          role="button"
+          class="collapsed"
+          data-toggle="collapse"
+          href="#course-title"
+          aria-expanded="false"
+          aria-controls="course-title"
+        >
+          <span class="material-icons"></span>
+        </a>
+      </div>
+      {{ end }}
+    </div>
+  </header>
+  {{ partial "mobile_nav_toggle.html" . }}
+</div>

--- a/course/layouts/partials/video.html
+++ b/course/layouts/partials/video.html
@@ -17,7 +17,7 @@
 
 <div class="video-page">
   <div class="description">
-    {{ .Params.about_this_resource_text | safeHTML }}
+    {{ .Content }}
   </div>
   {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime)}}
   <div class="video-buttons-container">

--- a/course/layouts/resources/single.html
+++ b/course/layouts/resources/single.html
@@ -1,11 +1,11 @@
 {{ define "main" }}
-{{ partial "course_content.html" . }}
+{{ partial "resource_title.html" . }}
 <div class="resource-page container">
     {{- if ne .Params.resourcetype "Video" }}
-        {{- if .Params.description -}}
+        {{- if .Content -}}
             <div class="row">
                 <div class="label col-3">Description:</div>
-                <div class="col-9">{{ .Params.description }}</div>
+                <div class="col-9">{{ .Content }}</div>
             </div>
         {{- end -}}
         {{- if .Params.learning_resource_types -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-hugo-projects/issues/185

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/187 we are setting resources so that in `ocw-studio` the description will be written into the markdown body, allowing linking to pages / resources using our shortcode / uuid system.  In https://github.com/mitodl/ocw-studio/pull/1382, we are migrating all existing values for resources in `metadata["description"]` to the markdown body, concatenating with the existing value if necessary.  This PR adjusts the theme to source resource descriptions from the markdown body of resource pages.

#### How should this be manually tested?
 - Follow the testing instructions for https://github.com/mitodl/ocw-studio/pull/1382, making sure you are set up to publish courses to a test Gtihub org
 - In your `ocw-studio`, run the following:
```
docker-compose run --rm web ./manage.py reset_sync_states --filter 18-01sc-single-variable-calculus-fall-2010 --skip_sync
docker-compose run --rm web ./manage.py sync_website_to_backend --website 18-01sc-single-variable-calculus-fall-2010
```
 - Clone `18.01sc-fall-2010` from your test org
 - Back in `ocw-hugo-themes`, set the following in your `.env`:
```
COURSE_CONTENT_PATH=/path/to/<your test org>/
OCW_TEST_COURSE=18.01sc-fall-2010
```
 - Run `npm run start:course`
 - Visit http://localhost:3000/resources/clip-1-introduction-to-18/ and verify that the description renders properly
 - Visit http://localhost:3000/resources/mit18_01scf10_final/ and verify that the description on the PDF renders properly (the PDF itself will not because of CORS)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/170585836-bc3b865f-5dcc-4aaf-8b38-ed72f10d399f.png)
![image](https://user-images.githubusercontent.com/12089658/170585895-a21b797a-6a3a-4990-bfbe-9b66f3847156.png)

