### PR TITLE
Log release version in sentry errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,5 +10,8 @@
       "browser": true,
       "jquery": true,
       "jest": true
+  },
+  "globals": {
+    "RELEASE_VERSION": true
   }
 }

--- a/base-theme/assets/js/sentry.ts
+++ b/base-theme/assets/js/sentry.ts
@@ -1,8 +1,8 @@
-/* eslint-disable no-console */
 import * as Sentry from "@sentry/browser"
 
 export const initSentry = () => {
   Sentry.init({
+    release:     RELEASE_VERSION,
     dsn:
       "https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953"
   })

--- a/base-theme/assets/js/sentry.ts
+++ b/base-theme/assets/js/sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/browser"
 
 export const initSentry = () => {
   Sentry.init({
-    release:     RELEASE_VERSION,
+    release: RELEASE_VERSION,
     dsn:
       "https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953"
   })

--- a/base-theme/assets/types/global.d.ts
+++ b/base-theme/assets/types/global.d.ts
@@ -1,0 +1,1 @@
+declare var RELEASE_VERSION: string

--- a/base-theme/assets/webpack/webpack.common.js
+++ b/base-theme/assets/webpack/webpack.common.js
@@ -144,8 +144,8 @@ module.exports = {
       Popper:          "popper.js/dist/umd/popper"
     }),
     new webpack.DefinePlugin({
-      RELEASE_VERSION: JSON.stringify(packageJson.version),
-    }),
+      RELEASE_VERSION: JSON.stringify(packageJson.version)
+    })
   ].concat(
     process.env.WEBPACK_ANALYZE === "true" ?
       new BundleAnalyzerPlugin({
@@ -154,5 +154,5 @@ module.exports = {
         openAnalyzer: true
       }) :
       []
-  ),
+  )
 }

--- a/base-theme/assets/webpack/webpack.common.js
+++ b/base-theme/assets/webpack/webpack.common.js
@@ -5,6 +5,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 const AssetsPlugin = require("assets-webpack-plugin")
 const Dotenv = require("dotenv-webpack")
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer")
+const packageJson = require("../../../package.json")
 
 /**
  * Resolve a path relative to package root.
@@ -141,7 +142,10 @@ module.exports = {
       jQuery:          "jquery",
       "window.jQuery": "jquery",
       Popper:          "popper.js/dist/umd/popper"
-    })
+    }),
+    new webpack.DefinePlugin({
+      RELEASE_VERSION: JSON.stringify(packageJson.version),
+    }),
   ].concat(
     process.env.WEBPACK_ANALYZE === "true" ?
       new BundleAnalyzerPlugin({
@@ -150,5 +154,5 @@ module.exports = {
         openAnalyzer: true
       }) :
       []
-  )
+  ),
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#875 

#### What's this PR do?
This PR sets the release tag on our sentry configuration to match the release tag in package.json.

#### How should this be manually tested?
1. `yarn run start:course` (or www)
2. in the developer console, manually `throw new Error("<yournamehere> is testing chris's PR")
3. Check the sentry logs at https://sentry.io/organizations/mit-office-of-digital-learning/issues/?project=5304953&statsPeriod=1h ... you should see your error show up within a few minutes (I think?).
4. In the "tags" section near the top (or on right hand side) there should be a "release" tag with a number matching our package.json.

_I believe we log all errors...if your error doesn't show up, maybe try a few more times._

#### Any background context you want to provide?
We recently fixed the sentry error in #875 , but a few of them are showing up. (Dozens per day rather than hundreds of thousands.) I'm fairly certain that these errors are people using old versions of the site. But we can't be sure without logging the site version.

#### Screenshots (if appropriate)

<img width="1071" alt="Screen Shot 2022-10-12 at 11 13 55 AM" src="https://user-images.githubusercontent.com/9010790/195384900-26bc452d-368e-4a81-88d6-2fa48be970c7.png">
