### PR TITLE
fix slash prefix issue with course sitemap disallowed url check

### DIFF
--- a/base-theme/layouts/_default/sitemap.xml
+++ b/base-theme/layouts/_default/sitemap.xml
@@ -6,7 +6,8 @@
   {{ range .Data.Pages }}
     {{- if and .RelPermalink (not .Params.headless) -}}
       {{- $path := strings.TrimPrefix "/" (partial "site_root_url.html" .RelPermalink) -}}
-      {{- if not (in $disallowedUrls (replace $path site.BaseURL "")) -}}
+      {{- $trimmedPath := strings.TrimPrefix "/" (replace $path site.BaseURL "") -}}
+      {{- if not (in $disallowedUrls $trimmedPath) -}}
         {{- $url := printf "https://%v/%v" $sitemapDomain $path -}}
   <url>
     <loc>{{ $url }}</loc>{{ if not .Lastmod.IsZero }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Hotfix for https://github.com/mitodl/ocw-hugo-themes/pull/710

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/710, we fixed an issue with the course sitemap construction not taking the `--baseUrl` setting into account.  Something that I failed to notice was that our `--baseUrl` setting in RC and production doesn't have a trailing slash.  This causes the check to fail, because there will be a preceeding slash on `$path` after stripping the `baseUrl`.  This PR does just that, strips the preceeding slash.

#### How should this be manually tested?
Follow the same testing instructions in https://github.com/mitodl/ocw-hugo-themes/pull/710.  Beyond that, further validation will be needed in RC
