### PR TITLE
fix: videojs-youtube lib included inside document.ready function

### DIFF
--- a/base-theme/assets/types/videojs-youtube.d.ts
+++ b/base-theme/assets/types/videojs-youtube.d.ts
@@ -1,0 +1,1 @@
+declare module "videojs-youtube"

--- a/course/assets/course.js
+++ b/course/assets/course.js
@@ -4,7 +4,6 @@ import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
 import "nanogallery2/src/jquery.nanogallery2.core.js"
 
 import "./css/course.scss"
-import "videojs-youtube"
 
 import { initPdfViewers } from "../../base-theme/assets/js/pdf_viewer"
 import { initDesktopCourseInfoToggle } from "./js/course_info_toggle"
@@ -19,6 +18,7 @@ import {
 } from "./js/quiz_multiple_choice"
 
 $(function() {
+  require("videojs-youtube")
   initPdfViewers()
   initDesktopCourseInfoToggle()
   initCourseInfoExpander(document)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/701 (Not sure if this PR will close it or not as this PR is more of a hit-and-trial. Please see some points below)

#### What's this PR do?
- **Note:** I was unable to reproduce this issue locally, but most likely, this issue is occurring from a third party, i.e: `videojs-youtube` and if this is the case, then I think loading this lib inside `document.ready` function can do the job. Still, I'm not very sure that this will fix the issue so this PR can be considered a hit-and-trial PR. Not sure if this is a good approach/practice.
- Replaces `import` with `require` for `videojs-youtube`
- Moves `require("videojs-youtube")` inside `document.ready` function.
- Declare module `videojs-youtube`

#### How should this be manually tested?
- Try to reproduce the issue (if you succeed in that, then I owe you a treat).
- Checkout this branch
- Verify that the changes done in this PR resolves the issue.
- If you're unable to reproduce it locally, then: 
    - Verify that this issue is occurring from a third party, i.e: `videojs-youtube` and moving its import in ready function can fix the issue. 
    - Verify that everything is working fine and the changes done in this PR do not have any side-effect.

