### PR TITLE
Removed italic styles from instructor insights block quotes

### DIFF
--- a/course-v2/assets/css/instructor-insights.scss
+++ b/course-v2/assets/css/instructor-insights.scss
@@ -19,8 +19,8 @@
 
   .quotewrapper blockquote,
   figcaption {
-    font-family: "Helvetica-Oblique", "Helvetica", sans-serif;
-    font-style: italic;
+    font-family: "Helvetica", sans-serif;
+    font-style: normal;
     margin: 0;
   }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #412

#### What's this PR do?
Removed italic styling from caption in blockqoutes

#### How should this be manually tested?
- Start ocw-courses
- Open instructor-insights and verify blockqoutes captions have font-style: normal

#### Any background context you want to provide?
Although, I have removed styles from course-v2 instructor-insights.scss but for me it did not work until i fixed styles in instructor-insights.sccc for course (v1).  I possible please do test if this PR works for you.

#### Screenshots (if appropriate)
(Optional)
<img width="963" alt="Screenshot 2022-08-17 at 5 28 10 PM" src="https://user-images.githubusercontent.com/87968618/185136774-71daa673-9970-4bad-b4db-6bb442ea7d96.png">

