### PR TITLE
fix mathjax url on course home pages

### DIFF
--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -118,7 +118,7 @@
 
   <script src="{{ partial "webpack_url.html" $theme.js }}"></script>
   <script src="{{ partial "webpack_url.html" $courseTheme.js }}"></script>
-  <script src="{{ partial "webpack_url.html" "/mathjax/tex-svg.js" }}" defer></script>
+  <script src="{{ partial "webpack_url.html" "/static/mathjax/tex-svg.js" }}" defer></script>
   <!-- Appzi: Capture Insightful Feedback -->
 
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/796

#### What's this PR do?
This PR fixes an issue with an incorrect URL to the Mathjax `tex-svg.js` file.  The `/static` prefix was missing, and this PR simply adds it.

#### How should this be manually tested?
 - Clone any course from `mitocwcontent`
 - Configure your `.env` to point to the course:
```
COURSE_CONTENT_PATH=/path/to/mitocwcontent
OCW_TEST_COURSE=<test course folder name>
```
 - Start the course with `npm run start:course
 - Visit http://localhost:3000 and pull up your browser's developer tools, verify that there are no 404 errors in the console
