### PR TITLE
revert image context change

### DIFF
--- a/base-theme/layouts/shortcodes/resource.html
+++ b/base-theme/layouts/shortcodes/resource.html
@@ -11,7 +11,7 @@
 {{- range $.Site.Pages -}}
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
     {{- if eq .Params.resourcetype "Image" -}}
-      {{ partial "image_resource.html" (dict "context" $page "href" $href "href_uuid" $href_uuid) }}
+      {{ partial "image_resource.html" (dict "context" . "href" $href "href_uuid" $href_uuid) }}
     {{- else if eq .Params.resourcetype "Video" -}}
       {{ partial "video_embed.html" (dict "context" $page "resource" .) }}
     {{- else -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/882

#### What's this PR do?
Reverts a change to the resource shortcode introduced in #859 

#### How should this be manually tested?

This PR can be tested with any course that has an image `{{< resource >}}`. The descript uses 1.74-fall-2020, but any course will do.

1. Clone https://github.mit.edu/mitocwcontent/1.74-fall-2020 into your ocw-content directory and set `OCW_TEST_COURSE="1.74-fall-2010`
2. On hugo-themes **main** branch:
    1. `npm run start:course` 
    2.  view http://localhost:3000/pages/instructor-insights/teaching-the-uncertainty/
    3. Check that the image above "An anti-GMO mural." (see below) has src just equal to `RESOURCE_BASE_URL`
    
    <img width="765" alt="Screen Shot 2022-10-03 at 10 53 28 AM" src="https://user-images.githubusercontent.com/9010790/193608420-c5a4c78c-beb6-4017-b9f2-ff6aedd2d451.png">
3. Repeat on this branch. The image src should now be correct:

    <img width="1001" alt="Screen Shot 2022-10-03 at 10 55 27 AM" src="https://user-images.githubusercontent.com/9010790/193608884-bfc4d245-0775-47fd-9e23-6009472ac1a5.png">

#### Any background context you want to provide?

I'm not sure if this change was introduced in #859 intentionally or not. If it was, it had to do with offline courses which are still WIP. That PR was mostly about videos, according to its title at least. (Videos appear to be working correctly right now.)