### PR TITLE
fix course banner link in course-offline theme

### DIFF
--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -22,7 +22,7 @@
       </div>
     </div>
     {{ end }}
-    {{ block "subheader" . }}{{ partialCached "course_banner.html" . }}{{ end }}
+    {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
 
     <div id="course-main-content">
       <div class="row">

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -15,7 +15,7 @@
     {{ partialCached "mobile_course_nav.html" . }}
     {{ partialCached "mobile_course_info.html" . }}
     {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
-    {{ block "subheader" . }}{{ partialCached "course_banner.html" . }}{{ end }}
+    {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
 
   <div id="course-main-content">
     <div class="row">

--- a/course/layouts/_default/baseof.html
+++ b/course/layouts/_default/baseof.html
@@ -22,7 +22,7 @@
       </div>
     </div>
     {{ end }}
-    {{ block "subheader" . }}{{ partialCached "course_banner.html" . }}{{ end }}
+    {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
     <div class="container-fluid">
       <div class="row outer-wrapper">
         {{ partialCached "desktop_nav.html" . }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/840

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/832 we added the `course-offline` theme with the goal of rendering a site using the `course` or `course-v2` theme that can be browsed from a local filesystem on any computer, even without an internet connection. Relative URLs are used as part of this, because when a user opens a course site on their local machine, the base URL will be prefixed with whatever the path is to the files on their local machine. Therefore, links need to be relative to work. The course banner is currently rendered using `partialCached` to save a small amount of rendering time, but this creates a situation where a cached link to the home page is rendered on sub-pages and ends up pointing to the wrong place. This PR swaps out `partialCached` for simply `partial` when calling `course_banner.html` to ensure consistency in the URL.

#### How should this be manually tested?
 - To see the issue in action, download this [ZIP file](https://drive.google.com/file/d/14PjY01key-IxoWUS7GMTKU0mFXwqT02A/view?usp=sharing) which is 18.01sc rendered using the `course-offline` theme as-is. You'll notice that if you go to a sub-section and then click the course banner, you will be brought to an invalid URL
 - Clone the 18.01sc content repo: https://github.mit.edu/mitocwcontent/18.01sc-fall-2010
 - Clone `ocw-hugo-projects`: https://github.com/mitodl/ocw-hugo-projects
 - Set up your local terminal with the AWS credentials from `ocw-studio` RC
 - Open a terminal in the 18.01sc content repo and run the following:
```
mkdir content/static_resources
aws s3 sync s3://ol-ocw-studio-app-qa/courses/18-01sc-single-variable-calculus-fall-2010 ./content/static_resources
```
 - Open a terminal in the `ocw-hugo-themes` directory (on this PR branch) and run the following, replacing `/path/to` with the path to the various repos on your machine: `npm run build -- /path/to/mitocwcontent/18.01sc-fall-2010 /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`
 - Browse to your 18.01sc content repo folder and go into the `dist` folder, then double click on `index.html` to open it in a browser. Browse to some of the sub sections, and then click the link in the course banner to return to the course home page and verify that the link works.
