### PR TITLE
make level array

### DIFF
--- a/base-theme/layouts/partials/course_cards_level.html
+++ b/base-theme/layouts/partials/course_cards_level.html
@@ -5,6 +5,9 @@
 {{/* safe guard from nil values  */}}
   {{ with .}}
     {{- $numLevels := len . -}}
+    {{- if gt $numLevels 0}}
+      <span> | </span>
+    {{- end -}}
     {{- range $index, $level := . -}}
       {{- $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $level) -}}
       <a href="{{ $levelSearchUrl }}">{{ $level }}</a>

--- a/base-theme/layouts/partials/course_carousel_card.html
+++ b/base-theme/layouts/partials/course_carousel_card.html
@@ -18,7 +18,7 @@
     </a>
     <div class="course-card-content pt-1 px-3 pb-3">
       <div class="course-level">
-        {{ $coursePrimaryNumber }} | {{ partial "course_cards_level.html" $courseLevel }}
+        {{ $coursePrimaryNumber }}{{ partial "course_cards_level.html" $courseLevel }}
       </div>
       <div class="pt-1">
         <div class="h5">

--- a/www/assets/js/LearningResources.ts
+++ b/www/assets/js/LearningResources.ts
@@ -78,7 +78,7 @@ export interface CourseJSON {
   extra_course_numbers: string
   term: string
   year: string
-  level: Level
+  level: Level[] | null
   image_src: string
   course_image_metadata: CourseImageMetadata
 }
@@ -116,7 +116,7 @@ interface CourseRunPrice {
   price: number
 }
 
