### PR TITLE
add footer to seach page

### DIFF
--- a/www/assets/css/search.scss
+++ b/www/assets/css/search.scss
@@ -247,6 +247,23 @@
     }
   }
 
+  .infinite-scroll-parent {
+    /*
+    This is used in tandem with InfiniteScroll's `useWindow={false}` option.
+    This way we get infinite scroll on the search results, but can still scroll
+    the page down to see the footer.
+
+    The 200vh value is somewhat arbitrary. The idea is to have the infinite
+    scroll container dominate the viewport at first, then after a bit of
+    scrolling show the footer.
+      - too small a value for max-height looks strange on screens short enough
+        that the facet height rivals the screen height.
+    */
+    max-height: 200vh;
+    min-height: 100vh;
+    overflow: auto;
+  }
+
   .search-results-area {
     background-color: #f8f8f8;
     border-top: none;

--- a/www/assets/css/search.scss
+++ b/www/assets/css/search.scss
@@ -253,13 +253,13 @@
     This way we get infinite scroll on the search results, but can still scroll
     the page down to see the footer.
 
-    The 200vh value is somewhat arbitrary. The idea is to have the infinite
+    The 150vh value is somewhat arbitrary. The idea is to have the infinite
     scroll container dominate the viewport at first, then after a bit of
     scrolling show the footer.
       - too small a value for max-height looks strange on screens short enough
         that the facet height rivals the screen height.
     */
-    max-height: 200vh;
+    max-height: 150vh;
     min-height: 100vh;
     overflow: auto;
   }

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -231,7 +231,7 @@ export default function SearchPage(props: SearchPageProps) {
             toggleFacet={toggleFacet}
             updateUI={updateUI}
           />
-          <div className="search-results-area col-12 col-lg-9 pb-2 pt-2">
+          <div className="infinite-scroll-parent search-results-area col-12 col-lg-9 pb-2 pt-2">
             <div
               className={`search-toggle ${
                 isResourceSearch ? "nofacet" : "facet"
@@ -338,6 +338,7 @@ export default function SearchPage(props: SearchPageProps) {
               hasMore={from + pageSize < total}
               loadMore={loadMore}
               initialLoad={false}
+              useWindow={false}
               loader={
                 completedInitialLoad ? <Spinner key="spinner" /> : undefined
               }

--- a/www/layouts/search/section.html
+++ b/www/layouts/search/section.html
@@ -14,4 +14,5 @@
     </main>
   </div>
 </div>
+{{ block "footer" . }}{{ partial "footer" . }}{{end}}
 {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
See https://mitodl.slack.com/archives/GQ89D0Z5M/p1665687170526699?thread_ts=1665685641.605519&cid=GQ89D0Z5M

#### What's this PR do?
This PR sets a max height for the search area of 150% of user's view port.  for the search area of 150% of the user's viewport height.

#### How should this be manually tested?
1. Run `yarn run start:www`
2. Visit the search page
3. Check that you can (a) infinite scroll and also (b) scroll to the footer, even without viewing a bazillion results.
4. Check that if you load the page zoomed out, search results still load.

    *To see what I mean, go to https://ocw.mit.edu/search/, zoom waaay out so you can see 10+ search results on one page on the screen, and reload. That's not very realistic, but this PR exacerbates the issue, so I addressed it here.*

#### Screenshots

https://user-images.githubusercontent.com/9010790/195717607-b2a35927-49a6-4014-a84e-f9f4a3675e99.mov

Mobile view is unchanged. It's significantly harder to scroll to the bottom without exhausting search results on mobile, but we can live with that for now.

