### PR TITLE
show more / show less for course description

### DIFF
--- a/base-theme/assets/css/button.scss
+++ b/base-theme/assets/css/button.scss
@@ -45,3 +45,7 @@ a.red-btn {
   cursor: pointer;
   white-space: nowrap;
 }
+
+button.btn-link.text-black {
+  color: black;
+}

--- a/base-theme/assets/css/button.scss
+++ b/base-theme/assets/css/button.scss
@@ -46,6 +46,7 @@ a.red-btn {
   white-space: nowrap;
 }
 
-button.btn-link.text-black {
-  color: black;
+button.btn-link {
+  color: inherit;
+  vertical-align: baseline;
 }

--- a/base-theme/assets/css/button.scss
+++ b/base-theme/assets/css/button.scss
@@ -48,5 +48,6 @@ a.red-btn {
 
 button.btn-link.link-button {
   color: inherit;
+  text-decoration: underline;
   vertical-align: baseline;
 }

--- a/base-theme/assets/css/button.scss
+++ b/base-theme/assets/css/button.scss
@@ -46,7 +46,7 @@ a.red-btn {
   white-space: nowrap;
 }
 
-button.btn-link {
+button.btn-link.link-button {
   color: inherit;
   vertical-align: baseline;
 }

--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -22,7 +22,7 @@ import {
 import "videojs-youtube"
 
 $(function() {
-  initCourseDescriptionExpander("#course-description")
+  initCourseDescriptionExpander(document)
   initCourseInfoExpander(document)
   initDownloadButton()
   initPlayBackSpeedButton()

--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -6,7 +6,10 @@ import "nanogallery2/src/jquery.nanogallery2.core.js"
 import "./css/course-v2.scss"
 
 import { initDivToggle } from "./js/div_toggle"
-import { initCourseInfoExpander } from "./js/course_expander"
+import {
+  initCourseInfoExpander,
+  initCourseDescriptionExpander
+} from "./js/course_expander"
 import { initVideoTranscriptTrack } from "./js/video_transcript_track"
 import { initPlayBackSpeedButton } from "./js/video_playback_speed"
 import { initVideoFullscreenToggle } from "./js/video_fullscreen_toggle"
@@ -19,6 +22,7 @@ import {
 import "videojs-youtube"
 
 $(function() {
+  initCourseDescriptionExpander("#course-description")
   initCourseInfoExpander(document)
   initDownloadButton()
   initPlayBackSpeedButton()

--- a/course-v2/assets/css/course-description.scss
+++ b/course-v2/assets/css/course-description.scss
@@ -1,4 +1,0 @@
-.course-description {
-  .description {
-  }
-}

--- a/course-v2/assets/css/course-description.scss
+++ b/course-v2/assets/css/course-description.scss
@@ -1,38 +1,4 @@
 .course-description {
   .description {
-    p:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  &.collapsed {
-    .description {
-      max-height: 6rem;
-      overflow: hidden;
-    }
-  }
-
-  .expand-link {
-    display: flex;
-    align-items: center;
-    border: 0;
-    padding: 0;
-    background-color: white;
-    color: $blue;
-
-    .material-icons {
-      color: black;
-    }
-  }
-
-  #course-description.collapse:not(.show) {
-    display: block;
-    /* height = lineheight * no of lines to display */
-    height: 4.5em;
-    overflow: hidden;
-  }
-
-  #course-description.collapsing {
-    height: 4.5em;
   }
 }

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -16,7 +16,6 @@
 @import "video-transcript";
 @import "course-content";
 @import "course-resources";
-@import "course-description";
 @import "partial-collapse-list";
 @import "topic";
 @import "learning-resource-types";

--- a/course-v2/assets/js/course_expander.ts
+++ b/course-v2/assets/js/course_expander.ts
@@ -43,11 +43,19 @@ const initCourseInfoExpander = document => {
 const initCourseDescriptionExpander = document => {
   const courseDescription = document.getElementById("course-description")
   if (courseDescription) {
-    const collapsedDescription = courseDescription.querySelector("#collapsed-description")
-    const expandedDescription = courseDescription?.querySelector("#expanded-description")
+    const collapsedDescription = courseDescription.querySelector(
+      "#collapsed-description"
+    )
+    const expandedDescription = courseDescription?.querySelector(
+      "#expanded-description"
+    )
     if (collapsedDescription && expandedDescription) {
-      const expandLink = collapsedDescription.querySelector("#expand-description")
-      const collapseLink = expandedDescription.querySelector("#collapse-description")
+      const expandLink = collapsedDescription.querySelector(
+        "#expand-description"
+      )
+      const collapseLink = expandedDescription.querySelector(
+        "#collapse-description"
+      )
       expandLink.addEventListener("click", () => {
         collapsedDescription.classList.add("d-none")
         expandedDescription.classList.remove("d-none")

--- a/course-v2/assets/js/course_expander.ts
+++ b/course-v2/assets/js/course_expander.ts
@@ -45,8 +45,8 @@ const initCourseDescriptionExpander = container => {
   const collapsedDescription = courseDescription.find("#collapsed-description")
   const expandedDescription = courseDescription.find("#expanded-description")
   if (collapsedDescription && expandedDescription) {
-    const expandLink = collapsedDescription.find("a")
-    const collapseLink = expandedDescription.find("a")
+    const expandLink = collapsedDescription.find("#expand-description")
+    const collapseLink = expandedDescription.find("#collapse-description")
     expandLink.on("click", () => {
       collapsedDescription.addClass("d-none")
       expandedDescription.removeClass("d-none")

--- a/course-v2/assets/js/course_expander.ts
+++ b/course-v2/assets/js/course_expander.ts
@@ -40,20 +40,20 @@ const initCourseInfoExpander = document => {
   }
 }
 
-const initCourseDescriptionExpander = container => {
-  const courseDescription = $(container)
-  const collapsedDescription = courseDescription.find("#collapsed-description")
-  const expandedDescription = courseDescription.find("#expanded-description")
+const initCourseDescriptionExpander = document => {
+  const courseDescription = document.getElementById("course-description")
+  const collapsedDescription = courseDescription.querySelector("#collapsed-description")
+  const expandedDescription = courseDescription?.querySelector("#expanded-description")
   if (collapsedDescription && expandedDescription) {
-    const expandLink = collapsedDescription.find("#expand-description")
-    const collapseLink = expandedDescription.find("#collapse-description")
-    expandLink.on("click", () => {
-      collapsedDescription.addClass("d-none")
-      expandedDescription.removeClass("d-none")
+    const expandLink = collapsedDescription.querySelector("#expand-description")
+    const collapseLink = expandedDescription.querySelector("#collapse-description")
+    expandLink.addEventListener("click", () => {
+      collapsedDescription.classList.add("d-none")
+      expandedDescription.classList.remove("d-none")
     })
-    collapseLink.on("click", () => {
-      collapsedDescription.removeClass("d-none")
-      expandedDescription.addClass("d-none")
+    collapseLink.addEventListener("click", () => {
+      collapsedDescription.classList.remove("d-none")
+      expandedDescription.classList.add("d-none")
     })
   }
 }

--- a/course-v2/assets/js/course_expander.ts
+++ b/course-v2/assets/js/course_expander.ts
@@ -40,4 +40,22 @@ const initCourseInfoExpander = document => {
   }
 }
 
-export { initCourseInfoExpander }
+const initCourseDescriptionExpander = container => {
+  const courseDescription = $(container)
+  const collapsedDescription = courseDescription.find("#collapsed-description")
+  const expandedDescription = courseDescription.find("#expanded-description")
+  if (collapsedDescription && expandedDescription) {
+    const expandLink = collapsedDescription.find("a")
+    const collapseLink = expandedDescription.find("a")
+    expandLink.on("click", () => {
+      collapsedDescription.addClass("d-none")
+      expandedDescription.removeClass("d-none")
+    })
+    collapseLink.on("click", () => {
+      collapsedDescription.removeClass("d-none")
+      expandedDescription.addClass("d-none")
+    })
+  }
+}
+
+export { initCourseInfoExpander, initCourseDescriptionExpander }

--- a/course-v2/assets/js/course_expander.ts
+++ b/course-v2/assets/js/course_expander.ts
@@ -42,19 +42,21 @@ const initCourseInfoExpander = document => {
 
 const initCourseDescriptionExpander = document => {
   const courseDescription = document.getElementById("course-description")
-  const collapsedDescription = courseDescription.querySelector("#collapsed-description")
-  const expandedDescription = courseDescription?.querySelector("#expanded-description")
-  if (collapsedDescription && expandedDescription) {
-    const expandLink = collapsedDescription.querySelector("#expand-description")
-    const collapseLink = expandedDescription.querySelector("#collapse-description")
-    expandLink.addEventListener("click", () => {
-      collapsedDescription.classList.add("d-none")
-      expandedDescription.classList.remove("d-none")
-    })
-    collapseLink.addEventListener("click", () => {
-      collapsedDescription.classList.remove("d-none")
-      expandedDescription.classList.add("d-none")
-    })
+  if (courseDescription) {
+    const collapsedDescription = courseDescription.querySelector("#collapsed-description")
+    const expandedDescription = courseDescription?.querySelector("#expanded-description")
+    if (collapsedDescription && expandedDescription) {
+      const expandLink = collapsedDescription.querySelector("#expand-description")
+      const collapseLink = expandedDescription.querySelector("#collapse-description")
+      expandLink.addEventListener("click", () => {
+        collapsedDescription.classList.add("d-none")
+        expandedDescription.classList.remove("d-none")
+      })
+      collapseLink.addEventListener("click", () => {
+        collapsedDescription.classList.remove("d-none")
+        expandedDescription.classList.add("d-none")
+      })
+    }
   }
 }
 

--- a/course-v2/layouts/partials/course_description.html
+++ b/course-v2/layouts/partials/course_description.html
@@ -3,21 +3,26 @@
 {{ with $courseData.course_description }}
   {{ $shouldCollapseDescription = gt (len .) 320 }}
 {{ end }}
-
-<div class="course-description">
+{{ $truncatedDescription := $courseData.course_description }}
+{{ $expandedDescription := print $courseData.course_description " [Show less](#collapse_description)" }}
+{{ if $shouldCollapseDescription }}
+  {{ $truncatedDescription = truncate 320 "...[Show more](#expand_description)" $courseData.course_description }}
+{{ end }}
+<div id="course-description">
   <div class="course-detail-title">
     Course Description
   </div>
-  <div id="course-description" class="description {{ if $shouldCollapseDescription }}collapse{{ end }}" aria-expanded="false">
-    {{- $courseData.course_description | markdownify -}}
+  {{ if $shouldCollapseDescription }}
+  <div id="collapsed-description" class="description">
+    {{- .context.RenderString $truncatedDescription -}}
   </div>
-  <div class="border-top-gray mt-2 {{ if not $shouldCollapseDescription }}mb-3{{ end }}">
-    {{ if $shouldCollapseDescription }}
-      <div class="collapse-btn-section float-right">
-        <a role="button" class="collapsed" data-toggle="collapse" href="#course-description" aria-expanded="false" aria-controls="course-description">
-          <span class="material-icons"></span>
-        </a>
-      </div>
-    {{ end }}
+  <div id="expanded-description" class="description d-none">
+    {{- .context.RenderString $expandedDescription -}}
   </div>
+  {{ else }}
+  <div id="full-description" class="description">
+    {{- .context.RenderString $courseData.course_description -}}
+  </div>
+  {{ end }}
+  <div class="border-top-gray mt-2"></div>
 </div>

--- a/course-v2/layouts/partials/course_description.html
+++ b/course-v2/layouts/partials/course_description.html
@@ -24,5 +24,4 @@
     {{- .context.RenderString $courseData.course_description -}}
   </div>
   {{ end }}
-  <div class="border-top-gray mt-2"></div>
 </div>

--- a/course-v2/layouts/partials/course_description.html
+++ b/course-v2/layouts/partials/course_description.html
@@ -3,21 +3,18 @@
 {{ with $courseData.course_description }}
   {{ $shouldCollapseDescription = gt (len .) 320 }}
 {{ end }}
-{{ $truncatedDescription := $courseData.course_description }}
-{{ $expandedDescription := print $courseData.course_description " [Show less](#collapse_description)" }}
-{{ if $shouldCollapseDescription }}
-  {{ $truncatedDescription = truncate 320 "...[Show more](#expand_description)" $courseData.course_description }}
-{{ end }}
 <div id="course-description">
   <div class="course-detail-title">
     Course Description
   </div>
   {{ if $shouldCollapseDescription }}
   <div id="collapsed-description" class="description">
-    {{- .context.RenderString $truncatedDescription -}}
+    {{- .context.RenderString (truncate 320 $courseData.course_description) -}}
+    {{- partial "link_button.html" (dict "text" "Show more" "id" "expand-description")  -}}
   </div>
   <div id="expanded-description" class="description d-none">
-    {{- .context.RenderString $expandedDescription -}}
+    {{- .context.RenderString $courseData.course_description -}}
+    {{- partial "link_button.html" (dict "text" "Show less" "id" "collapse-description")  -}}
   </div>
   {{ else }}
   <div id="full-description" class="description">

--- a/course-v2/layouts/partials/link_button.html
+++ b/course-v2/layouts/partials/link_button.html
@@ -1,1 +1,1 @@
-<button id="{{ .id }}" type="button" class="btn btn-link text-black p-0">{{ .text }}</button>
+<button id="{{ .id }}" type="button" class="btn btn-link p-0">{{ .text }}</button>

--- a/course-v2/layouts/partials/link_button.html
+++ b/course-v2/layouts/partials/link_button.html
@@ -1,0 +1,1 @@
+<button id="{{ .id }}" type="button" class="btn btn-link text-black p-0">{{ .text }}</button>

--- a/course-v2/layouts/partials/link_button.html
+++ b/course-v2/layouts/partials/link_button.html
@@ -1,1 +1,1 @@
-<button id="{{ .id }}" type="button" class="btn btn-link p-0">{{ .text }}</button>
+<button id="{{ .id }}" type="button" class="btn btn-link link-button p-0">{{ .text }}</button>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/864

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/330 we added some functionality to add a collapse / expand arrow to the course description using a JS / CSS based solution. This ended up being confusing for users, and a new approach (invision design link in the issue above) to use an inline link with the text "Show more" at the end of truncated text. This PR implements that using Hugo's [`truncate`](https://gohugo.io/functions/truncate/) function to truncate the description if it's over 320 characters long. This was the character threshold determining whether the expand / collapse should be initialized on the description in the CSS based method, so I stuck with that. Both the truncated and full description (with expand / collapse links) are written to the page with the expanded description hidden at first. Clicking the links simply toggles the `d-none` class on both the descriptions, effectively toggling them.

#### How should this be manually tested?
 - Clone https://github.mit.edu/mitocwcontent/15.s21-january-iap-2014
 - Point to it by setting the following in your `.env.`:
```
COURSE_CONTENT_PATH=/path/to/mitocwcontent/
OCW_TEST_COURSE=15.s21-january-iap-2014
```
 - Run `npm run start:course`
 - Visit http://localhost:3000/
 - Click the "Show more" link on the course description and confirm that the description is expanded
 - Click the "Show less" link and ensure that the description collapses
 - Go into the course content repo, open the `data/course.json` file and edit `course_description` to a short string like "test"
 - Verify that the short description loads and that there are no show / hide links
 - Repeat the above for as many browsers as you have access to and simulate mobile as well

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/193162076-aab693db-eabc-452f-8465-a8414fb206d4.png)
![image](https://user-images.githubusercontent.com/12089658/193162095-da623356-e44f-4d20-94ba-40c077750b5b.png)
![image](https://user-images.githubusercontent.com/12089658/193162270-0b67eaf3-0cdd-4681-be40-d52f32c833ad.png)
![image](https://user-images.githubusercontent.com/12089658/193162289-cd436edc-4a59-4129-b7e6-3ec65490c677.png)

