### PR TITLE
Netlify deployment: www, course, course-v2 comment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
           RESOURCE_BASE_URL: ${{ secrets.RESOURCE_BASE_URL }}
 
       - name: Deploy www Preview to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.3
         if: ${{ github.event_name == 'pull_request' }}
         with:
           publish-dir: '../ocw-www/public'
@@ -104,7 +104,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       
       - name: Deploy Course Preview to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.3
         if: ${{ github.event_name == 'pull_request' }}
         with:
           publish-dir: '../ocw-course/public-v1'
@@ -119,7 +119,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Deploy v2 Course Preview to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.3
         if: ${{ github.event_name == 'pull_request' }}
         with:
           publish-dir: '../ocw-course/public-v2'
@@ -134,7 +134,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Deploy CI build to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.3
         if: ${{ github.event_name == 'push' }}
         with:
           publish-dir: '../ocw-www/public'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
           RESOURCE_BASE_URL: ${{ secrets.RESOURCE_BASE_URL }}
 
       - name: Deploy www Preview to Netlify
-        uses: nwtgck/actions-netlify@v1.2.3
+        uses: nwtgck/actions-netlify@v1.1
         if: ${{ github.event_name == 'pull_request' }}
         with:
           publish-dir: '../ocw-www/public'
@@ -104,7 +104,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       
       - name: Deploy Course Preview to Netlify
-        uses: nwtgck/actions-netlify@v1.2.3
+        uses: nwtgck/actions-netlify@v1.1
         if: ${{ github.event_name == 'pull_request' }}
         with:
           publish-dir: '../ocw-course/public-v1'
@@ -120,7 +120,7 @@ jobs:
 
       - name: Deploy v2 Course Preview to Netlify
         id: netlify-deployed-course-v2
-        uses: nwtgck/actions-netlify@v1.2.3
+        uses: nwtgck/actions-netlify@v1.1
         if: ${{ github.event_name == 'pull_request' }}
         with:
           publish-dir: '../ocw-course/public-v2'
@@ -165,7 +165,7 @@ jobs:
 
       
       - name: Deploy CI build to Netlify
-        uses: nwtgck/actions-netlify@v1.2.3
+        uses: nwtgck/actions-netlify@v1.1
         if: ${{ github.event_name == 'push' }}
         with:
           publish-dir: '../ocw-www/public'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,7 +147,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
-            - name: Set comment body
+      - name: Set comment body
         id: set-comment-body
         run: |
           body=$(echo '${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}' | node util/formatLighthouseComment.js)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,7 @@ jobs:
           deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: false
