### PR TITLE
prefix the canonical url with the sitemap domain

### DIFF
--- a/base-theme/layouts/partials/seo.html
+++ b/base-theme/layouts/partials/seo.html
@@ -8,10 +8,11 @@
   {{- $metaDataDescription = (.Params.description | plainify) | default $defaultMetadataDescription -}}
   {{- end -}}
   {{- $sitemapDomain := partial "sitemap_domain.html" -}}
+  {{- $path := partial "site_root_url.html" .RelPermalink -}}
 
   <meta name="description" content="{{- $metaDataDescription -}}">
   <meta name="keywords" content="opencourseware,MIT OCW,courseware,MIT opencourseware,Free Courses,class notes,class syllabus,class materials,tutorials,online courses,MIT courses">
-  <link rel="canonical" href="https://{{ $sitemapDomain }}/{{- strings.TrimPrefix "/" .Permalink -}}" />
+  <link rel="canonical" href="https://{{ strings.TrimSuffix "/" $sitemapDomain }}/{{- strings.TrimPrefix "/" $path -}}" />
 
   <script type="application/ld+json">
       {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ocw-hugo-themes/pull/767

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/767, we began generating `<link rel="canonical"` elements for all our pages with a value of `.Permalink`.  Because our `--baseUrl` setting in RC / production doesn't include the domain, this PR alters that code so that it is prefixed with the same domain used to generate the sitemap.

#### How should this be manually tested?
 - Clone `ocw-hugo-themes` on this branch and any course repo from `mitocwcontent`
 - Set the following in your `.env`:
```
COURSE_CONTENT_PATH=/path/to/mitocwcontent/
OCW_TEST_COURSE=<your test course>
SITEMAP_DOMAIN=ocw.mit.edu
```
 - Run the course with `npm run start:course`
 - Visit a few pages, inspecting the source, and make sure you see a `<link rel="canonical"` element with the `href` property as a proper URL to the page, prefixed with the `SITEMAP_DOMAIN`
