### PR TITLE
fix: wrapping content in a max width

### DIFF
--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -194,25 +194,6 @@ h5 {
   }
 }
 
-@media (min-width: 1620px) and (max-width: 1800px) {
-  #desktop-header .contents,
-  #course-banner .course-banner-content,
-  #footer-container .row {
-    max-width: inherit !important;
-  }
-
-  .course-home-page #course-main-content {
-    max-width: inherit !important;
-  }
-
-  #footer-container {
-    padding: 2rem 2rem !important;
-  }
-  #footer-container .row {
-    padding: 0 !important;
-  }
-}
-
 // TODO: overriding some css of header and footer in this new theme
 // when we roll out this theme completely then we can move this css to thier respective files in base-theme
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/873

#### What's this PR do?
- Removes some CSS for specific screen sizes which makes the course content expand fully. 

#### How should this be manually tested?
- Checkout this branch
- Verify that course content remains in a max-width container regardless of the screen size.
- Verify this change has no side-effects.

#### Any background context you want to provide?
- This media query CSS was added in [Compact Design PR](https://github.com/mitodl/ocw-hugo-themes/pull/784) and I remember I received a word document consisting of some CSS to be added for the `course-v2` theme, it also included this media query CSS which was added back then. I have no idea what was the thought process/agenda for adding this media query and allowing content to expand fully on some screen sizes. 
But now it seems like a bug hence removing it.  

#### Screenshots (if appropriate)

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/93309234/194047660-e5be6d9b-c373-4e84-8563-949b5b4bca40.png">

