### PR TITLE
only load mathjax if necessary

### DIFF
--- a/base-theme/layouts/partials/mathjax_if_necessary.html
+++ b/base-theme/layouts/partials/mathjax_if_necessary.html
@@ -1,0 +1,27 @@
+{{- $mathjax := .context.Site.Data.webpack.mathjax -}}
+<script>
+  console.log("Should I load MathJax?"  )
+</script>
+{{ with findRE `\\\(.*?\\\)|\\[.*?\\]` .context.Page.Content 1 }}
+<script>
+  console.log("Yes you should!"  )
+  window.MathJax = {
+      TeX: {
+        equationNumbers: {
+          autoNumber: "AMS"
+        }
+      },
+      displayAlign: "left",
+      displayIndent: "2em",
+      menuSettings: {
+        zoom: "Double-Click",
+        mpContext: true,
+        mpMouse: true
+      },
+      errorSettings: {
+        message: ["[Math Error]"]
+      }
+    }
+</script>
+<script src="{{ partial "webpack_url.html" (dict "context" . "url" "/static/mathjax/tex-svg.js") }}" defer></script>
+{{ end }}

--- a/base-theme/layouts/partials/mathjax_if_necessary.html
+++ b/base-theme/layouts/partials/mathjax_if_necessary.html
@@ -1,10 +1,5 @@
-{{- $mathjax := .context.Site.Data.webpack.mathjax -}}
-<script>
-  console.log("Should I load MathJax?"  )
-</script>
 {{ with findRE `\\\(.*?\\\)|\\[.*?\\]` .context.Page.Content 1 }}
 <script>
-  console.log("Yes you should!"  )
   window.MathJax = {
       TeX: {
         equationNumbers: {

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -176,34 +176,14 @@
     }
   </script>
 
-  <script>
-    window.MathJax = {
-      TeX: {
-        equationNumbers: {
-          autoNumber: "AMS"
-        }
-      },
-      displayAlign: "left",
-      displayIndent: "2em",
-      menuSettings: {
-        zoom: "Double-Click",
-        mpContext: true,
-        mpMouse: true
-      },
-      errorSettings: {
-        message: ["[Math Error]"]
-      }
-    }
-  </script>
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
   {{- $theme := .Site.Data.webpack.main -}}
   {{- $courseTheme := .Site.Data.webpack.course_v2 -}}
-  {{- $mathjax := .Site.Data.webpack.mathjax -}}
   {{ partial "include_js.html" (dict "context" . "url" $theme.js) }}
   {{ partial "include_js.html" (dict "context" . "url" $courseTheme.js) }}
-  <script src="{{ partial "webpack_url.html" (dict "context" . "url" "/static/mathjax/tex-svg.js") }}" defer></script>
   <!-- Appzi: Capture Insightful Feedback -->
+  {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
 
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
 

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -41,26 +41,6 @@
   {{ block "footer" . }}{{ partial "footer-v2" . }}{{end}}
   {{ partialCached "hide_offline_links.html" . }}
   </div>
-  <script>
-    window.MathJax = {
-      TeX: {
-        equationNumbers: {
-          autoNumber: "AMS"
-        }
-      },
-      displayAlign: "left",
-      displayIndent: "2em",
-      menuSettings: {
-        zoom: "Double-Click",
-        mpContext: true,
-        mpMouse: true
-      },
-      errorSettings: {
-        message: ["[Math Error]"]
-      }
-    }
-
-  </script>
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
   {{- $theme := .Site.Data.webpack.main -}}
@@ -68,9 +48,9 @@
 
   {{ partial "include_js.html" (dict "context" . "url" $theme.js) }}
   {{ partial "include_js.html" (dict "context" . "url" $courseTheme.js) }}
-  <script src="{{ partial "webpack_url.html" (dict "context" . "url" "/static/mathjax/tex-svg.js") }}" defer></script>
   <!-- Appzi: Capture Insightful Feedback -->
 
+  {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
 
   <!-- End Appzi -->

--- a/course/layouts/_default/baseof.html
+++ b/course/layouts/_default/baseof.html
@@ -53,35 +53,14 @@
     {{ block "footer" . }}{{ partial "footer" . }}{{end}}
     {{ partialCached "hide_offline_links.html" . }}
   </div>
-  <script>
-    window.MathJax = {
-      TeX: {
-        equationNumbers: {
-          autoNumber: "AMS"
-        }
-      },
-      displayAlign: "left",
-      displayIndent: "2em",
-      menuSettings: {
-        zoom: "Double-Click",
-        mpContext: true,
-        mpMouse: true
-      },
-      errorSettings: {
-        message: ["[Math Error]"]
-      }
-    }
-
-  </script>
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
   {{- $theme := .Site.Data.webpack.main -}}
   {{- $courseTheme := .Site.Data.webpack.course -}}
-  {{- $mathjax := .Site.Data.webpack.mathjax -}}
 
   {{ partial "include_js.html" (dict "context" . "url" $theme.js) }}
   {{ partial "include_js.html" (dict "context" . "url" $courseTheme.js) }}
-  <script src="{{ partial "webpack_url.html" (dict "context" . "url" "/static/mathjax/tex-svg.js") }}" defer></script>
+  {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
   <!-- Appzi: Capture Insightful Feedback -->
 
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -95,26 +95,6 @@
     {{ block "footer" . }}{{ partial "footer" . }}{{end}}
     {{ partialCached "hide_offline_links.html" . }}
   </div>
-  <script>
-    window.MathJax = {
-      TeX: {
-        equationNumbers: {
-          autoNumber: "AMS"
-        }
-      },
-      displayAlign: "left",
-      displayIndent: "2em",
-      menuSettings: {
-        zoom: "Double-Click",
-        mpContext: true,
-        mpMouse: true
-      },
-      errorSettings: {
-        message: ["[Math Error]"]
-      }
-    }
-
-  </script>
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
   {{- $theme := .Site.Data.webpack.main -}}
@@ -122,7 +102,7 @@
 
   {{ partial "include_js.html" (dict "context" . "url" $theme.js) }}
   {{ partial "include_js.html" (dict "context" . "url" $courseTheme.js) }}
-  <script src="{{ partial "webpack_url.html" (dict "context" . "url" "/static/mathjax/tex-svg.js") }}" defer></script>
+  {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
   <!-- Appzi: Capture Insightful Feedback -->
 
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>

--- a/www/layouts/_default/baseof.html
+++ b/www/layouts/_default/baseof.html
@@ -17,7 +17,7 @@
     {{ block "extrajs" . }}{{ end }}
     {{ partial "include_js.html" (dict "context" . "url" $main.js) }}
     <!-- Appzi: Capture Insightful Feedback -->
-
+    {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
     <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
 
     <!-- End Appzi -->


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/905

#### What's this PR do?
This PR switches us to including Mathjax only on pages that use it.

#### How should this be manually tested?
First, load https://ocw.mit.edu/courses/11-382-water-diplomacy-spring-2021/ and view network tab. Observe that a file called `tex-svg.js` is downloaded.

Now on this branch:
1. Load any course page without math. No `tex-svg.js` should be downloaded.
2. Edit the markdown to include `\\(E=mc^2\\)` OR `\\[E=mc^2\\]`. `tex-svg.js` should now be downloaded.
3. Repeat (2) for site pages, site homepage, on v1, v2, and www theme. 
