### PR TITLE
fix: leading new lines removed from link

### DIFF
--- a/base-theme/layouts/_default/_markup/render-link.html
+++ b/base-theme/layouts/_default/_markup/render-link.html
@@ -1,4 +1,5 @@
 {{- /*  Please don't end this file with a new line since it causes an unnecessary space after the link */ -}}
 {{ $destination := partial "get_destination.html" . }}
+{{- /* This comment removes leading newlines. */ -}}
 <a href="{{ $destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix $destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
-{{- /* This comment removes trailing newlines. Adding this just to be on a safer side. */ -}}
+{{- /* This comment removes trailing newlines. */ -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/848

#### What's this PR do?
- Removes leading spaces/newlines for links
- Trailing space/newlines were removed in https://github.com/mitodl/ocw-hugo-themes/pull/858

#### How should this be manually tested?
- Checkout this branch
- Go to any course ([example](https://github.mit.edu/mitocwcontent/17.810-spring-2001)) which has links wrapped up in `""`, `()`, `,`, `.` etc OR edit markdown of any course and manually add/wrap links to reproduce this issue.
- Verify that there is no leading and trailing space around the link.

#### Screenshots (if appropriate)

On main branch: 

<img width="252" alt="image" src="https://user-images.githubusercontent.com/93309234/193249858-c9c0fc0c-9d2b-4222-af79-91eca1842b80.png">


<img width="158" alt="image" src="https://user-images.githubusercontent.com/93309234/193249112-c3b2a400-1d1f-4ba2-997c-bc94da2e6623.png">

<img width="238" alt="image" src="https://user-images.githubusercontent.com/93309234/193249164-6566bed9-956e-4eae-8e43-5e34f4487b37.png">

On this branch: 

<img width="256" alt="image" src="https://user-images.githubusercontent.com/93309234/193249914-615c1ca6-3211-46ba-a315-cdd9a9db55b2.png">

<img width="162" alt="image" src="https://user-images.githubusercontent.com/93309234/193249272-3a1eae1f-7641-46e4-84ef-cb87fd3220b1.png">

<img width="240" alt="image" src="https://user-images.githubusercontent.com/93309234/193249224-529d18f1-c1c1-4ebe-9a5f-b927ae7a353a.png">





