### PR TITLE
style: "show course info" button replaced with an icon

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -385,3 +385,13 @@ article.content {
 .pointer {
   cursor: pointer;
 }
+
+/* This CSS override can be removed once we upgrade to bootstrap 5 */
+/* revert the bootstrap 4 rule */
+button:focus:not(.focus-visible) {
+  outline: revert;
+}
+/* re-add it so that it only applies to btn buttons */
+button.btn:focus:not(.focus-visible) {
+  outline: 0;
+}

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -36,6 +36,8 @@ $featured-facet-blue: #385d70;
 $transparency-gray: rgba(246, 247, 249, 0.77);
 $transparency-gray-light: rgba(246, 246, 246, 0.71);
 $mobile-menu-btn-color: #115f83;
+$course-info-btn-color: #e4e4e4;
+$course-info-btn-hover-color: #c0c0c0;
 
 // course pages
 $course-content-link-unclicked: #115f83;

--- a/base-theme/static/images/left_arrow.svg
+++ b/base-theme/static/images/left_arrow.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="12px" viewBox="0 0 16 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>7DB3AF8F-214E-413E-A815-4EEB88101BBB</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="OCW---Course-Detail---hidden-info---v.1.3" transform="translate(-1309.000000, -204.000000)" fill="#000000" fill-rule="nonzero">
+            <g id="Group-5" transform="translate(1301.000000, 194.000000)">
+                <g id="arrow-/-short_left" transform="translate(8.000000, 10.000000)">
+                    <path d="M3.82999992,5 L7.41000032,1.40999997 L6,0 L0,6 L6,12 L7.40999842,10.5900002 L3.82999992,7 L16,7 L16,5 L3.82999992,5 Z"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -34,10 +34,13 @@ $panel-course-info-text-color: #464646;
 
 .show-course-info-left-arrow {
   position: absolute;
-  right: 0;
-  padding: 8px;
-  margin-top: -17px;
   background-color: #e4e4e4;
+  margin-top: -17px;
+  padding-top: 5px;
+  right: 0;
+  width: 32px;
+  height: 32px;
+  text-align: center;
   cursor: pointer;
 }
 

--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -42,6 +42,10 @@ $panel-course-info-text-color: #464646;
   height: 32px;
   text-align: center;
   cursor: pointer;
+
+  .left-arrow {
+    margin-bottom: 2px;
+  }
 }
 
 .show-course-info-left-arrow:hover {

--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -34,13 +34,13 @@ $panel-course-info-text-color: #464646;
 
 .show-course-info-left-arrow {
   position: absolute;
-  right:0;
+  right: 0;
   padding: 8px;
   margin-top: -17px;
   background-color: #e4e4e4;
   cursor: pointer;
 }
 
-.show-course-info-left-arrow:hover{
+.show-course-info-left-arrow:hover {
   background-color: #c0c0c0;
 }

--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -35,8 +35,8 @@ $panel-course-info-text-color: #464646;
 .show-course-info-left-arrow {
   position: absolute;
   background-color: #e4e4e4;
+  border: none;
   margin-top: -18px;
-  padding-top: 5px;
   right: 0;
   width: 32px;
   height: 32px;

--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -31,3 +31,16 @@ $panel-course-info-text-color: #464646;
 .close-course-info:hover {
   background-color: #c0c0c0;
 }
+
+.show-course-info-left-arrow {
+  position: absolute;
+  right:0;
+  padding: 8px;
+  margin-top: -17px;
+  background-color: #e4e4e4;
+  cursor: pointer;
+}
+
+.show-course-info-left-arrow:hover{
+  background-color: #c0c0c0;
+}

--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -35,7 +35,7 @@ $panel-course-info-text-color: #464646;
 .show-course-info-left-arrow {
   position: absolute;
   background-color: #e4e4e4;
-  margin-top: -17px;
+  margin-top: -18px;
   padding-top: 5px;
   right: 0;
   width: 32px;

--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -23,31 +23,22 @@ $panel-course-info-text-color: #464646;
 
 .close-course-info {
   margin-left: auto;
-  padding: 5px 10px 5px 10px;
-  background-color: #e4e4e4;
-  cursor: pointer;
+  background-color: $course-info-btn-color !important;
+  border-radius: 0px !important;
 }
 
 .close-course-info:hover {
-  background-color: #c0c0c0;
+  background-color: $course-info-btn-hover-color !important;
 }
 
-.show-course-info-left-arrow {
+.show-course-info {
   position: absolute;
-  background-color: #e4e4e4;
-  border: none;
-  margin-top: -18px;
+  top: 0;
   right: 0;
-  width: 32px;
-  height: 32px;
-  text-align: center;
-  cursor: pointer;
-
-  .left-arrow {
-    margin-bottom: 2px;
-  }
+  background-color: $course-info-btn-color !important;
+  border-radius: 0px !important;
 }
 
-.show-course-info-left-arrow:hover {
-  background-color: #c0c0c0;
+.show-course-info:hover {
+  background-color: $course-info-btn-hover-color !important;
 }

--- a/course-v2/assets/css/course-nav.scss
+++ b/course-v2/assets/css/course-nav.scss
@@ -31,18 +31,6 @@ nav {
   color: $mobile-menu-btn-color;
 }
 
-.show-course-info {
-  position: absolute;
-  right: 0;
-  z-index: 10;
-  width: 38px;
-
-  .toggle {
-    writing-mode: vertical-lr;
-    transform: rotate(180deg);
-  }
-}
-
 .course-nav-text-wrapper {
   width: 100%;
 }

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -42,9 +42,9 @@
                 <div class="col-12 p-0" id="main-course-section">
                   <div class="card-body">
                     {{ if not $isCourseHomePage }}
-                      <div id="show-desktop-course-drawer" class="show-course-info-left-arrow large-and-above-only">
+                      <button type="button" id="show-desktop-course-drawer" class="show-course-info-left-arrow large-and-above-only">
                         <img src="/images/left_arrow.svg" alt=""/>
-                      </div>
+                      </button>
                     {{ end }} 
                     {{ block "main" . }}{{ end }}
                   </div>

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -48,7 +48,7 @@
                         class="show-course-info-left-arrow large-and-above-only"
                         aria-label="Show Course Info"
                         >
-                        <img src="/images/left_arrow.svg" alt=""/>
+                        <img class="left-arrow" src="/images/left_arrow.svg" alt=""/>
                       </button>
                     {{ end }} 
                     {{ block "main" . }}{{ end }}

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -42,7 +42,12 @@
                 <div class="col-12 p-0" id="main-course-section">
                   <div class="card-body">
                     {{ if not $isCourseHomePage }}
-                      <button type="button" id="show-desktop-course-drawer" class="show-course-info-left-arrow large-and-above-only">
+                      <button 
+                        type="button" 
+                        id="show-desktop-course-drawer" 
+                        class="show-course-info-left-arrow large-and-above-only"
+                        aria-label="Show Course Info"
+                        >
                         <img src="/images/left_arrow.svg" alt=""/>
                       </button>
                     {{ end }} 

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -44,11 +44,11 @@
                     {{ if not $isCourseHomePage }}
                       <button 
                         type="button" 
-                        id="show-desktop-course-drawer" 
-                        class="show-course-info-left-arrow large-and-above-only"
+                        class="btn show-course-info large-and-above-only"
+                        id="show-desktop-course-drawer"
                         aria-label="Show Course Info"
                         >
-                        <img class="left-arrow" src="/images/left_arrow.svg" alt=""/>
+                        <img src="/images/left_arrow.svg" alt=""/>
                       </button>
                     {{ end }} 
                     {{ block "main" . }}{{ end }}

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -41,6 +41,11 @@
               <div class="d-flex">
                 <div class="col-12 p-0" id="main-course-section">
                   <div class="card-body">
+                    {{ if not $isCourseHomePage }}
+                      <div id="show-desktop-course-drawer" class="show-course-info-left-arrow large-and-above-only">
+                        <img src="/images/left_arrow.svg" alt=""/>
+                      </div>
+                    {{ end }} 
                     {{ block "main" . }}{{ end }}
                   </div>
                 </div>
@@ -55,13 +60,6 @@
             </div>
           </div>
         </div>
-        {{ if not $isCourseHomePage }}
-        <button id="show-desktop-course-drawer" class="show-course-info large-and-above-only bg-light shadow-sm border border-right-0 rounded-left p-0 d-none">
-          <span class="btn px-2 m-0 toggle navbar-toggle offcanvas-toggle font-weight-bold">
-            Show Course Info
-        </span>
-        </button>
-        {{ end }} 
       </div>
     </div>
 

--- a/course-v2/layouts/partials/course_info.html
+++ b/course-v2/layouts/partials/course_info.html
@@ -10,7 +10,7 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
       {{ if $inPanel }}
       <button
         type="button"
-        class="btn close-course-info font-black large-and-above-only"
+        class="btn close-course-info large-and-above-only"
         id="{{ if $isDesktopCourseDrawer }}hide-desktop-course-drawer{{ end }}"
         aria-label="Close Course Info"
         >
@@ -18,6 +18,7 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
           class="toggle navbar-toggle offcanvas-toggle"
           src="/images/close_small.svg"
           alt=""
+          width="12px"
         />
       </button>
       {{ end }}

--- a/course-v2/layouts/partials/course_info.html
+++ b/course-v2/layouts/partials/course_info.html
@@ -8,15 +8,18 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
         Course Info
       </div>
       {{ if $inPanel }}
-      <div
-        class="font-black close-course-info large-and-above-only"
-        id="{{ if $isDesktopCourseDrawer }}hide-desktop-course-drawer{{ end }}">
+      <button
+        type="button"
+        class="btn close-course-info font-black large-and-above-only"
+        id="{{ if $isDesktopCourseDrawer }}hide-desktop-course-drawer{{ end }}"
+        aria-label="Close Course Info"
+        >
         <img
           class="toggle navbar-toggle offcanvas-toggle"
           src="/images/close_small.svg"
           alt=""
         />
-      </div>
+      </button>
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/863

#### What's this PR do?
- Removes the old `show course info` button.
- Adds a new icon (left arrow) button. 

#### How should this be manually tested?
- Checkout this branch
- Verify that when you close the course info drawer, a left arrow icon is shown instead of text button.
- Verify that this icon works as expected and open the course info drawer on clicking.
- Verify that this change is only applied on large screens and mobile view and functionality is unaffected.
- Test this on multiple screens sizes and on multiple browsers. 
- Verify that all the points mentioned in the acceptance criteria of issue ticket are fullfilled.

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/93309234/193028305-0d18aff5-796c-44fb-9f73-5c6c823c1f95.mov


