### PR TITLE
user selected canonical URL

### DIFF
--- a/base-theme/layouts/partials/seo.html
+++ b/base-theme/layouts/partials/seo.html
@@ -10,6 +10,7 @@
 
   <meta name="description" content="{{- $metaDataDescription -}}">
   <meta name="keywords" content="opencourseware,MIT OCW,courseware,MIT opencourseware,Free Courses,class notes,class syllabus,class materials,tutorials,online courses,MIT courses">
+  <link rel="canonical" href="{{- .Permalink -}}" />
 
   <script type="application/ld+json">
       {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/766

#### What's this PR do?
This PR makes it so that every page generated when using a theme that uses `base-theme` will deposit a `link` element with `rel="canonical"` and an `href` equal to the permalink of the current page.  This instructs search engines like Google that the page we are generating here in the Hugo build should be the user selected canonical URL for the content generated in that page as detailed here: https://developers.google.com/search/blog/2013/04/5-common-mistakes-with-relcanonical

#### How should this be manually tested?
Render a course or `ocw-www`, visit http://localhost:3000/ and bring up the page source.  If you search the source for "canonical" you should come up with the `link` element described above, and the URL there should be the URL for the current page.  Note that this is based off of the `--baseUrl` argument set when building the site, and when running the site locally that will be `//localhost:3000`, but in RC / production we set `--baseUrl` to be the fully qualified domain target of the build pipeline, including the `https://` protocol.  This will need to be verified in RC after this PR merges, but as far as testing locally the `//localhost:3000` prefix is expected.  However, the URL should match the URL of the current page you're on.
