### PR TITLE
fix: new line removed

### DIFF
--- a/base-theme/layouts/_default/_markup/render-link.html
+++ b/base-theme/layouts/_default/_markup/render-link.html
@@ -1,2 +1,4 @@
+{{- /*  Please don't end this file with a new line since it causes an unnecessary space after the link */ -}}
 {{ $destination := partial "get_destination.html" . }}
 <a href="{{ $destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix $destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+{{- /* This comment removes trailing newlines. Adding this just to be on a safer side. */ -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/848

#### What's this PR do?
- Removes trailing newline from `render-link.html`

#### How should this be manually tested?
- View any course which has either comma, period after a link (as shown in the issue ticket) or visit `/pages/get-started/` on www.
- See these unnecessary spaces: 
    - <img width="363" alt="image" src="https://user-images.githubusercontent.com/93309234/191737050-69d1fd56-9177-4825-8245-0440ecab0d33.png">
    - <img width="152" alt="image" src="https://user-images.githubusercontent.com/93309234/191737084-556675bd-cded-4ca7-9a64-f50e9c92c04c.png">
- Checkout this branch.
- Now verify that the unnecessary spaces are no more.

#### Screenshots (if appropriate)

<img width="360" alt="image" src="https://user-images.githubusercontent.com/93309234/191737375-c0353c63-5375-47cb-b127-c012883c6655.png">

<img width="149" alt="image" src="https://user-images.githubusercontent.com/93309234/191737408-48e58a6d-7143-404d-9f3a-be8058cf519c.png">

<img width="228" alt="image" src="https://user-images.githubusercontent.com/93309234/191737437-8b77d47d-b84e-4da6-a943-5a880f3f5494.png">

