### PR TITLE
Fix video transcripts RESOURCE_BASE_URL

### DIFF
--- a/base-theme/layouts/partials/video.html
+++ b/base-theme/layouts/partials/video.html
@@ -1,6 +1,6 @@
 {{ $youtubeKey := .Params.video_metadata.youtube_id }}
-{{ $captionsLocation := .Params.video_files.video_captions_file }}
-{{ $transcriptPdfLocation := .Params.video_files.video_transcript_file }}
+{{ $captionsLocation := partial "resource_url.html" .Params.video_files.video_captions_file }}
+{{ $transcriptPdfLocation := partial "resource_url.html" .Params.video_files.video_transcript_file }}
 {{ $downloadLink := .Params.file }}
 {{ $relatedResourses := .Params.related_resources_text | default "" }}
 {{ $optionalTabTitle := .Params.optional_tab_title | default "" }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
For local development, RESOURCE_BASE_URL currently isn't applied to video transcripts so the caption file and transcript download doesn't work locally. This fixes the issue

#### How should this be manually tested?
Download a course with videos from https://github.mit.edu/mitocwcontent. One option is

https://github.mit.edu/mitocwcontent/15.071-spring-2017

Set
RESOURCE_BASE_URL=https://ocw-content-live-production.s3.amazonaws.com/

Run the course locally. You should see text in the automated transcript track