### PR TITLE
expand parent nav item when selected

### DIFF
--- a/course-v2/assets/js/navigation.js
+++ b/course-v2/assets/js/navigation.js
@@ -22,6 +22,7 @@ function courseNav() {
           window.location.pathname.replace(/\/$/, "")
         ) {
           navLinkEl.classList.add("active")
+          // @ts-ignore
           const uuid = navLinkEl.dataset.uuid
           const navItemEl = navLinkEl.closest(".course-nav-list-item")
           const collapseEl = navItemEl?.querySelector(".collapse")

--- a/course-v2/assets/js/navigation.js
+++ b/course-v2/assets/js/navigation.js
@@ -1,3 +1,12 @@
+// @ts-ignore
+function expandNav(navItemEl, collapseEl) {
+  collapseEl.classList.add("show")
+  // @ts-ignore
+  navItemEl
+    .querySelector(".course-nav-section-toggle, video-tab-toggle-section")
+    .setAttribute("aria-expanded", "true")
+}
+
 function courseNav() {
   document
     .querySelectorAll(".course-nav, .transcript-header")
@@ -13,6 +22,19 @@ function courseNav() {
           window.location.pathname.replace(/\/$/, "")
         ) {
           navLinkEl.classList.add("active")
+          const uuid = navLinkEl.dataset.uuid
+          const navItemEl = navLinkEl.closest(".course-nav-list-item")
+          const collapseEl = navItemEl?.querySelector(".collapse")
+          const sectionToggles = Array.prototype.filter.call(
+            document.querySelectorAll(".course-nav-section-toggle"),
+            node => {
+              return node.dataset.uuid === uuid
+            }
+          )
+          // if this is a parent item, expand its children
+          if (navItemEl && collapseEl && sectionToggles.length > 0) {
+            expandNav(navItemEl, collapseEl)
+          }
         }
       })
 
@@ -22,13 +44,7 @@ function courseNav() {
       navEl.querySelectorAll(".course-nav-list-item").forEach(navItemEl => {
         const collapseEl = navItemEl.querySelector(".collapse")
         if (collapseEl && collapseEl.contains(activeEl)) {
-          collapseEl.classList.add("show")
-          // @ts-ignore
-          navItemEl
-            .querySelector(
-              ".course-nav-section-toggle, video-tab-toggle-section"
-            )
-            .setAttribute("aria-expanded", "true")
+          expandNav(navItemEl, collapseEl)
         }
       })
     })

--- a/course-v2/layouts/partials/nav_item.html
+++ b/course-v2/layouts/partials/nav_item.html
@@ -7,6 +7,7 @@
   <div class="course-nav-parent d-flex flex-direction-row align-items-center justify-content-between">
     <span class="course-nav-text-wrapper">
       <a class="text-dark nav-link"
+        data-uuid="{{ .menuItem.Identifier }}"
         href="{{ $url }}">
         {{ .menuItem.Name }}
       </a>
@@ -16,7 +17,8 @@
       href="#nav-container_{{ .menuItem.Identifier }}"
       data-toggle="collapse"
       aria-controls="nav-container_{{ .menuItem.Identifier }}"
-      aria-expanded="">
+      aria-expanded=""
+      data-uuid="{{ .menuItem.Identifier }}">
       <i class="material-icons md-18"></i>
     </a>
     {{ end }}

