### PR TITLE
collapse facets and move department to top

### DIFF
--- a/www/assets/js/LearningResources.ts
+++ b/www/assets/js/LearningResources.ts
@@ -275,4 +275,4 @@ export interface LearningResource {
 
 export type FacetKey = keyof Facets
 
-export type FacetManifest = [FacetKey, string, boolean][]
+export type FacetManifest = [FacetKey, string, boolean, boolean][]

--- a/www/assets/js/components/Facet.tsx
+++ b/www/assets/js/components/Facet.tsx
@@ -14,12 +14,20 @@ interface Props {
   results: Aggregation | null
   currentlySelected: string[]
   onUpdate: React.ChangeEventHandler<HTMLInputElement>
+  expandedOnLoad: boolean
 }
 
 function SearchFacet(props: Props) {
-  const { name, title, results, currentlySelected, onUpdate } = props
+  const {
+    name,
+    title,
+    results,
+    currentlySelected,
+    onUpdate,
+    expandedOnLoad
+  } = props
 
-  const [showFacetList, setShowFacetList] = useState(true)
+  const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
   const [showAllFacets, setShowAllFacets] = useState(false)
 
   const titleLineIcon = showFacetList ? "arrow_drop_down" : "arrow_right"

--- a/www/assets/js/components/FacetDisplay.test.tsx
+++ b/www/assets/js/components/FacetDisplay.test.tsx
@@ -7,9 +7,9 @@ import { Facets } from "@mitodl/course-search-utils"
 
 describe("FacetDisplay component", () => {
   const facetMap: FacetManifest = [
-    ["topics", "Topics", false],
-    ["type", "Types", false],
-    ["department_name", "Departments", false]
+    ["topics", "Topics", false, false],
+    ["type", "Types", false, false],
+    ["department_name", "Departments", false, true]
   ]
 
   function setup() {
@@ -42,6 +42,7 @@ describe("FacetDisplay component", () => {
     facets.slice(1, 4).map((facet, key) => {
       expect(facet.prop("name")).toBe(facetMap[key][0])
       expect(facet.prop("title")).toBe(facetMap[key][1])
+      expect(facet.prop("expandedOnLoad")).toBe(facetMap[key][3])
     })
   })
 

--- a/www/assets/js/components/FacetDisplay.tsx
+++ b/www/assets/js/components/FacetDisplay.tsx
@@ -71,26 +71,29 @@ const FacetDisplay = React.memo(
             ))
           )}
         </div>
-        {facetMap.map(([name, title, useFilterableFacet], key) =>
-          useFilterableFacet ? (
-            <FilterableFacet
-              key={key}
-              results={facetOptions(name)}
-              name={name}
-              title={title}
-              currentlySelected={activeFacets[name] || []}
-              onUpdate={onUpdateFacets}
-            />
-          ) : (
-            <Facet
-              key={key}
-              title={title}
-              name={name}
-              results={facetOptions(name)}
-              onUpdate={onUpdateFacets}
-              currentlySelected={activeFacets[name] || []}
-            />
-          )
+        {facetMap.map(
+          ([name, title, useFilterableFacet, expandedOnLoad], key) =>
+            useFilterableFacet ? (
+              <FilterableFacet
+                key={key}
+                results={facetOptions(name)}
+                name={name}
+                title={title}
+                currentlySelected={activeFacets[name] || []}
+                onUpdate={onUpdateFacets}
+                expandedOnLoad={expandedOnLoad}
+              />
+            ) : (
+              <Facet
+                key={key}
+                title={title}
+                name={name}
+                results={facetOptions(name)}
+                onUpdate={onUpdateFacets}
+                currentlySelected={activeFacets[name] || []}
+                expandedOnLoad={expandedOnLoad}
+              />
+            )
         )}
       </React.Fragment>
     )

--- a/www/assets/js/components/FilterableFacet.tsx
+++ b/www/assets/js/components/FilterableFacet.tsx
@@ -18,11 +18,19 @@ interface Props {
   results: Aggregation | null
   currentlySelected: string[]
   onUpdate: React.ChangeEventHandler<HTMLInputElement>
+  expandedOnLoad: boolean
 }
 
 function FilterableSearchFacet(props: Props) {
-  const { name, title, results, currentlySelected, onUpdate } = props
-  const [showFacetList, setShowFacetList] = useState(true)
+  const {
+    name,
+    title,
+    results,
+    currentlySelected,
+    onUpdate,
+    expandedOnLoad
+  } = props
+  const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
 
   // null is signal for no input yet or cleared input
   const [filteredList, setFilteredList] = useState<Bucket[] | null>(null)

--- a/www/assets/js/components/SearchPage.test.tsx
+++ b/www/assets/js/components/SearchPage.test.tsx
@@ -415,7 +415,7 @@ describe("SearchPage component", () => {
     const wrapper = await render()
     await resolveSearch()
     wrapper.update()
-    const [topic, features, department] = Array.from(
+    const [department, topic, features] = Array.from(
       // @ts-ignore
       wrapper.find("FilterableSearchFacet")
     )

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -28,15 +28,15 @@ import { emptyOrNil, isDoubleQuoted } from "../lib/util"
 import { FacetManifest, LearningResourceResult } from "../LearningResources"
 
 const COURSE_FACETS: FacetManifest = [
-  ["level", "Level", false],
-  ["topics", "Topics", true],
-  ["course_feature_tags", "Features", true],
-  ["department_name", "Departments", true]
+  ["department_name", "Departments", true, true],
+  ["level", "Level", false, false],
+  ["topics", "Topics", true, false],
+  ["course_feature_tags", "Features", true, false]
 ]
 
 const RESOURCE_FACETS: FacetManifest = [
-  ["resource_type", "Resource Types", true],
-  ["topics", "Topics", true]
+  ["resource_type", "Resource Types", true, false],
+  ["topics", "Topics", true, false]
 ]
 
 interface Result {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  
<img width="1679" alt="Screen Shot 2022-09-19 at 12 48 39 PM" src="https://user-images.githubusercontent.com/1934992/191070682-93e9f881-bda3-4404-ae6a-eb05eb330873.png">

  - [x] Mobile width screenshots
 
<img width="405" alt="Screen Shot 2022-09-19 at 12 48 54 PM" src="https://user-images.githubusercontent.com/1934992/191070721-ad5b7421-3ea4-4703-8861-2f62bd0f68e2.png">

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/845

#### What's this PR do?
Moves department to the top in the course search
Makes facets collapsed by default 

#### How should this be manually tested?
run ocw-www and go to the search page. Check that this PR does the above and doesn't break anything