### PR TITLE
sidebar and image section height and width styling

### DIFF
--- a/course-v2/assets/css/course-home.scss
+++ b/course-v2/assets/css/course-home.scss
@@ -85,7 +85,7 @@
     }
 
     @include media-breakpoint-down(sm) {
-      width: 100% !important;
+      display: none;
     }
   }
 

--- a/course-v2/assets/css/course-home.scss
+++ b/course-v2/assets/css/course-home.scss
@@ -22,6 +22,7 @@
     border-radius: 0px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.16);
     border: 0px;
+    height: 100%;
   }
 
   .container-fluid {

--- a/course-v2/assets/css/course-home.scss
+++ b/course-v2/assets/css/course-home.scss
@@ -21,10 +21,7 @@
       padding-left: 5px !important;
       padding-right: 5px !important;
     }
-    
   }
-
-  
 
   .card {
     border-radius: 0px;
@@ -64,32 +61,31 @@
     }
   }
 
-
-#desktop-nav {
-  width: 18% !important;
-}
-
-#course-detail {
-  width: 50% !important;
-
-  @include media-breakpoint-down(md) {
-    width: 65% !important;
+  #desktop-nav {
+    width: 18% !important;
   }
 
-  @include media-breakpoint-down(sm) {
-    width: 100% !important;
-  }
-}
+  #course-detail {
+    width: 50% !important;
 
-#course-image-section {
-  width: 32% !important;
+    @include media-breakpoint-down(md) {
+      width: 65% !important;
+    }
 
-  @include media-breakpoint-down(md) {
-    width: 35% !important;
+    @include media-breakpoint-down(sm) {
+      width: 100% !important;
+    }
   }
 
-  @include media-breakpoint-down(sm) {
-    width: 100% !important;
+  #course-image-section {
+    width: 32% !important;
+
+    @include media-breakpoint-down(md) {
+      width: 35% !important;
+    }
+
+    @include media-breakpoint-down(sm) {
+      width: 100% !important;
+    }
   }
-}
 }

--- a/course-v2/assets/css/course-home.scss
+++ b/course-v2/assets/css/course-home.scss
@@ -8,15 +8,23 @@
   }
 
   .course-home-grid {
-    padding-left: 5px !important;
-    padding-right: 5px !important;
+    padding-left: 10px !important;
+    padding-right: 10px !important;
   }
 
-  .course-cards {
-    @include media-breakpoint-down(xs) {
+  @include media-breakpoint-down(sm) {
+    .course-cards {
       flex-flow: column-reverse;
     }
+
+    .course-home-grid {
+      padding-left: 5px !important;
+      padding-right: 5px !important;
+    }
+    
   }
+
+  
 
   .card {
     border-radius: 0px;
@@ -55,4 +63,33 @@
       }
     }
   }
+
+
+#desktop-nav {
+  width: 18% !important;
+}
+
+#course-detail {
+  width: 50% !important;
+
+  @include media-breakpoint-down(md) {
+    width: 65% !important;
+  }
+
+  @include media-breakpoint-down(sm) {
+    width: 100% !important;
+  }
+}
+
+#course-image-section {
+  width: 32% !important;
+
+  @include media-breakpoint-down(md) {
+    width: 35% !important;
+  }
+
+  @include media-breakpoint-down(sm) {
+    width: 100% !important;
+  }
+}
 }

--- a/course-v2/assets/css/course-home.scss
+++ b/course-v2/assets/css/course-home.scss
@@ -61,11 +61,11 @@
     }
   }
 
-  #desktop-nav {
+  .desktop-nav-section {
     width: 18% !important;
   }
 
-  #course-detail {
+  .course-info-section {
     width: 50% !important;
 
     @include media-breakpoint-down(md) {
@@ -77,7 +77,7 @@
     }
   }
 
-  #course-image-section {
+  .course-image-section {
     width: 32% !important;
 
     @include media-breakpoint-down(md) {
@@ -85,6 +85,14 @@
     }
 
     @include media-breakpoint-down(sm) {
+      width: 100% !important;
+    }
+  }
+
+  .course-content-section {
+    width: 82% !important;
+
+    @include media-breakpoint-down(md) {
       width: 100% !important;
     }
   }

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -33,10 +33,10 @@
         </div>
       </div>
       <div class="row course-cards">
-        <div class="col-2 course-home-grid large-and-above-only">  
+        <div class="desktop-nav-section course-home-grid large-and-above-only">  
           {{ partialCached "desktop_nav.html" . }}
         </div>
-        <div class="col-lg-10 col-sm-12 course-home-grid">
+        <div class="course-content-section course-home-grid">
           <div class="">
             <div class="card">
               <div class="d-flex">

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -26,13 +26,13 @@
       </div>
     </div>
     <div class="row course-cards">
-      <div class="col-2 course-home-grid large-and-above-only">  
+      <div class="course-home-grid large-and-above-only" id="desktop-nav">  
         {{ partialCached "desktop_nav.html" . }}
       </div>
-      <div class="col-lg-6 col-sm-8 course-home-grid">
+      <div class="course-home-grid" id="course-detail">
         {{ partialCached "course_detail.html" . }}
       </div>
-      <div class="col-lg-4 col-sm-4 mb-2 mb-sm-0 course-home-grid">
+      <div class="mb-3 mb-md-0 course-home-grid" id="course-image-section">
         {{ partialCached "course_image_section.html" . }}
       </div>
     </div>

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -29,10 +29,10 @@
       <div class="col-2 course-home-grid large-and-above-only">  
         {{ partialCached "desktop_nav.html" . }}
       </div>
-      <div class="col-lg-7 col-sm-8 course-home-grid">
+      <div class="col-lg-6 col-sm-8 course-home-grid">
         {{ partialCached "course_detail.html" . }}
       </div>
-      <div class="col-lg-3 col-sm-4 mb-2 mb-sm-0 course-home-grid">
+      <div class="col-lg-4 col-sm-4 mb-2 mb-sm-0 course-home-grid">
         {{ partialCached "course_image_section.html" . }}
       </div>
     </div>

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -26,13 +26,13 @@
       </div>
     </div>
     <div class="row course-cards">
-      <div class="course-home-grid large-and-above-only" id="desktop-nav">  
+      <div class="desktop-nav-section course-home-grid large-and-above-only">  
         {{ partialCached "desktop_nav.html" . }}
       </div>
-      <div class="course-home-grid" id="course-detail">
+      <div class="course-info-section course-home-grid">
         {{ partialCached "course_detail.html" . }}
       </div>
-      <div class="mb-3 mb-md-0 course-home-grid" id="course-image-section">
+      <div class="course-image-section mb-3 mb-md-0 course-home-grid">
         {{ partialCached "course_image_section.html" . }}
       </div>
     </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/811

#### What's this PR do?
- Makes the height of all 3 sections on CHP the same.
- Makes the height of the sidebar section and the content section on interior pages the same.
- Increases the width of the course image section on the home page.
- Replaces bootstrap classes on sections of CHP and interior page with custom CSS to achieve more precision in section's widths.

#### How should this be manually tested?
- Build any v2 course locally or view [netlify course v2](https://ocw-hugo-themes-course-v2-pr-814--ocw-next.netlify.app)
- Verify the above-mentioned points on multiple browsers and screen dimensions. Also compare it with the [design](https://projects.invisionapp.com/d/main?origin=v7#/console/21537330/467361595/preview)

#### Screenshots
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/93309234/186345806-f9b903c0-2dab-454f-b305-3407f8661539.png">

