### PR TITLE
added code to maintain order of list

### DIFF
--- a/course/layouts/lists/single.html
+++ b/course/layouts/lists/single.html
@@ -11,7 +11,7 @@
     </div>
       {{ range $id := $uids }}
         {{ $page := where $.Site.Pages "Params.uid" $id }}
-        {{$resources = $resources |  append (index $page 0) }}
+        {{ $resources = $resources |  append (index $page 0) }}
       {{ end }}
       {{- partial "resource_list.html" (dict "resources" $resources "sort" false) -}}
   </div>

--- a/course/layouts/lists/single.html
+++ b/course/layouts/lists/single.html
@@ -2,13 +2,17 @@
 
   {{- $bundle := . -}}
   {{- $uids := .Params.resources.content -}}
+  {{- $resources := slice -}}
 
   {{ partial "course_content.html" . }}
   <div class="mb-5">
     <div class="mb-3 collection-description">
       {{ $bundle.Description | .RenderString }}
     </div>
-      {{ $resources :=  where .Site.Pages "Params.uid" "in" $uids }}
-      {{- partial "resource_list.html" (dict "resources" $resources) -}}
+      {{ range $id := $uids }}
+        {{ $page := where $.Site.Pages "Params.uid" $id }}
+        {{$resources = $resources |  append (index $page 0) }}
+      {{ end }}
+      {{- partial "resource_list.html" (dict "resources" $resources "sort" false) -}}
   </div>
 {{ end }}

--- a/course/layouts/partials/resource_list.html
+++ b/course/layouts/partials/resource_list.html
@@ -1,5 +1,6 @@
-{{ $hideThumbnail := .hideThumbnail | default false }}
-{{ $hideDownloadIcon := .hideDownloadIcon | default false }}
+{{- $hideThumbnail := .hideThumbnail | default false -}}
+{{- $hideDownloadIcon := .hideDownloadIcon | default false -}}
+{{- $defaultSort := .sort | default true -}}
 
 {{ $resources := .resources }}
 {{ $numberOfResources := len $resources }}
@@ -7,9 +8,16 @@
 {{ $limitResources := .limitResources | default $numberOfResources }}
 
 {{ if gt $numberOfResources 0 }}
-  {{ range sort (first $limitResources $resources) .Params "title" }}
-    {{ partial "resource_list_item.html" (dict "params" .Params "permalink" .Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) }}
-    <hr>
+  {{ if $defaultSort }}
+    {{ range sort (first $limitResources $resources) .Params "title" }}
+      {{- partial "resource_list_item.html" (dict "params" .Params "permalink" .Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
+      <hr>
+    {{end}}
+  {{ else }}
+    {{ range (first $limitResources $resources)}}
+      {{- partial "resource_list_item.html" (dict "params" .Params "permalink" .Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
+      <hr>
+    {{ end }}
   {{ end }}
 {{ else }}
   {{ partial "no_resources_found.html" }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket

#### What's this PR do?
Adds feature to maintain resource list order

#### How should this be manually tested?
- Clone the following [course](https://github.mit.edu/ocw-content-rc/3.21-spring-2006)
- Verify resource list is rendered in the order it was added in the course

#### Additional Context
In the following [PR](https://github.com/mitodl/ocw-hugo-themes/pull/775), we added support for `resource-list`. Which are essentially a curated list for resources created by the author. This PR adds a feature to maintain their order (as they were added by the author in the resource-list tab in ocw-studio).

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2022-06-30 at 6 55 12 PM" src="https://user-images.githubusercontent.com/87968618/176695552-b8db8089-68c6-4d34-a33e-e4ad56bdc5b0.png">

