### PR TITLE
fix for base url in course sitemap

### DIFF
--- a/base-theme/layouts/_default/sitemap.xml
+++ b/base-theme/layouts/_default/sitemap.xml
@@ -6,7 +6,7 @@
   {{ range .Data.Pages }}
     {{- if and .RelPermalink (not .Params.headless) -}}
       {{- $path := strings.TrimPrefix "/" (partial "site_root_url.html" .RelPermalink) -}}
-      {{- if not (in $disallowedUrls $path) -}}
+      {{- if not (in $disallowedUrls (replace $path site.BaseURL "")) -}}
         {{- $url := printf "https://%v/%v" $sitemapDomain $path -}}
   <url>
     <loc>{{ $url }}</loc>{{ if not .Lastmod.IsZero }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Hotfix for https://github.com/mitodl/ocw-hugo-themes/pull/698

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/698, we added a list of "disallowed urls" that we don't want ending up in the sitemaps.  This PR failed to take into account the `--baseUrl` argument being used in RC and production.  This PR adjusts the course sitemap template to take that into account when comparing against the disallowed urls.

#### How should this be manually tested?
 - Clone any course repo from `ocw-content-rc` or create one yourself and clone the course content repo locally
 - Set the following in your `.env`:
```
COURSE_CONTENT_PATH=/path/to/ocw-content-rc/
OCW_TEST_COURSE=<your course id>
SITEMAP_DOMAIN=ocwnext-rc.odl.mit.edu
```
 - Modify the `hugo server` line in `start_course.sh` to look something like this, replacing the course ID with your course:
```
hugo server \
  -p 3000 \
  --bind 0.0.0.0 \
  --config $COURSE_HUGO_CONFIG_PATH \
  --themesDir $THEMES_PATH \
  --baseUrl http://localhost:3000/courses/18-01sc-single-variable-calculus-fall-2010/
```
 - Run `npm run start:course`
 - Visit http://localhost:3000/courses/18-01sc-single-variable-calculus-fall-2010/sitemap.xml
 - The urls may look strange.  This is a quirk of the Hugo dev server, where it expects `baseUrl` to be fully qualified.  In our Concourse builds, our `baseUrl` is root-relative which works fine as long as you're not using the dev server, but in order for the Hugo dev server to serve pages at the expected URL the URL you use here needs to be fully qualified.  Anyway, what you're looking to verify here is that the disallowed urls are not included in this list, like `tags/`, etc.
