### PR TITLE
fix: import order of videojs-youtube sorted

### DIFF
--- a/course/assets/course.js
+++ b/course/assets/course.js
@@ -18,9 +18,9 @@ import {
   checkAnswer,
   showSolution
 } from "./js/quiz_multiple_choice"
+import "videojs-youtube"
 
 $(function() {
-  require("videojs-youtube")
   initPdfViewers()
   initDesktopCourseInfoToggle()
   initCourseInfoExpander(document)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/770

#### What's this PR do?
- Moves `require("videojs-youtube")` outside the load function 

#### How should this be manually tested?
- Open any course which has videos and open any video page.
- Check if you have this error `No compatible source was found for this media.`
    - If not, then you can reproduce this error by delaying the loading of `videojs-youtube` (maybe call the require in a [settimeout](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout) after 1 second or so)
    - Now the issue is reproduced, I think (but not very sure) it is occurring intermittently due to the requiring of package here in this load function along with the calling of all those functions which uses this as a dependency.
- Checkout this branch
- Verify that the error does not occur again.
- Verify that all the functionalities of video work as before (downloading video, transcript) etc etc
- Repeat this after clearing cache or using incognito mode.
- Repeat this in multiple browsers.
- Repeat the above for multiple videos and courses.

#### Any background context you want to provide?
- This issue seems to be a side-effect of https://github.com/mitodl/ocw-hugo-themes/pull/728