--- a/course/assets/js/navigation.js
+++ b/course/assets/js/navigation.js
@@ -22,6 +22,7 @@ function courseNav() {
           window.location.pathname.replace(/\/$/, "")
         ) {
           navLinkEl.classList.add("active")
+          // @ts-ignore
           const uuid = navLinkEl.dataset.uuid
           const navItemEl = navLinkEl.closest(".course-nav-list-item")
           const collapseEl = navItemEl?.querySelector(".collapse")

--- a/course/assets/js/navigation.js
+++ b/course/assets/js/navigation.js
@@ -1,3 +1,12 @@
+// @ts-ignore
+function expandNav(navItemEl, collapseEl) {
+  collapseEl.classList.add("show")
+  // @ts-ignore
+  navItemEl
+    .querySelector(".course-nav-section-toggle, video-tab-toggle-section")
+    .setAttribute("aria-expanded", "true")
+}
+
 function courseNav() {
   document
     .querySelectorAll(".course-nav, .transcript-header")
@@ -13,6 +22,19 @@ function courseNav() {
           window.location.pathname.replace(/\/$/, "")
         ) {
           navLinkEl.classList.add("active")
+          const uuid = navLinkEl.dataset.uuid
+          const navItemEl = navLinkEl.closest(".course-nav-list-item")
+          const collapseEl = navItemEl?.querySelector(".collapse")
+          const sectionToggles = Array.prototype.filter.call(
+            document.querySelectorAll(".course-nav-section-toggle"),
+            node => {
+              return node.dataset.uuid === uuid
+            }
+          )
+          // if this is a parent item, expand its children
+          if (navItemEl && collapseEl && sectionToggles.length > 0) {
+            expandNav(navItemEl, collapseEl)
+          }
         }
       })
 
@@ -22,13 +44,7 @@ function courseNav() {
       navEl.querySelectorAll(".course-nav-list-item").forEach(navItemEl => {
         const collapseEl = navItemEl.querySelector(".collapse")
         if (collapseEl && collapseEl.contains(activeEl)) {
-          collapseEl.classList.add("show")
-          // @ts-ignore
-          navItemEl
-            .querySelector(
-              ".course-nav-section-toggle, video-tab-section-toggle"
-            )
-            .setAttribute("aria-expanded", "true")
+          expandNav(navItemEl, collapseEl)
         }
       })
     })

--- a/course/layouts/partials/nav_item.html
+++ b/course/layouts/partials/nav_item.html
@@ -7,6 +7,7 @@
   <div class="course-nav-parent d-flex flex-direction-row align-items-center justify-content-between pt-2 pb-2{{ if $hasChildren }} pr-3{{ end }}">
     <span class="course-nav-text-wrapper">
       <a class="text-uppercase text-dark nav-link"
+        data-uuid="{{ .menuItem.Identifier }}"
         href="{{ $url }}">
         {{ .menuItem.Name }}
       </a>
@@ -16,7 +17,8 @@
       href="#nav-container_{{ .menuItem.Identifier }}"
       data-toggle="collapse"
       aria-controls="nav-container_{{ .menuItem.Identifier }}"
-      aria-expanded="">
+      aria-expanded=""
+      data-uuid="{{ .menuItem.Identifier }}">
       <i class="material-icons md-18"></i>
     </a>
     {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/849

#### What's this PR do?
This PR expands on the functionality in `navigation.js` that's responsible for maintaining the "selected" state on nav items as well as expanding collapsed sections of the nav on page load if you are viewing a page that is in a collapsible nav section. Previously, if you selected a parent in the nav menu, the children would remain collapsed. This PR fixes that so that when you select a parent in the nav menu, the children are expanded.

#### How should this be manually tested?
 - Clone a course with nested menu items, such as https://github.mit.edu/mitocwcontent/18.01sc-fall-2010
 - Point to the course using your env:
```
COURSE_CONTENT_PATH=/ptah/to/mitocwcontent`
OCW_TEST_COURSE=18.01sc-fall-2010
```
 - Spin up the course with `npm run start:course`
 - Click one of the nav items on the side and verify that its children are expanded and the parent item is selected
 - Click one of the child elements and confirm that the nav is still expanded and the child is selected
 - Click the Syllabus section and verify that no nav sections are expanded

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/191625503-ef981dac-93be-40e8-b14a-31e203fecb94.png)
![image](https://user-images.githubusercontent.com/12089658/191625541-e53ffb91-5d86-4fb7-9867-cb29dcdbc959.png)

