### PR TITLE
search API error handling improved

### DIFF
--- a/www/assets/js/lib/api.ts
+++ b/www/assets/js/lib/api.ts
@@ -1,9 +1,5 @@
 import { buildSearchQuery, SearchQueryParams } from "./search"
-import {
-  isApiSuccessful,
-  sentryCaptureException,
-  sentryCaptureMessage
-} from "./util"
+import { isApiSuccessful, sentryCaptureException } from "./util"
 
 export const search = async (params: SearchQueryParams) => {
   let results: any = {}

--- a/www/assets/js/lib/api.ts
+++ b/www/assets/js/lib/api.ts
@@ -23,11 +23,16 @@ export const search = async (params: SearchQueryParams) => {
     if (isApiSuccessful(response.status)) {
       results = await response.json()
     } else {
-      sentryCaptureMessage(
-        `Something went wrong in the search API. Query Details: ${JSON.stringify(
-          params
-        )}`
-      )
+      const additionalData = {
+        tags: {
+          "search-url": window.location.href,
+          "api-status": response?.status,
+          "api-status-text": response?.statusText
+        },
+        level: "error",
+        extra: { "Search Query Params": JSON.stringify(params) }
+      }
+      sentryCaptureException(new Error("Search API failed"), additionalData)
       results["apiFailed"] = true
     }
   } catch (e) {

--- a/www/assets/js/lib/util.ts
+++ b/www/assets/js/lib/util.ts
@@ -39,7 +39,7 @@ export const sentryCaptureMessage = (
   message: string,
   additionalData: any = {}
 ) => {
-  Sentry.captureException(message, additionalData)
+  Sentry.captureMessage(message, additionalData)
 }
 
 /**

--- a/www/assets/js/lib/util.ts
+++ b/www/assets/js/lib/util.ts
@@ -28,12 +28,18 @@ export const isApiSuccessful = (status: number) => {
   )
 }
 
-export const sentryCaptureException = (excetpion: any) => {
-  Sentry.captureException(excetpion)
+export const sentryCaptureException = (
+  excetpion: any,
+  additionalData: any = {}
+) => {
+  Sentry.captureException(excetpion, additionalData)
 }
 
-export const sentryCaptureMessage = (message: string) => {
-  Sentry.captureException(message)
+export const sentryCaptureMessage = (
+  message: string,
+  additionalData: any = {}
+) => {
+  Sentry.captureException(message, additionalData)
 }
 
 /**


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/736

#### What's this PR do?
- Sends additional data for better debugging when search API fails.
    - Tags added: 
        1. API response status
        2. API response status text
        3. Current URL with query params
    - Level set to "Error"
    - Extras: Search Query Params
- **Note:** I spent some time but was unable to debug the actual cause of why the issue is occurring in the first place. Hence the error message has been improved by which I think we will be in a better position to debug the issue.

#### How should this be manually tested?
- Go to the search page. (If having CORs issue then [run chrome without cors](https://alfilatov.com/posts/run-chrome-without-cors/))
- Test and verify that everything is working as expected.
- Now we want the API to fail, this can be done by any method (give an invalid URL, let the code break from any other method etc)
- Verify that now an error msg is shown to the user and an event is logged in sentry with the following details/info:
    - Event does not have `<unknown>` title.
    - Similar events are grouped/merged into one. 
    - Current URL with query params tag (for quick testing)
    - API response status tag.
    - API response status text tag
    - Level: Error tag
    - Search Query Params
- Any use-case which needs to be tested.

#### Screenshots

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/93309234/175021646-02b8fcd5-1d75-4f01-96f7-02e9003a87a7.png">

<img width="847" alt="image" src="https://user-images.githubusercontent.com/93309234/175021515-e1bb5eda-0500-45ee-b6d9-9332f9f51fe3.png">

<img width="875" alt="image" src="https://user-images.githubusercontent.com/93309234/175021570-55140cb7-ce3d-4c30-8a4d-76ab7d25d6c2.png">
