### PR TITLE
style: menu button & more info link mobile design

### DIFF
--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -35,6 +35,7 @@ $search-gray: rgba(0, 0, 0, 0.85);
 $featured-facet-blue: #385d70;
 $transparency-gray: rgba(246, 247, 249, 0.77);
 $transparency-gray-light: rgba(246, 246, 246, 0.71);
+$mobile-menu-btn-color: #115f83;
 
 // course pages
 $course-content-link-unclicked: #115f83;

--- a/base-theme/static/images/expand.svg
+++ b/base-theme/static/images/expand.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>0001A30E-0517-418E-A661-6CDB34B3B76A</title>
+    <defs>
+        <rect id="path-1" x="0" y="0" width="16" height="16"></rect>
+    </defs>
+    <g id="OCW-Q3-2022" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Mobile---Course-Materials-&amp;-Course-Info-locations" transform="translate(-23.000000, -135.000000)">
+            <g id="Group-2" transform="translate(16.000000, 130.000000)">
+                <g id="arrow-/-expand" transform="translate(7.000000, 5.000000)">
+                    <mask id="mask-2" fill="white">
+                        <use xlink:href="#path-1"></use>
+                    </mask>
+                    <g id="arrow-/-expand-(Background/Mask)"></g>
+                    <path d="M11.3333333,4.66666667 L8,4.66666667 L8,3.33333333 L12.6666667,3.33333333 L12.6615829,8.00000032 L11.3333333,8.00000032 L11.3333333,4.66666667 Z M4.66666683,11.3333333 L8,11.3333333 L8,12.6666667 L3.33333333,12.6666667 L3.33841778,7.99999936 L4.66666714,7.99999936 L4.66666683,11.3333333 Z" fill="#115F83" mask="url(#mask-2)"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/course-v2/assets/css/course-nav.scss
+++ b/course-v2/assets/css/course-nav.scss
@@ -20,8 +20,8 @@ nav {
 }
 
 .mobile-course-nav-toggle-btn {
-  border: 1px solid #136F9A;
-  color: #115F83;
+  border: 1px solid #136f9a;
+  color: #115f83;
   border-radius: 15px;
   padding: 3px 15px 3px 10px;
 }

--- a/course-v2/assets/css/course-nav.scss
+++ b/course-v2/assets/css/course-nav.scss
@@ -20,10 +20,14 @@ nav {
 }
 
 .mobile-course-nav-toggle-btn {
-  border: 1px solid #136f9a;
-  color: #115f83;
+  border: 1px solid $mobile-menu-btn-color;
+  color: $mobile-menu-btn-color;
   border-radius: 15px;
   padding: 3px 15px 3px 10px;
+}
+
+.mobile-course-info-toggle-btn {
+  color: $mobile-menu-btn-color;
 }
 
 .show-course-info {

--- a/course-v2/assets/css/course-nav.scss
+++ b/course-v2/assets/css/course-nav.scss
@@ -19,14 +19,11 @@ nav {
   }
 }
 
