### PR TITLE
added styles to fix title overlap

### DIFF
--- a/course/assets/css/video.scss
+++ b/course/assets/css/video.scss
@@ -49,6 +49,14 @@
           position: absolute;
           top: 50%;
           transform: translateY(-50%);
+          
+          @media (max-width: 350px) {
+            font-size: small;
+          }
+
+          @media (max-width: 250px) {
+            font-size: x-small;
+          }
         }
       }
     }

--- a/course/assets/css/video.scss
+++ b/course/assets/css/video.scss
@@ -49,7 +49,7 @@
           position: absolute;
           top: 50%;
           transform: translateY(-50%);
-          
+
           @media (max-width: 350px) {
             font-size: small;
           }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #739

#### What's this PR do?
- Adds css to dynamically reduce font size on screen decrease.

#### How should this be manually tested?
- Verify title for the video gallery does not overlap on mobile screens.

#### Screenshots (if appropriate) 
<img width="1438" alt="Screenshot 2022-06-10 at 4 27 19 PM" src="https://user-images.githubusercontent.com/87968618/173055667-d32c1ac8-0c25-4666-85d8-b18c118aa8df.png">
<img width="1438" alt="Screenshot 2022-06-10 at 4 27 14 PM" src="https://user-images.githubusercontent.com/87968618/173055699-61addd30-2337-4c4f-959b-f310f6f8c917.png">
<img width="1438" alt="Screenshot 2022-06-10 at 4 27 09 PM" src="https://user-images.githubusercontent.com/87968618/173055713-25b22051-1a2b-456c-b8da-3d05372b5f97.png">

