### PR TITLE
search course card css improvements

### DIFF
--- a/www/assets/css/learning-resource-card.scss
+++ b/www/assets/css/learning-resource-card.scss
@@ -435,6 +435,10 @@
   }
 
   .course-title {
+    font-weight: 700;
+    a:hover {
+      text-decoration: underline;
+    }
     @include breakpoint(desktop) {
       width: 45%;
     }

--- a/www/assets/css/search.scss
+++ b/www/assets/css/search.scss
@@ -26,7 +26,7 @@
   }
 
   .search-box-description {
-    font-size: $font-md;
+    font-size: $font-lg;
     font-weight: lighter;
     letter-spacing: 0.8px;
     color: rgb(163, 31, 52);
@@ -36,7 +36,7 @@
   }
 
   .search-box-inner {
-    margin-bottom: 0;
+    margin-bottom: 0 !important;
   }
 
   .search-page .search-box-inner h1 {
@@ -89,7 +89,10 @@
 
   .search-page {
     .container {
-      max-width: $max-content-width;
+      max-width: 100%;
+      .search-box {
+        border-bottom: 1px solid #d2d2d2;
+      }
     }
 
     a {
@@ -256,8 +259,15 @@
     }
   }
 
+  .search-results-area.col-12.col-lg-8 {
+    /* update this the appropriate col class or equiv to 75% */
+    width: 75%;
+    max-width: 75%;
+    flex: 0 0 75%;
+  }
+
   .facet-display-wrapper {
-    border-top: 1px solid #d2d2d2;
+    border-top: none;
   }
 }
 

--- a/www/assets/css/search.scss
+++ b/www/assets/css/search.scss
@@ -30,9 +30,14 @@
     font-weight: lighter;
     letter-spacing: 0.8px;
     color: rgb(163, 31, 52);
+    text-align: center;
     @include breakpoint(phone) {
       font-size: $font-md;
     }
+  }
+
+  .search-box-description-wrapper {
+    text-align: center;
   }
 
   .search-box-inner {
@@ -91,7 +96,9 @@
     .container {
       max-width: 100%;
       .search-box {
-        border-bottom: 1px solid #d2d2d2;
+        @include breakpoint(desktop) {
+          border-bottom: 1px solid #d2d2d2;
+        }
       }
     }
 

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -196,7 +196,7 @@ export default function SearchPage() {
           <div className="col-lg-3" />
           <div className="col-lg-6 search-box-inner d-flex flex-column align-items-center mb-2 mb-sm-5 mb-md-4">
             <h1>Explore OpenCourseWare</h1>
-            <div>
+            <div className="search-box-description-wrapper">
               <span className="align-item-center search-box-description">
                 Search for courses, materials & teaching resources
               </span>


### PR DESCRIPTION
#### Pre-Flight checklist

![Screen Shot 2022-06-13 at 11 12 41 AM](https://user-images.githubusercontent.com/1934992/173386168-3ccf868c-c83e-4355-8573-8ca18a98f6e0.png)
![Screen Shot 2022-06-13 at 11 12 25 AM](https://user-images.githubusercontent.com/1934992/173386208-b901a524-92fb-4dcd-af1d-f4f2ca7cc030.png)
![Screen Shot 2022-06-13 at 11 11 14 AM](https://user-images.githubusercontent.com/1934992/173386244-7c06acc4-e4ed-494e-8fa0-eb03430585ed.png)
![Screen Shot 2022-06-13 at 11 11 25 AM](https://user-images.githubusercontent.com/1934992/173386250-1852656e-b1a5-4e10-9c5c-e9b07c32b3c8.png)

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Nicolae Herrera had some suggestions for improving search card css so it looks better on wide screens. This implements those changes

#### How should this be manually tested?
Run ocw search in a variety of window sizes. Verify that the cards look good