-export type Level = "Graduate" | "Undergraduate" | null
+export type Level = "Graduate" | "Undergraduate" | "Non Credit"
 
 export interface CourseRun {
   run_id: string
@@ -127,7 +127,7 @@ export interface CourseRun {
   language: "es-US" | "fr" | null
   semester: "Fall" | "Spring" | null
   year: number
-  level: Level
+  level: Level[] | null
   start_date: string
   end_date: string
   best_start_date: string
@@ -256,7 +256,7 @@ export interface LearningResource {
   platform: string | null
   topics: Topic[]
   runs: CourseRun[]
-  level: "Graduate" | "Undergraduate" | null
+  level: Level[] | null
   instructors: string[]
   department: string | undefined
   audience: Audience | undefined

--- a/www/assets/js/components/CourseListRow.test.tsx
+++ b/www/assets/js/components/CourseListRow.test.tsx
@@ -30,5 +30,7 @@ test("should show the title, coursenum, level", () => {
   const { wrapper, course } = setup()
   expect(wrapper.find("h4").text()).toBe(course.title)
   expect(wrapper.find(".coursenum").text()).toBe(course.coursenum)
-  expect(wrapper.find(".level").text()).toBe(course.level ? course.level : "")
+  expect(wrapper.find(".level").text()).toBe(
+    course.level ? course.level.join(", ") : ""
+  )
 })

--- a/www/assets/js/components/CourseListRow.tsx
+++ b/www/assets/js/components/CourseListRow.tsx
@@ -22,7 +22,9 @@ export default function CourseListRow(props: Props) {
           <h4 className="mb-0">{course.title}</h4>
           <div className="coursenum">{course.coursenum}</div>
         </div>
-        <div className="level">{course.level ?? ""}</div>
+        <div className="level">
+          {course.level ? course.level.join(", ") : ""}
+        </div>
       </a>
     </Card>
   )

--- a/www/assets/js/components/SearchResult.test.tsx
+++ b/www/assets/js/components/SearchResult.test.tsx
@@ -142,7 +142,9 @@ describe("SearchResult component with compact view", () => {
       .props()
     expect(href).toBe(object.url)
     expect(wrapper.find(".course-num").text()).toBe(object.coursenum)
-    expect(wrapper.find(".resource-level").text()).toBe(object.level || "")
+    expect(wrapper.find(".resource-level").text()).toBe(
+      object.level ? object.level.join(", ") : ""
+    )
   })
 
   it("should render the things we expect for a resource", () => {

--- a/www/assets/js/components/SearchResult.tsx
+++ b/www/assets/js/components/SearchResult.tsx
@@ -178,7 +178,9 @@ export function LearningResourceDisplay(props: SRProps) {
         <div className="lr-info search-result has-min-height">
           <div className="lr-row resource-header">
             <div className="resource-type">
-              {`${object.coursenum}${object.level ? " | " : ""}${object.level}`}
+              {`${object.coursenum}${
+                object.level ? " | ".concat("", object.level.join(", ")) : ""
+              }`}
             </div>
           </div>
           <div className="lr-row course-title">
@@ -270,7 +272,9 @@ export function CompactLearningResourceDisplay(props: SRProps) {
               <span>{object.title}</span>
             )}
           </div>
-          <div className="col-2 resource-level">{object.level}</div>
+          <div className="col-2 resource-level">
+            {object.level ? `${object.level.join(", ")}` : ""}
+          </div>
         </div>
       </Card>
     )

--- a/www/assets/js/factories/search.ts
+++ b/www/assets/js/factories/search.ts
@@ -91,7 +91,13 @@ export const makeRun = (): CourseRun => {
     language: casual.random_element(["en-US", "fr", null]),
     semester: casual.random_element(["Fall", "Spring", null]),
     year: casual.year,
-    level: casual.random_element(["Graduate", "Undergraduate", null]),
+    level: casual.random_element([
+      ["Graduate"],
+      ["Undergraduate"],
+      ["Graduate", "Undergraduate"],
+      [],
+      null
+    ]),
     start_date: casual.date(DATE_FORMAT),
     end_date: casual.date(DATE_FORMAT),
     best_start_date: casual.date(DATE_FORMAT),
@@ -159,7 +165,13 @@ export const makeCourseJSON = (): CourseJSON => ({
     [casual.word, casual.word],
     [casual.word, casual.word]
   ],
-  level: casual.random_element(["Graduate", "Undergraduate", null]),
+  level: casual.random_element([
+    ["Graduate"],
+    ["Undergraduate"],
+    ["Graduate", "Undergraduate"],
+    [],
+    null
+  ]),
   instructors: [...Array(4)].map(() => {
     let first_name = casual.first_name
     let last_name = casual.last_name


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  
<img width="986" alt="Screen Shot 2022-06-09 at 11 58 28 AM" src="https://user-images.githubusercontent.com/1934992/173064686-2ae5d66f-a8a4-4830-93d0-281789749e76.png">
<img width="927" alt="Screen Shot 2022-06-09 at 11 58 38 AM" src="https://user-images.githubusercontent.com/1934992/173064688-efd7a31d-4086-4871-a4dd-749b66ae87fe.png">
<img width="311" alt="Screen Shot 2022-06-09 at 11 58 50 AM" src="https://user-images.githubusercontent.com/1934992/173064691-396fe047-4c86-43fd-849a-ddb1e76928a1.png">


- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/738

#### What's this PR do?
While testing the compact view we noticed that level was not being rendered correctly when there were multiple levels. Turns out ocw-hugo-themes expects level to be a string but it is actually an array both in the data coming from search and the data coming from /course/json.data 

#### How should this be manually tested?
Clone ocw-www from git@github.mit.edu:ocw-content-rc/ocw-www.git

Set EXTERNAL_SITE_PATH=<your path>/ocw-www
STATIC_API_BASE_URL=https://live-qa.ocw.mit.edu/
SITEMAP_DOMAIN=https://live-qa.ocw.mit.edu/

Run `start:www`

In the new course carusel RES.6-013  will have multiple levels and TEST101 has null level. Both should look good and the links should work correctly

In your local search, either find or create courses with no level or multiple levels. If you don't have handy test courses you can create them by running 
```
from course_catalog.models import *
from search import task_helpers as search_task_helpers

course=Course.objects.filter(title='some course title', platform='ocw').first()
run = course.runs.first()
run.level= "Graduate, Undergraduate"
run.save()
search_task_helpers.upsert_course(course.id)

course=Course.objects.filter(title='some other course title', platform='ocw').first()
run = course.runs.first()
run.level=None
run.save()
search_task_helpers.upsert_course(course.id)
```
from your shell in open. Verify that the level is displayed correctly in the search results for both courses in both the list and compact views. Once https://github.com/mitodl/ocw-hugo-themes/pull/742 is merged you can access the compact view by adding &u=compact to the url