### PR TITLE
use new search metadata fields

### DIFF
--- a/base-theme/layouts/partials/seo.html
+++ b/base-theme/layouts/partials/seo.html
@@ -3,8 +3,8 @@
   {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web-based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
   {{- $defaultMetadataKeywords := "opencourseware,MIT OCW,courseware,MIT opencourseware,Free Courses,class notes,class syllabus,class materials,tutorials,online courses,MIT courses" -}}
   
-  {{- $metaDataDescription := .Params.metadataDescription | default $defaultMetadataDescription -}}
-  {{- $metaDataKeywords := .Params.metadataKeywords | default $defaultMetadataKeywords -}}
+  {{- $metaDataDescription := .Params.metadata_description | default .Params.description | default $defaultMetadataDescription -}}
+  {{- $metaDataKeywords := .Params.metadata_keywords | default $defaultMetadataKeywords -}}
 
   <meta name="description" content="{{- $metaDataDescription -}}">
   <meta name="keywords" content="{{- $metaDataKeywords -}}">

--- a/base-theme/layouts/partials/seo.html
+++ b/base-theme/layouts/partials/seo.html
@@ -1,13 +1,11 @@
 {{ define "seo" }}
-  <!-- these are the default values of metadata description and keywords -->
+  <!-- default value for the meta description -->
   {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web-based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
-  {{- $defaultMetadataKeywords := "opencourseware,MIT OCW,courseware,MIT opencourseware,Free Courses,class notes,class syllabus,class materials,tutorials,online courses,MIT courses" -}}
   
-  {{- $metaDataDescription := .Params.metadata_description | default $defaultMetadataDescription -}}
-  {{- $metaDataKeywords := .Params.metadata_keywords | default $defaultMetadataKeywords -}}
+  {{- $metaDataDescription := .Params.description | default $defaultMetadataDescription -}}
 
   <meta name="description" content="{{- $metaDataDescription -}}">
-  <meta name="keywords" content="{{- $metaDataKeywords -}}">
+  <meta name="keywords" content="opencourseware,MIT OCW,courseware,MIT opencourseware,Free Courses,class notes,class syllabus,class materials,tutorials,online courses,MIT courses">
 
   <script type="application/ld+json">
       {

--- a/base-theme/layouts/partials/seo.html
+++ b/base-theme/layouts/partials/seo.html
@@ -3,7 +3,7 @@
   {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web-based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
   {{- $defaultMetadataKeywords := "opencourseware,MIT OCW,courseware,MIT opencourseware,Free Courses,class notes,class syllabus,class materials,tutorials,online courses,MIT courses" -}}
   
-  {{- $metaDataDescription := .Params.metadata_description | default .Params.description | default $defaultMetadataDescription -}}
+  {{- $metaDataDescription := .Params.metadata_description | default $defaultMetadataDescription -}}
   {{- $metaDataKeywords := .Params.metadata_keywords | default $defaultMetadataKeywords -}}
 
   <meta name="description" content="{{- $metaDataDescription -}}">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/725

#### What's this PR do?
This PR changes the default source for the `meta` `description` and `keywords` tags to `.Params.metadata_description` and `.Params.metadata_keywords`.  This is based on the new fields being added to `ocw-studio` in https://github.com/mitodl/ocw-hugo-projects/pull/190.  The fields have been named to conform with the standard of front matter parameters being in snake case.

#### How should this be manually tested?
 - Clone a course repo from `ocw-content-rc`
 - Set the following in your `.env`:
```
COURSE_CONTENT_PATH=/path/to/ocw-content-rc/
OCW_TEST_COURSE=<folder name of course you cloned>
```
 - Run the course with `npm run start:course`
 - Visit http://localhost:3000 and visit any page, then inspect the source.  Look for the `meta` tag with `name="description"` and ensure that the description is there