-.mobile-course-nav-toggle {
-  *:not(i) {
-    font-size: $font-normal;
-  }
-
-  i {
-    font-size: $font-lg;
-  }
+.mobile-course-nav-toggle-btn {
+  border: 1px solid #136F9A;
+  color: #115F83;
+  border-radius: 15px;
+  padding: 3px 15px 3px 10px;
 }
 
 .show-course-info {

--- a/course-v2/assets/css/course-nav.scss
+++ b/course-v2/assets/css/course-nav.scss
@@ -24,6 +24,7 @@ nav {
   color: $mobile-menu-btn-color;
   border-radius: 15px;
   padding: 3px 15px 3px 10px;
+  background: none;
 }
 
 .mobile-course-info-toggle-btn {

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -14,21 +14,20 @@
     {{ partialCached "mobile_course_info.html" . }}
     {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
     {{ $isCourseHomePage := (eq .Params.layout "course_home") }}
-    {{ if not $isCourseHomePage }}
-    <div class="show-course-info medium-and-below-only bg-light shadow-sm border border-right-0 rounded-left">
-      <div class="btn px-2 m-0 toggle navbar-toggle offcanvas-toggle text-uppercase font-weight-bold"
-        data-toggle="offcanvas" data-target="#course-info-drawer">
-        Course Info
-      </div>
-    </div>
-    {{ end }}
     {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
 
     <div id="course-main-content">
       <div class="row">
         <div class="col-12 course-home-grid">
           <div class="medium-and-below-only">
-            {{ partial "mobile_nav_toggle.html" . }}
+            <div class="d-flex align-items-center mb-3">
+              <div class="col-6 px-0">
+                {{ partial "mobile_nav_toggle.html" . }}
+              </div>
+              <div class="col-6 px-0">
+                {{ partial "course_info_toggle.html" (dict "isCourseHomePage" $isCourseHomePage) }}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -20,7 +20,7 @@
   <div id="course-main-content">
     <div class="row">
       <div class="col-12 course-home-grid">
-        <div class="medium-and-below-only">
+        <div class="medium-and-below-only mb-3">
           {{ partial "mobile_nav_toggle.html" . }}
         </div>
       </div>

--- a/course-v2/layouts/partials/course_info_toggle.html
+++ b/course-v2/layouts/partials/course_info_toggle.html
@@ -1,10 +1,10 @@
 {{ $isCourseHomePage := .isCourseHomePage | default "" }}
 
 {{ if not $isCourseHomePage }}
-  <button class="btn btn-link float-right">
-    <a href="javascript:void(0)" class="mobile-course-info-toggle-btn toggle navbar-toggle offcanvas-toggle"
-      data-toggle="offcanvas" data-target="#course-info-drawer">
-      More Info
-    </a>
+  <button 
+    class="btn btn-link float-right mobile-course-info-toggle-btn toggle navbar-toggle offcanvas-toggle" 
+    data-toggle="offcanvas" 
+    data-target="#course-info-drawer">
+    More Info
   </button>
 {{ end }}

--- a/course-v2/layouts/partials/course_info_toggle.html
+++ b/course-v2/layouts/partials/course_info_toggle.html
@@ -1,0 +1,10 @@
+{{ $isCourseHomePage := .isCourseHomePage | default "" }}
+
+{{ if not $isCourseHomePage }}
+  <div class="d-flex justify-content-end">
+    <a href="javascript:void(0)" class="mobile-course-info-toggle-btn toggle navbar-toggle offcanvas-toggle"
+      data-toggle="offcanvas" data-target="#course-info-drawer">
+      More Info
+    </a>
+  </div>
+{{ end }}

--- a/course-v2/layouts/partials/course_info_toggle.html
+++ b/course-v2/layouts/partials/course_info_toggle.html
@@ -1,10 +1,10 @@
 {{ $isCourseHomePage := .isCourseHomePage | default "" }}
 
 {{ if not $isCourseHomePage }}
-  <div class="d-flex justify-content-end">
+  <button class="btn btn-link float-right">
     <a href="javascript:void(0)" class="mobile-course-info-toggle-btn toggle navbar-toggle offcanvas-toggle"
       data-toggle="offcanvas" data-target="#course-info-drawer">
       More Info
     </a>
-  </div>
+  </button>
 {{ end }}

--- a/course-v2/layouts/partials/mobile_nav_toggle.html
+++ b/course-v2/layouts/partials/mobile_nav_toggle.html
@@ -1,4 +1,4 @@
-<div class="mb-4">
+<div>
   <div
     id="mobile-course-nav-toggle"
     class="mobile-course-nav-toggle-btn d-inline-flex align-items-center offcanvas-toggle"

--- a/course-v2/layouts/partials/mobile_nav_toggle.html
+++ b/course-v2/layouts/partials/mobile_nav_toggle.html
@@ -1,12 +1,11 @@
-<div class="mobile-course-nav-toggle medium-and-below-only mb-4">
+<div class="mb-4">
   <div
     id="mobile-course-nav-toggle"
-    class="btn bg-blue white-color d-inline-flex align-items-center rounded-0 navbar-toggle offcanvas-toggle"
+    class="mobile-course-nav-toggle-btn d-inline-flex align-items-center offcanvas-toggle"
     data-toggle="offcanvas"
     data-target="#mobile-course-nav"
   >
-    <i class="material-icons pr-2">arrow_back</i>
-    <span class="pr-2">Browse Course Material</span>
-    <i class="material-icons pr-2">library_books</i>
+    <img src="/images/expand.svg" alt=""/>
+    <span class="pl-1">Menu</span>
   </div>
 </div>

--- a/course-v2/layouts/partials/mobile_nav_toggle.html
+++ b/course-v2/layouts/partials/mobile_nav_toggle.html
@@ -1,5 +1,5 @@
 <div>
-  <div
+  <button
     id="mobile-course-nav-toggle"
     class="mobile-course-nav-toggle-btn d-inline-flex align-items-center offcanvas-toggle"
     data-toggle="offcanvas"
@@ -7,5 +7,5 @@
   >
     <img src="/images/expand.svg" alt=""/>
     <span class="pl-1">Menu</span>
-  </div>
+  </button>
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/877

#### What's this PR do?
- Updates buttons for mobile design for course-v2.

#### How should this be manually tested?
- Checkout this branch
- Set screen size of tablet or mobile.
- Verify that `Menu` button and `More Info` link are according to the design provided in issue ticket.
- Verify that both work as expected.
- Verify that they are hidden on large screens.
- Verify that they are completely responsive.
- Verify that there is no change/affect/impact on course-v1 theme.
- Any other use-case that needs to be tested. 

#### Screenshots (if appropriate)

<img width="756" alt="image" src="https://user-images.githubusercontent.com/93309234/193821230-6f00104b-dd18-4fe1-9693-27ae61c124a9.png">


<img width="407" alt="image" src="https://user-images.githubusercontent.com/93309234/193821169-05637cf5-8929-4cf4-9b6c-01b4e8c89f93.png">
