### PR TITLE
fix: catching exception while fetching PDF

### DIFF
--- a/base-theme/assets/js/pdf_viewer.js
+++ b/base-theme/assets/js/pdf_viewer.js
@@ -3,19 +3,23 @@
 /* eslint-disable no-console */
 export const initPdfViewers = () => {
   $(".pdf-wrapper").each(async (index, pdfWrapper) => {
-    const pdfUrl = pdfWrapper.dataset.pdfurl
-    const response = await window.fetch(pdfUrl)
-    if (response.status !== 200) {
-      console.error(`Problem fetching PDF: ${response.status}`)
-      return
+    try {
+      const pdfUrl = pdfWrapper.dataset.pdfurl
+      const response = await window.fetch(pdfUrl)
+      if (response.status !== 200) {
+        console.error(`Problem fetching PDF: ${response.status}`)
+        return
+      }
+      const blob = await response.blob()
+      const blobURI = window.URL.createObjectURL(blob)
+      const viewerUrl = `/pdfjs/web/viewer.html?file=${encodeURIComponent(
+        blobURI
+      )}`
+      $(pdfWrapper).html(
+        `<iframe class="w-100 h-100" frameborder="0" scrolling="yes" seamless="seamless" src="${viewerUrl}"></iframe>`
+      )
+    } catch (e) {
+      console.log("Exception occurred while fetching PDF: ", e)
     }
-    const blob = await response.blob()
-    const blobURI = window.URL.createObjectURL(blob)
-    const viewerUrl = `/pdfjs/web/viewer.html?file=${encodeURIComponent(
-      blobURI
-    )}`
-    $(pdfWrapper).html(
-      `<iframe class="w-100 h-100" frameborder="0" scrolling="yes" seamless="seamless" src="${viewerUrl}"></iframe>`
-    )
   })
 }

--- a/base-theme/assets/js/pdf_viewer.js
+++ b/base-theme/assets/js/pdf_viewer.js
@@ -19,7 +19,7 @@ export const initPdfViewers = () => {
         `<iframe class="w-100 h-100" frameborder="0" scrolling="yes" seamless="seamless" src="${viewerUrl}"></iframe>`
       )
     } catch (e) {
-      console.log("Exception occurred while fetching PDF: ", e)
+      console.error("Exception occurred while fetching PDF: ", e)
     }
   })
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/723

#### What's this PR do?
- Adds `try-catch` in fetching PDF in `pdf_viewer.js` 
- **Note:** The error, `TypeError: Failed to fetch` can occur due to various reasons, and I'm unable to find that out in this case, so this is an attempt to quiet the issue

#### How should this be manually tested?
- Reproduce the issue, either by giving an incorrect PDF URL [here](https://github.com/mitodl/ocw-hugo-themes/blob/34c8d845206be69db959704b74c488b7cea6647b/base-theme/assets/js/pdf_viewer.js#L7) or via any other way. (e.g: If you try to hit any `HTTPS` endpoint from your `localhost`, you will end up in a CORS issue along with `TypeError: Failed to fetch`. The error should also be logged in sentry.
- Checkout this branch.
- Repeat the above steps to reproduce the issue.
- Verify that now the issue/exception is caught quietly and no error is logged in sentry. You should only be seeing an error in 
the console. 
