### PR TITLE
fix: course list order maintained

### DIFF
--- a/fields/layouts/home.html
+++ b/fields/layouts/home.html
@@ -33,14 +33,14 @@
     {{- $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" | default "https://ocw.mit.edu"  -}}
     {{- range $field.Params.subfields.content -}}
       {{- $subfield := index (where $.Site.Pages ".Params.uid" .) 0 -}}
-      {{- $subfield_data := dict -}}
+      {{- $subfield_data := (slice) -}}
       {{- range (first 5 $subfield.Params.courses) -}}
           {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" .id "/data.json") "" -}}
           {{- $data := getJSON $url -}}
           {{- $data = merge $data (dict "url_path" .id) -}}
-          {{- $subfield_data = merge $subfield_data (dict .id $data) -}}
+          {{- $subfield_data = $subfield_data | append (dict .id $data) -}}
       {{- end -}}
-      {{- $subfields_data = merge $subfields_data (dict $subfield.Params.uid $subfield_data) -}}
+      {{- $subfields_data = merge subfields_data (dict $subfield.Params.uid $subfield_data) -}}
     {{- end -}}
     window.courseListsData = JSON.parse("{{ $subfields_data | jsonify }}");
   </script>

--- a/fields/layouts/home.html
+++ b/fields/layouts/home.html
@@ -40,7 +40,7 @@
           {{- $data = merge $data (dict "url_path" .id) -}}
           {{- $subfield_data = $subfield_data | append (dict .id $data) -}}
       {{- end -}}
-      {{- $subfields_data = merge subfields_data (dict $subfield.Params.uid $subfield_data) -}}
+      {{- $subfields_data = merge $subfields_data (dict $subfield.Params.uid $subfield_data) -}}
     {{- end -}}
     window.courseListsData = JSON.parse("{{ $subfields_data | jsonify }}");
   </script>

--- a/fields/layouts/subfields/single.html
+++ b/fields/layouts/subfields/single.html
@@ -10,12 +10,12 @@
   {{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
   <script>
     {{- $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" | default "https://ocw.mit.edu"  -}}
-    {{- $courseListData := dict -}}
+    {{- $courseListData := (slice) -}}
     {{- range $courselist.Params.courses -}}
         {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" .id "/data.json") "" -}}
         {{- $data := getJSON $url -}}
         {{- $data = merge $data (dict "url_path" .id) -}}
-        {{- $courseListData = merge $courseListData (dict .id $data) -}}
+        {{- $courseListData = $courseListData | append (dict .id $data) -}}
     {{- end -}}
     {{- $courseListsData := dict $courselist.Params.uid $courseListData -}}
     window.courseListsData = JSON.parse("{{ $courseListsData | jsonify }}");

--- a/www/assets/js/LearningResources.ts
+++ b/www/assets/js/LearningResources.ts
@@ -84,6 +84,14 @@ export interface CourseJSON {
 }
 
 /**
+ * A map from a course name to the `CourseJSON` record for that course. This value
+ * is needed for dealing with both course collections and resource collections.
+ */
+export interface CourseJSONMap {
+  [name: string]: CourseJSON
+}
+
+/**
  * Interface describing the shape of the ResourceJSON files generated
  * by the course theme for resource content items.
  *

--- a/www/assets/js/hooks/hugo_data.test.ts
+++ b/www/assets/js/hooks/hugo_data.test.ts
@@ -6,10 +6,8 @@ import {
   makeFakeUUID,
   makeResourceJSON
 } from "../factories/search"
-import {
-  courseJSONToLearningResource,
-  resourceJSONToLearningResource
-} from "../lib/search"
+import { resourceJSONToLearningResource } from "../lib/search"
+import { getLearningResourcesFromCourseList } from "../lib/util"
 import {
   CollectionItem,
   OCWWindow,
@@ -23,9 +21,9 @@ let testUid = "test-uuid-1234-5678"
 
 function courseListsSetup() {
   window.courseListsData = {
-    [testUid]: Object.fromEntries(
-      [...Array(10)].map((_, index) => [`course-${index}`, makeCourseJSON()])
-    )
+    [testUid]: [...Array(10)].map((_, index) => ({
+      [`course-${index}`]: makeCourseJSON()
+    }))
   }
 }
 
@@ -33,9 +31,7 @@ test("course collection hook should return LearningResources", () => {
   courseListsSetup()
   const { result } = renderHook(() => useCourseListData(testUid))
   expect(result.current).toEqual(
-    Object.entries(window.courseListsData[testUid]).map(([name, courseJSON]) =>
-      courseJSONToLearningResource(name, courseJSON)
-    )
+    getLearningResourcesFromCourseList(window.courseListsData[testUid])
   )
 })
 

--- a/www/assets/js/hooks/hugo_data.ts
+++ b/www/assets/js/hooks/hugo_data.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import {
-  CourseJSON,
+  CourseJSONMap,
   LearningResource,
   ResourceJSON
 } from "../LearningResources"
@@ -8,14 +8,7 @@ import {
   courseJSONToLearningResource,
   resourceJSONToLearningResource
 } from "../lib/search"
-
-/**
- * A map from a course name to the `CourseJSON` record for that course. This value
- * is needed for dealing with both course collections and resource collections.
- */
-interface CourseJSONMap {
-  [name: string]: CourseJSON
-}
+import { getLearningResourcesFromCourseList } from "../lib/util"
 
 export type CollectionItem = [string, string]
 
@@ -26,7 +19,7 @@ export interface OCWWindow extends Window {
    * Map is from collection UUID to CourseJSONMap (a map of the course JSON
    * objects for that collection).
    */
-  courseListsData: Record<string, CourseJSONMap>
+  courseListsData: Record<string, CourseJSONMap[]>
   /**
    * Data needed for resource collection rendering in React.
    *
@@ -80,17 +73,13 @@ export function useCourseListData(uid: string): LearningResource[] {
   const [data, setData] = useState<LearningResource[]>([])
 
   useEffect(() => {
-    const data = window.courseListsData?.[uid]
+    const courseList = window.courseListsData?.[uid]
 
-    if (data === undefined) {
+    if (courseList === undefined) {
       throw new Error("course collection data missing")
     }
 
-    setData(
-      Object.entries(data).map(([name, courseJSON]) =>
-        courseJSONToLearningResource(name, courseJSON)
-      )
-    )
+    setData(getLearningResourcesFromCourseList(courseList))
   }, [setData])
 
   return data

--- a/www/assets/js/lib/util.ts
+++ b/www/assets/js/lib/util.ts
@@ -1,6 +1,8 @@
 import * as Sentry from "@sentry/browser"
 import { either, isEmpty, isNil, match } from "ramda"
 import { STATUS_CODES } from "./constants"
+import { LearningResource, CourseJSONMap } from "../LearningResources"
+import { courseJSONToLearningResource } from "./search"
 
 export const emptyOrNil = either(isEmpty, isNil)
 
@@ -32,4 +34,21 @@ export const sentryCaptureException = (excetpion: any) => {
 
 export const sentryCaptureMessage = (message: string) => {
   Sentry.captureException(message)
+}
+
+/**
+ * Converts course list array into learning resources array while maintaing order
+ */
+export const getLearningResourcesFromCourseList = (
+  courseList: CourseJSONMap[]
+): LearningResource[] => {
+  const numberOfCourses = courseList.length || 0
+  const learningResources: LearningResource[] = []
+  for (let i = 0; i < numberOfCourses; i++) {
+    const key = Object.keys(courseList[i])[0]
+    learningResources.push(
+      courseJSONToLearningResource(key, courseList[i][key])
+    )
+  }
+  return learningResources
 }

--- a/www/assets/js/lib/util.ts
+++ b/www/assets/js/lib/util.ts
@@ -42,13 +42,9 @@ export const sentryCaptureMessage = (message: string) => {
 export const getLearningResourcesFromCourseList = (
   courseList: CourseJSONMap[]
 ): LearningResource[] => {
-  const numberOfCourses = courseList.length || 0
-  const learningResources: LearningResource[] = []
-  for (let i = 0; i < numberOfCourses; i++) {
-    const key = Object.keys(courseList[i])[0]
-    learningResources.push(
-      courseJSONToLearningResource(key, courseList[i][key])
-    )
-  }
+  const learningResources: LearningResource[] = courseList.map(course => {
+    const key = Object.keys(course)[0]
+    return courseJSONToLearningResource(key, course[key])
+  })
   return learningResources
 }

--- a/www/layouts/collections/single.html
+++ b/www/layouts/collections/single.html
@@ -32,12 +32,12 @@
     {{- $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" | default "https://ocwnext.odl.mit.edu"  -}}
     {{- range $collection.Params.courselists.content -}}
       {{- $course_list := index (where $.Site.Pages ".Params.uid" .) 0 -}}
-      {{- $course_list_data := dict -}}
+      {{- $course_list_data := (slice) -}}
       {{- range (first 5 $course_list.Params.courses) -}}
           {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" .id "/data.json") "" -}}
           {{- $data := getJSON $url -}}
           {{- $data = merge $data (dict "url_path" .id) -}}
-          {{- $course_list_data = merge $course_list_data (dict .id $data) -}}
+          {{- $course_list_data = $course_list_data | append (dict .id $data) -}}
       {{- end -}}
       {{- $course_lists_data = merge $course_lists_data (dict $course_list.Params.uid $course_list_data) -}}
     {{- end -}}

--- a/www/layouts/course-lists/single.html
+++ b/www/layouts/course-lists/single.html
@@ -10,12 +10,12 @@
   {{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
   <script>
     {{- $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" | default "https://ocwnext.odl.mit.edu"  -}}
-    {{- $courseListData := dict -}}
+    {{- $courseListData := (slice) -}}
     {{- range $courselist.Params.courses -}}
         {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" .id "/data.json") "" -}}
         {{- $data := getJSON $url -}}
         {{- $data = merge $data (dict "url_path" .id) -}}
-        {{- $courseListData = merge $courseListData (dict .id $data) -}}
+        {{- $courseListData = $courseListData | append (dict .id $data) -}}
     {{- end -}}
     {{- $courseListsData := dict $courselist.Params.uid $courseListData -}}
     window.courseListsData = JSON.parse("{{ $courseListsData | jsonify }}");


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/705

#### What's this PR do?
- Changes the approach of storing course list data from nested objects to array of object so original list order can be maintained.
- Makes appropriate changes in React component and tests

#### How should this be manually tested?
- Checkout this branch.
- Open any course list (e.g: http://localhost:3000/course-lists/open-learning-library/ OR `netlify-link`/course-lists/open-learning-library/)
- Verify that the order of courses in all the course lists is exactly the same as their order in studio.
- Test any other use case that needs to be tested.

#### Screenshots 
![screencapture-ocw-hugo-themes-pr-721-ocw-next-netlify-app-course-lists-open-learning-library-2022-06-01-22_07_11](https://user-images.githubusercontent.com/93309234/171461326-3a1ac9b4-8af3-4470-be2b-a804a590ae0f.png)

