### PR TITLE
Responsive tables for course-v2

### DIFF
--- a/course-v2/assets/js/responsive_tables.ts
+++ b/course-v2/assets/js/responsive_tables.ts
@@ -1,31 +1,28 @@
-// @ts-nocheck
 function initResponsiveTables2() {
-  const tables = document
-    .getElementById("course-content-section")
-    .getElementsByTagName("table")
-  for (const table of tables) {
-    const headings = table.getElementsByTagName("th")
-    const tbody = table.getElementsByTagName("tbody")[0]
-    const rows = tbody.getElementsByTagName("tr")
+  const tables = document.querySelectorAll('#course-content-section table')
+  tables.forEach(table => {
+    const headings = table.querySelectorAll<HTMLElement>("thead th")
+    const rows = table.querySelectorAll("tbody tr")
     // set data-title attribute on table cells
-    for (const row of rows) {
-      const cells = row.getElementsByTagName("td")
-      for (let i = 0; i < cells.length; i++) {
+    rows.forEach(row => {
+      const cells = row.querySelectorAll("td")
+      cells.forEach((cell, i) => {
         if (headings.length >= i + 1) {
           cells[i].setAttribute(
             "data-title",
             headings[i].innerText.trim().concat(": ")
           )
         }
-      }
-    }
+      })
+    })
     // force mobile style if table width exceeds main content area
     const tableWidth = table.clientWidth
     const mainContentWidth = document.getElementById("course-content-section")
-      .clientWidth
+      ?.clientWidth ?? 0
     if (tableWidth > mainContentWidth) {
       table.classList.add("mobile-table")
     }
-  }
+  })
 }
+
 initResponsiveTables2()

--- a/course-v2/assets/js/responsive_tables.ts
+++ b/course-v2/assets/js/responsive_tables.ts
@@ -1,25 +1,43 @@
+const getTables = () => document.querySelectorAll<HTMLElement>("#course-content-section table")
+const getCourseContent = () => document.getElementById("course-content-section")
+
 function initResponsiveTables2() {
-  const tables = document.querySelectorAll('#course-content-section table')
+  const tables = getTables()
+  const mainContent = getCourseContent()
+  if (!mainContent) return
+  if (!window.ResizeObserver) return
+
+  const observer = new ResizeObserver(() => calculateOverlap2())
+  observer.observe(mainContent)
   tables.forEach(table => {
-    const headings = table.querySelectorAll<HTMLElement>("thead th")
-    const rows = table.querySelectorAll("tbody tr")
+    const headings = table.getElementsByTagName("th")
+    const rows = table.querySelectorAll("table tr")
     // set data-title attribute on table cells
     rows.forEach(row => {
       const cells = row.querySelectorAll("td")
       cells.forEach((cell, i) => {
         if (headings.length >= i + 1) {
-          cells[i].setAttribute(
-            "data-title",
-            headings[i].innerText.trim().concat(": ")
-          )
+          cells[i].dataset["title"] = headings[i].innerText.trim().concat(": ")
         }
       })
     })
-    // force mobile style if table width exceeds main content area
-    const tableWidth = table.clientWidth
-    const mainContentWidth = document.getElementById("course-content-section")
-      ?.clientWidth ?? 0
-    if (tableWidth > mainContentWidth) {
+  })
+}
+
+function calculateOverlap2() {
+  const tables = getTables()
+  const mainContent = getCourseContent()
+  if (!mainContent) return
+
+  tables.forEach(table => {
+    const mainRect = mainContent.getBoundingClientRect()
+    const tableMinWidth = +(table.dataset.minWidth ?? 0)
+    if (mainRect.width > tableMinWidth) {
+      table.classList.remove('mobile-table')
+    }
+    const tableRect = table.getBoundingClientRect()
+    if (tableRect.right > mainRect.right) {
+      table.dataset.minWidth = `${tableRect.width}`
       table.classList.add("mobile-table")
     }
   })

--- a/course-v2/assets/js/responsive_tables.ts
+++ b/course-v2/assets/js/responsive_tables.ts
@@ -1,4 +1,5 @@
-const getTables = () => document.querySelectorAll<HTMLElement>("#course-content-section table")
+const getTables = () =>
+  document.querySelectorAll<HTMLElement>("#course-content-section table")
 const getCourseContent = () => document.getElementById("course-content-section")
 
 function initResponsiveTables2() {
@@ -33,7 +34,7 @@ function calculateOverlap2() {
     const mainRect = mainContent.getBoundingClientRect()
     const tableMinWidth = +(table.dataset.minWidth ?? 0)
     if (mainRect.width > tableMinWidth) {
-      table.classList.remove('mobile-table')
+      table.classList.remove("mobile-table")
     }
     const tableRect = table.getBoundingClientRect()
     if (tableRect.right > mainRect.right) {

--- a/course-v2/layouts/partials/responsive_tables_js.html
+++ b/course-v2/layouts/partials/responsive_tables_js.html
@@ -1,4 +1,4 @@
-{{ $navjs := resources.Get "js/responsive_tables.js" }}
+{{ $navjs := resources.Get "js/responsive_tables.ts" | js.Build }}
 {{ $minified := $navjs | resources.Minify }}
 <script>
 {{ $minified.Content | safeJS }}

--- a/course/assets/js/responsive_tables.ts
+++ b/course/assets/js/responsive_tables.ts
@@ -4,6 +4,7 @@ function initResponsiveTables() {
   const observer = new ResizeObserver(() => calculateOverlap())
   const mainContent = document.getElementById("main-content")
   if (!mainContent) return
+  if (!window.ResizeObserver) return
   observer.observe(mainContent)
   tables.forEach(table => {
     const headings = table.getElementsByTagName("th")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- #875 
- #835 

#### What's this PR do?
This PR makes v2 tables sensitive to resizing. We did something similar for v1 tables in https://github.com/mitodl/ocw-hugo-themes/pull/844. Additionally, this settles the "cannot read property of XYZ of null" issue noted in #875

#### How should this be manually tested?
Running the v2 theme:
1. Visit any page. Replace its markdown content with Replace it with https://gist.github.com/ChristopherChudzicki/dd0d177987b2baf219dfb9b2f351a097
2. View the hugo build for that page. Resize the window and toggle course info (upper right). The tables should resize appropriately.

#### Screenshots (if appropriate)

**Note:** The jumping in content width is fixed in #889  

https://user-images.githubusercontent.com/9010790/194137152-8d15d3bf-0fea-4ee0-badb-27cd14858594.mov

