### PR TITLE
bootstrap col restored

### DIFF
--- a/course-v2/assets/css/course-home.scss
+++ b/course-v2/assets/css/course-home.scss
@@ -60,40 +60,4 @@
       }
     }
   }
-
-  .desktop-nav-section {
-    width: 18% !important;
-  }
-
-  .course-info-section {
-    width: 50% !important;
-
-    @include media-breakpoint-down(md) {
-      width: 65% !important;
-    }
-
-    @include media-breakpoint-down(sm) {
-      width: 100% !important;
-    }
-  }
-
-  .course-image-section {
-    width: 32% !important;
-
-    @include media-breakpoint-down(md) {
-      width: 35% !important;
-    }
-
-    @include media-breakpoint-down(sm) {
-      display: none;
-    }
-  }
-
-  .course-content-section {
-    width: 82% !important;
-
-    @include media-breakpoint-down(md) {
-      width: 100% !important;
-    }
-  }
 }

--- a/course-v2/assets/css/course-image-section.scss
+++ b/course-v2/assets/css/course-image-section.scss
@@ -1,8 +1,5 @@
 .course-image {
-  @include media-breakpoint-down(md) {
-    height: 200px;
-  }
-
+  object-fit: contain;
   border: 1px solid $medium-gray;
   width: 100%;
 }

--- a/course-v2/assets/css/course-image-section.scss
+++ b/course-v2/assets/css/course-image-section.scss
@@ -5,7 +5,6 @@
 
   border: 1px solid $medium-gray;
   width: 100%;
-  object-fit: cover;
 }
 
 .course-image-caption {

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -33,14 +33,14 @@
         </div>
       </div>
       <div class="row course-cards">
-        <div class="desktop-nav-section course-home-grid large-and-above-only">  
+        <div class="col-2 course-home-grid large-and-above-only">  
           {{ partialCached "desktop_nav.html" . }}
         </div>
-        <div class="course-content-section course-home-grid">
+        <div class="col-sm-12 col-lg-10 course-home-grid">
           <div class="">
             <div class="card">
               <div class="d-flex">
-                <div class="col-12 col-md-12 p-0" id="main-course-section">
+                <div class="col-12 p-0" id="main-course-section">
                   <div class="card-body">
                     {{ block "main" . }}{{ end }}
                   </div>

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -26,13 +26,13 @@
       </div>
     </div>
     <div class="row course-cards">
-      <div class="desktop-nav-section course-home-grid large-and-above-only">  
+      <div class="col-2 course-home-grid large-and-above-only">  
         {{ partialCached "desktop_nav.html" . }}
       </div>
-      <div class="course-info-section course-home-grid">
+      <div class="col-12 col-md-8 col-lg-7 course-home-grid">
         {{ partialCached "course_detail.html" . }}
       </div>
-      <div class="course-image-section mb-3 mb-md-0 course-home-grid">
+      <div class="col-12 col-md-4 col-lg-3 mb-3 mb-md-0 course-home-grid">
         {{ partialCached "course_image_section.html" . }}
       </div>
     </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/853

#### What's this PR do?
- Removes custom CSS for the sections/cols in CHP and restores bootstrap cols

#### How should this be manually tested?
- Go to course home page
- Verify that everything, including the 3 sections, looks fine.
- Go to interior page
- Verify that everything looks fine.
- Repeat the above step for multiple screen sizes and browsers. 

#### Screenshots (if appropriate)

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/93309234/192306946-1401cab7-3508-47a8-a5ef-42a562c2ebb1.png">

<img width="532" alt="image" src="https://user-images.githubusercontent.com/93309234/192307036-9dd02f92-7601-490c-a4ff-4cef20015661.png">

<img width="315" alt="image" src="https://user-images.githubusercontent.com/93309234/192307115-85b9b054-2eee-4386-9d1f-1464a408aa99.png">
