### PR TITLE
rework video_embed to properly generate links to video pages offline

### DIFF
--- a/base-theme/layouts/partials/page_url.html
+++ b/base-theme/layouts/partials/page_url.html
@@ -1,0 +1,1 @@
+{{ return .url }}

--- a/base-theme/layouts/partials/video_embed.html
+++ b/base-theme/layouts/partials/video_embed.html
@@ -1,22 +1,24 @@
-{{ $youtubeKey := .Params.video_metadata.youtube_id }}
-{{ $captionsLocation := partial "video_captions_file_url.html" (dict "context" . "url" .Params.video_files.video_captions_file) }}
-{{ $uid := .Params.uid }}
-{{ $startTime := .Params.start_time | default "" }}
-{{ $endTime := .Params.end_time | default "" }}
-{{ $downloadLink := .Params.file }}
+{{ $context := .context }}
+{{ $resource := .resource }}
+{{ $youtubeKey := $resource.Params.video_metadata.youtube_id }}
+{{ $captionsLocation := partial "video_captions_file_url.html" (dict "context" . "url" $resource.Params.video_files.video_captions_file) }}
+{{ $uid := $resource.Params.uid }}
+{{ $startTime := $resource.Params.start_time | default "" }}
+{{ $endTime := $resource.Params.end_time | default "" }}
+{{ $downloadLink := $resource.Params.file }}
 {{ if (eq $downloadLink nil) }}
-{{ $downloadLink = .Params.video_files.archive_url }}
+{{ $downloadLink = $resource.Params.video_files.archive_url }}
 {{ else }}
-{{ $downloadLink =  partial "resource_url.html" (dict "context" . "url" $downloadLink) }}
+{{ $downloadLink =  partial "resource_url.html" (dict "context" $context "url" $downloadLink) }}
 {{ end }}
 
 {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime "downloadLink" $downloadLink) }}
-{{- range where $.Site.Pages "Params.uid" $uid -}}
-	
+{{ range where site.Pages "Params.uid" $uid }}
+{{ $resourceUrl := partial "page_url.html" (dict "context" $context "url" .Permalink) }}
 <div class="video-buttons-container">
-    <div class='video-page-link-section' onclick="window.location='{{- .Permalink -}}';">
+    <div class='video-page-link-section' onclick="window.location='{{ $resourceUrl }}';">
       <div class="video-page-link">View video page</div>
 			<i class="material-icons video-page-link">chevron_right</i>
     </div>
   </div>
-{{- end -}}
+{{ end }}

--- a/base-theme/layouts/shortcodes/resource.html
+++ b/base-theme/layouts/shortcodes/resource.html
@@ -1,6 +1,7 @@
 {{- $uuid := default "" (.Get "uuid") -}}
 {{- $href := default "" (.Get "href") -}}
 {{- $href_uuid := default "" (.Get "href_uuid") -}}
+{{- $page := .Page -}}
 
 {{- if not $uuid -}}
   {{- $uuid = index .Params 0 -}}
@@ -10,11 +11,11 @@
 {{- range $.Site.Pages -}}
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
     {{- if eq .Params.resourcetype "Image" -}}
-      {{ partial "image_resource.html" (dict "context" . "href" $href "href_uuid" $href_uuid) }}
+      {{ partial "image_resource.html" (dict "context" $page "href" $href "href_uuid" $href_uuid) }}
     {{- else if eq .Params.resourcetype "Video" -}}
-      {{ partial "video_embed.html" . }}
+      {{ partial "video_embed.html" (dict "context" $page "resource" .) }}
     {{- else -}}
-      <a href="{{ partial "resource_url.html" (dict "context" . "url" .Params.file) }}">{{ .Params.title }}</a>
+      <a href="{{ partial "resource_url.html" (dict "context" $page "url" .Params.file) }}">{{ .Params.title }}</a>
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/course-offline/layouts/partials/page_url.html
+++ b/course-offline/layouts/partials/page_url.html
@@ -1,0 +1,2 @@
+{{ $pathToRoot := partial "path_to_root.html" .context }}
+{{ return printf "%s/%s/index.html" (strings.TrimSuffix "/" $pathToRoot) (strings.TrimSuffix "/" (strings.TrimPrefix "/" .url)) }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/852

#### What's this PR do?
The "view video page" links on embedded videos currently use `.Permalink` to form the link to the video page. The offline theme needs to use a relative link. Since this link is generated in the context of a shortcode, `.RelPermalink` doesn't work properly because the shortcode doesn't have a template rendering context. This PR reworks how the URL is generated in the offline theme to use a method consistent with the way the rest of the offline theme works, using `path_to_root.html` and appending the URL onto that.

#### How should this be manually tested?
 - Clone `ocw-hugo-themes` on this PR branch, `ocw-hugo-projects`, and https://github.mit.edu/mitocwcontent/18.01sc-fall-2010
 - Set the following `.env` variables:
```
STATIC_API_BASE_URL=https://ocw.mit.edu/
COURSE_HUGO_CONFIG_PATH=/path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml
```
 - Run the following command: `npm run build -- /path/to/mitocwcontent/18.01sc-fall-2010 /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`
 - Browse to `/path/to/mitocwcontent/18.01sc-fall-2010/dist` and double click on `index.html` to open the course site using some variant of Chrome so we can simulate being offline easily
 - Browse to `pages/1.-differentiation/part-a-definition-and-basic-rules/session-1-introduction-to-derivatives/` relative to the root of the course site
 - Scroll down to any embedded video and click the "view video page" link, verify that you are properly brought to the video page
