### PR TITLE
style: max width for video player section

### DIFF
--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -41,6 +41,9 @@ $mobile-menu-btn-color: #115f83;
 $course-content-link-unclicked: #115f83;
 $course-content-link-hover-clicked: #355b6b;
 
+// video
+$video-section-max-width: 100vh;
+
 // about page
 $timeline-spacing: 128px;
 $about-red: #a92d41;

--- a/base-theme/layouts/partials/video_embed.html
+++ b/base-theme/layouts/partials/video_embed.html
@@ -12,13 +12,15 @@
 {{ $downloadLink =  partial "resource_url.html" (dict "context" $context "url" $downloadLink) }}
 {{ end }}
 
-{{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime "downloadLink" $downloadLink) }}
-{{ range where site.Pages "Params.uid" $uid }}
-{{ $resourceUrl := partial "page_url.html" (dict "context" $context "url" .Permalink) }}
-<div class="video-buttons-container">
-    <div class='video-page-link-section' onclick="window.location='{{ $resourceUrl }}';">
-      <div class="video-page-link">View video page</div>
-			<i class="material-icons video-page-link">chevron_right</i>
+<div class="video-embed">
+  {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime "downloadLink" $downloadLink) }}
+  {{ range where site.Pages "Params.uid" $uid }}
+  {{ $resourceUrl := partial "page_url.html" (dict "context" $context "url" .Permalink) }}
+  <div class="video-buttons-container">
+      <div class='video-page-link-section' onclick="window.location='{{ $resourceUrl }}';">
+        <div class="video-page-link">View video page</div>
+        <i class="material-icons video-page-link">chevron_right</i>
+      </div>
     </div>
-  </div>
-{{ end }}
+  {{ end }}
+</div>

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -55,7 +55,7 @@
   }
 }
 
-.video-embed{
+.video-embed {
   max-width: $video-section-max-width;
 }
 

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -55,6 +55,10 @@
   }
 }
 
+.video-embed{
+  max-width: $video-section-max-width;
+}
+
 .embedded-video-container {
   // this padding will be applied when video is embedded
   padding-bottom: 44px;
@@ -62,6 +66,8 @@
 }
 
 .video-page {
+  max-width: $video-section-max-width;
+
   .video-container {
     height: 0;
     padding-bottom: 56% !important;


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/865

#### What's this PR do?
- Sets max-width for video player (for both, embedded videos and video page)

#### How should this be manually tested?
- Checkout this branch or view netlify deployed version
- Build any course locally which has videos
- Verify that the video player section is not too big and fitted in your screen size with the transcript widget being visible.
- Verify that the video player section width remains same/does not change when you toggle (open/close) course info drawer.
- Verify these points for both, embedded videos and video pages.

#### Screenshots (if appropriate)

Uploading video player section max width.mov…
