### PR TITLE
render course home page description

### DIFF
--- a/base-theme/layouts/partials/seo.html
+++ b/base-theme/layouts/partials/seo.html
@@ -1,8 +1,12 @@
 {{ define "seo" }}
   <!-- default value for the meta description -->
-  {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web-based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
-  
-  {{- $metaDataDescription := .Params.description | default $defaultMetadataDescription -}}
+  {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
+  {{- $metaDataDescription := $defaultMetadataDescription -}}
+  {{- if .IsHome -}}
+  {{- $metaDataDescription = (.Site.Data.course.course_description | plainify) | default $defaultMetadataDescription -}}
+  {{- else -}}
+  {{- $metaDataDescription = (.Params.description | plainify) | default $defaultMetadataDescription -}}
+  {{- end -}}
 
   <meta name="description" content="{{- $metaDataDescription -}}">
   <meta name="keywords" content="opencourseware,MIT OCW,courseware,MIT opencourseware,Free Courses,class notes,class syllabus,class materials,tutorials,online courses,MIT courses">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/755

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/726, we set the `seo.html` partial to use the metadata `description` property of pages to render a `meta` tag with `name="description"` for parsing by Google and other search engines.  This didn't handle the case of course home pages, which store their description in `.Site.Data.course.course_description`.  This PR detects if the home page is being rendered and attempts to fetch the description from there instead.

#### How should this be manually tested?
 - Clone any course repo from `ocw-content-rc`
 - Set the following in your `.env`:
```
COURSE_CONTENT_PATH=/path/to/ocw-content-rc/
OCW_TEST_COURSE=<test course folder name>
RESOURCE_BASE_URL=https://live-qa.ocw.mit.edu/
```
 - Run the course site with `npm run start:course` and visit http://localhost:3000
 - Inspect the page source and look for the `meta` tag with `name="description"` and make sure the value matches the course description