### PR TITLE
actually fix invalid entries in course sitemap

### DIFF
--- a/base-theme/layouts/_default/sitemap.xml
+++ b/base-theme/layouts/_default/sitemap.xml
@@ -6,7 +6,8 @@
   {{ range .Data.Pages }}
     {{- if and .RelPermalink (not .Params.headless) -}}
       {{- $path := strings.TrimPrefix "/" (partial "site_root_url.html" .RelPermalink) -}}
-      {{- $trimmedPath := strings.TrimPrefix "/" (replace $path site.BaseURL "") -}}
+      {{- $trimmedBaseUrl := strings.TrimPrefix "/" site.BaseURL -}}
+      {{- $trimmedPath := strings.TrimPrefix "/" (replace $path $trimmedBaseUrl "") -}}
       {{- if not (in $disallowedUrls $trimmedPath) -}}
         {{- $url := printf "https://%v/%v" $sitemapDomain $path -}}
   <url>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Hotfix following up https://github.com/mitodl/ocw-hugo-themes/pull/712

#### What's this PR do?
If you read the history in https://github.com/mitodl/ocw-hugo-themes/pull/712, you'll see that 2 other PR's have been merged attempting to fix this issue that have been unsuccessful.  This is because of a discrepancy between running the site locally using `hugo server` vs how the site is simply built by running `hugo` in Concourse.  This PR actually fixes the issue and removes the invalid URLs from the sitemap.

#### How should this be manually tested?
The main issue with testing the fixes to this issue previously was the use of `hugo server` to fully run the site locally when testing.  Instead, we should just build the site using `hugo` manually with the same arguments used in Concourse.

 - Clone any course repo, such as https://github.mit.edu/ocw-content-rc/18.01sc-fall-2010
 - Clone `ocw-hugo-themes` on this branch
 - Clone `ocw-hugo-projects`
 - In your terminal, browse directly to the course repo you cloned and run the following from that directory: `hugo --config /path/to/ocw-hugo-projects/ocw-course/config.yaml --themesDir /path/to/ocw-hugo-themes/ -d dist -v --baseUrl /courses/18-01sc-single-variable-calculus-fall-2010`
 - Browse to the `dist` folder under the course repo you cloned and inspect `sitemap.xml`.  Ensure that none of the `disallowedUrls` are present (i.e. `/tags/`, `/resources/`, etc.).  A good way to search for them is to search for something like `/resources/<`