-          overwrites-pull-request-comment: true
+          overwrites-pull-request-comment: false
           alias: ocw-hugo-themes-www-pr-${{ github.event.number }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -112,7 +112,7 @@ jobs:
           deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: false
-          overwrites-pull-request-comment: true
+          overwrites-pull-request-comment: false
           alias: ocw-hugo-themes-course-pr-${{ github.event.number }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -127,7 +127,7 @@ jobs:
           deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: false
-          overwrites-pull-request-comment: true
+          overwrites-pull-request-comment: false
           alias: ocw-hugo-themes-course-v2-pr-${{ github.event.number }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,15 +150,6 @@ jobs:
       - name: Set comment body
         id: set-comment-body
         run: |
-          body=$(echo '${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}' | node util/formatLighthouseComment.js)
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo ::set-output name=body::$body
-
-      - name: Set comment body
-        id: set-comment-body
-        run: |
           body="Testing comment body"
           echo ::set-output name=body::$body
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,9 +151,7 @@ jobs:
       - name: Set comment body
         id: set-comment-body
         run: |
-          body="Testing comment body"
-          body="https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/"
-          body=${{ steps.netlify-deployed-course-v2.outputs.alias }}
+          body="Testing comment body: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/, ${{ steps.netlify-deployed-course-v2.outputs.alias }}"
           echo ::set-output name=body::$body
       
       - name: Find Comment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           publish-dir: '../ocw-www/public'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: ${{ github.event.pull_request.title }}
+          deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: false
           overwrites-pull-request-comment: false
@@ -147,6 +147,45 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
+            - name: Set comment body
+        id: set-comment-body
+        run: |
+          body=$(echo '${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}' | node util/formatLighthouseComment.js)
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo ::set-output name=body::$body
+
+      - name: Set comment body
+        id: set-comment-body
+        run: |
+          body="Testing comment body"
+          echo ::set-output name=body::$body
+      
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "Testing comment body"
+
+      - name: Create comment
+        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.set-comment-body.outputs.body }}
+
+      - name: Update comment
+        if: ${{ steps.fc.outputs.comment-id != 0 }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: ${{ steps.set-comment-body.outputs.body }}
+
+  
   lighthouse:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Set comment body
         id: set-comment-body
         run: |
-          body=$(echo 'Testing comment body: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/ ${{ steps.netlify-deployed-course-v2.outputs.alias }}')
+          body=$(echo 'Testing comment body: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/')
           echo ::set-output name=body::$body
       
       - name: Find Comment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,7 +211,7 @@ jobs:
           echo ::set-output name=body::$body
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v2
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,7 +126,7 @@ jobs:
           publish-dir: '../ocw-course/public-v2'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: true
+          enable-pull-request-comment: false
           enable-commit-comment: false
           overwrites-pull-request-comment: false
           alias: ocw-hugo-themes-course-v2-pr-${{ github.event.number }}
@@ -134,24 +134,10 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
-      - name: Deploy CI build to Netlify
-        uses: nwtgck/actions-netlify@v1.2.3
-        if: ${{ github.event_name == 'push' }}
-        with:
-          publish-dir: '../ocw-www/public'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: false
-          enable-commit-comment: false
-          production-deploy: true
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-
       - name: Set comment body
         id: set-comment-body
         run: |
-          body=$(echo 'Testing comment body: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/')
+          body=$(echo 'Netlify Deployments:<br>www: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br>Course: https://ocw-hugo-themes-course-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v2: https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/')
           echo ::set-output name=body::$body
       
       - name: Find Comment
@@ -160,7 +146,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: "Testing comment body"
+          body-includes: "Netlify Deployments"
 
       - name: Create comment
         if: ${{ steps.fc.outputs.comment-id == 0 }}
@@ -176,6 +162,21 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
           body: ${{ steps.set-comment-body.outputs.body }}
+
+      
+      - name: Deploy CI build to Netlify
+        uses: nwtgck/actions-netlify@v1.2.3
+        if: ${{ github.event_name == 'push' }}
+        with:
+          publish-dir: '../ocw-www/public'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          production-deploy: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
   
   lighthouse:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,7 +119,6 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Deploy v2 Course Preview to Netlify
-        id: netlify-deployed-course-v2
         uses: nwtgck/actions-netlify@v1.1
         if: ${{ github.event_name == 'pull_request' }}
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Set comment body
         id: set-comment-body
         run: |
-          body="Testing comment body: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/, ${{ steps.netlify-deployed-course-v2.outputs.alias }}"
+          body=$(echo 'Testing comment body: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/ ${{ steps.netlify-deployed-course-v2.outputs.alias }}')
           echo ::set-output name=body::$body
       
       - name: Find Comment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,7 @@ jobs:
           publish-dir: '../ocw-www/public'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: true
+          enable-pull-request-comment: false
           enable-commit-comment: false
           overwrites-pull-request-comment: false
           alias: ocw-hugo-themes-www-pr-${{ github.event.number }}
@@ -110,7 +110,7 @@ jobs:
           publish-dir: '../ocw-course/public-v1'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: true
+          enable-pull-request-comment: false
           enable-commit-comment: false
           overwrites-pull-request-comment: false
           alias: ocw-hugo-themes-course-pr-${{ github.event.number }}
@@ -119,6 +119,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Deploy v2 Course Preview to Netlify
+        id: netlify-deployed-course-v2
         uses: nwtgck/actions-netlify@v1.2.3
         if: ${{ github.event_name == 'pull_request' }}
         with:
@@ -151,6 +152,8 @@ jobs:
         id: set-comment-body
         run: |
           body="Testing comment body"
+          body="https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/"
+          body=${{ steps.netlify-deployed-course-v2.outputs.alias }}
           echo ::set-output name=body::$body
       
       - name: Find Comment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Set comment body
         id: set-comment-body
         run: |
-          body=$(echo 'Netlify Deployments:<br>www: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br>Course: https://ocw-hugo-themes-course-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v2: https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/')
+          body=$(echo 'Netlify Deployments:<br>www: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v1: https://ocw-hugo-themes-course-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v2: https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/')
           echo ::set-output name=body::$body
       
       - name: Find Comment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           publish-dir: '../ocw-www/public'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions"
+          deploy-message: ${{ github.event.pull_request.title }}
           enable-pull-request-comment: true
           enable-commit-comment: false
           overwrites-pull-request-comment: false


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- None

#### What's this PR do?
- A flag `overwrites-pull-request-comment` was set to `true` in this PR https://github.com/mitodl/ocw-hugo-themes/pull/809/ to avoid/stop the bot from posting new comments on every commit. As ideally, there should be only initial netlify comments which should be overridden on every commit instead of new comments. But it turns out that the bot is posting only 1 comment and overriding/edititing it for `www`, `course`, and `course-v2`. [Example](https://github.com/mitodl/ocw-hugo-themes/pull/820#issuecomment-1211902434). Hence that change is being reverted.
- As suggested [here](https://github.com/mitodl/ocw-hugo-themes/pull/824#discussion_r946099853), we can combine and show all the deployment links in 1 comment instead of having 3 separate comments. This has been achieved by manually creating/updating the comment after `course-v2` build.

#### How should this be manually tested?
- View deployment [comment](https://github.com/mitodl/ocw-hugo-themes/pull/824#issuecomment-1218025657).
- For testing: 
    - Push any commit with a change that doesn't affect anything. (maybe some new line in a file or correct some formatting anywhere).
    - Verify that no new comment is posted by the bot after this commit.
    - Verify that `www`, `course`, `course-v2` are built, deployed and the deployed [comment](https://github.com/mitodl/ocw-hugo-themes/pull/824#issuecomment-1218025657) is edited.
    - Verify no github action msgs are displayed. View this [comment](https://github.com/mitodl/ocw-hugo-themes/pull/824#issuecomment-1218444582) for some more context

