### PR TITLE
fix: overlapping timecode

### DIFF
--- a/course/assets/css/video-transcript.scss
+++ b/course/assets/css/video-transcript.scss
@@ -28,6 +28,10 @@
   margin-left: 95px;
 }
 
+.transcript-text:empty {
+  height: 20px;
+}
+
 .transcript-line:hover {
   background-color: $medium-gray;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/752

#### What's this PR do?
- Increases height for those transcript texts which are empty so that the timecode does not overlap.
- **Note:** I'm not sure whether this is a good solution as ideally, we should hide the `transcript line` when the text is empty as stated in the issue ticket but we can not access this parent element via CSS. I also tried accessing the sibling element (i.e: `transcript-timestamp`) and setting `display: none` to it but it also didn't work. 
We can achieve this via JS, but I don't think a custom JS solution only for this thing will be suitable as we will have to iterate thousands of transcript elements, check which are empty, and hide them. 


#### How should this be manually tested?
- Checkout this branch
- Open any transcript page which has missing transcript texts ([e.g](https://draft.ocw.mit.edu/courses/18-100a-real-analysis-fall-2020/resources/18100a-lecture-1-multicammp4/))
- Verify that the timestamps are not overlapping.

#### Screenshots
<img width="316" alt="Screenshot 2022-06-20 at 5 23 05 PM" src="https://user-images.githubusercontent.com/93309234/174602670-536d1347-dfe1-48b8-89d5-34c0d2b8cec0.png">


<img width="331" alt="Screenshot 2022-06-20 at 5 22 53 PM" src="https://user-images.githubusercontent.com/93309234/174602660-a1f9f48d-6492-4617-ab6f-8fc4c143b700.png">
