### PR TITLE
Added theme for resource list

### DIFF
--- a/course/layouts/lists/single.html
+++ b/course/layouts/lists/single.html
@@ -1,0 +1,16 @@
+{{ define "main" }}
+
+  {{- $bundle := . -}}
+  {{- $uids := .Params.resources.content -}}
+
+  {{ partial "course_content.html" . }}
+  <div class="mb-5">
+    <div class="mb-3 collection-description">
+      {{ $bundle.Description | .RenderString }}
+    </div>
+    {{ range where .Site.Pages "Params.uid" "in" $uids }}
+      {{- partial "resource_list_item" (dict "params" .Params "permalink" .Permalink) -}}
+      <hr>
+    {{ end }}
+  </div>
+{{ end }}

--- a/course/layouts/lists/single.html
+++ b/course/layouts/lists/single.html
@@ -8,9 +8,7 @@
     <div class="mb-3 collection-description">
       {{ $bundle.Description | .RenderString }}
     </div>
-    {{ range where .Site.Pages "Params.uid" "in" $uids }}
-      {{- partial "resource_list_item" (dict "params" .Params "permalink" .Permalink) -}}
-      <hr>
-    {{ end }}
+      {{ $resources :=  where .Site.Pages "Params.uid" "in" $uids }}
+      {{- partial "resource_list.html" (dict "resources" $resources) -}}
   </div>
 {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #757 

#### What's this PR do?
Adds theme for resource lists.

#### How should this be manually tested?
This PR can be tested in the following manner
- Clone the following course https://github.com/OCW-LOCAL-COURSES/resource-list-test
- OR use the the following configuration to create a resource list https://github.com/mitodl/ocw-hugo-projects/blob/wassaf/196-add-resource-bundlet-to-ocw-course/ocw-course/ocw-studio.yaml
- Visit list/{title-of-resource-list}/
- Verify design is as required

#### Any background context you want to provide?
This PR is a duplicate of https://github.com/mitodl/ocw-hugo-themes/pull/760 since recent changes in master are breaking the older PR.

#### Screenshots (if appropriate)
<img width="1438" alt="Screenshot 2022-06-27 at 5 06 29 PM" src="https://user-images.githubusercontent.com/87968618/175940331-67c297c0-dd02-4b8a-9b3f-cfb72a71294e.png">
<img width="1438" alt="Screenshot 2022-06-27 at 5 36 43 PM" src="https://user-images.githubusercontent.com/87968618/175943470-754c160e-081b-4a0c-9d6a-f020ee23b779.png">

<img width="793" alt="Screenshot 2022-06-27 at 5 37 06 PM" src="https://user-images.githubusercontent.com/87968618/175943414-74c1a34b-ddcb-48aa-950b-36f55dcd02e5.png">
