### PR TITLE
fix: max-width for drawers

### DIFF
--- a/course-v2/assets/css/drawer.scss
+++ b/course-v2/assets/css/drawer.scss
@@ -1,3 +1,8 @@
-.nav-drawer {
+.drawer {
   background: white;
+  max-width: 50% !important;
+
+  @include media-breakpoint-down(xs) {
+    max-width: 75% !important;
+  }
 }

--- a/course-v2/layouts/partials/mobile_course_info.html
+++ b/course-v2/layouts/partials/mobile_course_info.html
@@ -1,6 +1,6 @@
 <div
   id="course-info-drawer"
-  class="bg-faded pt-3 bg-light navbar-offcanvas navbar-offcanvas-right medium-and-below-only nav-drawer"
+  class="bg-faded pt-3 bg-light navbar-offcanvas navbar-offcanvas-right medium-and-below-only drawer"
 >
   {{ partial "course_info.html" (dict "context" . "inPanel" true) }}
   {{ partial "topics.html" (dict "context" . "inPanel" true) }}

--- a/course-v2/layouts/partials/mobile_course_nav.html
+++ b/course-v2/layouts/partials/mobile_course_nav.html
@@ -1,6 +1,6 @@
 <div
   id="mobile-course-nav"
-  class="navbar-offcanvas medium-and-below-only nav-drawer">
+  class="navbar-offcanvas medium-and-below-only drawer">
   <div class="mb-4 mt-4">Browse Course Material</div>
   {{ partial "nav.html" . }}
 </div>

--- a/course/assets/css/drawer.scss
+++ b/course/assets/css/drawer.scss
@@ -1,3 +1,8 @@
-.nav-drawer {
+.drawer {
   background: white;
+  max-width: 50% !important;
+
+  @include media-breakpoint-down(xs) {
+    max-width: 75% !important;
+  }
 }

--- a/course/layouts/partials/mobile_course_info.html
+++ b/course/layouts/partials/mobile_course_info.html
@@ -1,6 +1,6 @@
 <div
   id="course-info-drawer"
-  class="bg-faded pt-3 bg-light navbar-offcanvas navbar-offcanvas-right medium-and-below-only nav-drawer"
+  class="bg-faded pt-3 bg-light navbar-offcanvas navbar-offcanvas-right medium-and-below-only drawer"
 >
   {{ partial "course_info.html" (dict "context" . "inPanel" true) }}
   {{ partial "topics.html" (dict "context" . "inPanel" true) }}

--- a/course/layouts/partials/mobile_course_nav.html
+++ b/course/layouts/partials/mobile_course_nav.html
@@ -1,6 +1,6 @@
 <div
   id="mobile-course-nav"
-  class="navbar-offcanvas medium-and-below-only nav-drawer">
+  class="navbar-offcanvas medium-and-below-only drawer">
   <h5 class="text-uppercase mb-4 mt-4">Browse Course Material</h5>
   {{ partial "nav.html" . }}
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/896

#### What's this PR do?
- Sets max-width for course menu and info drawers, in both course (v1, v2) themes.

#### How should this be manually tested?
- Please follow the steps mentioned in the issue ticket to reproduce the issue and verify the fix on this branch.

#### Screenshots (if appropriate)

<img width="707" alt="image" src="https://user-images.githubusercontent.com/93309234/195843590-3edbdbb4-9480-4d98-b73a-52a368e246a3.png">


<img width="443" alt="image" src="https://user-images.githubusercontent.com/93309234/195843534-03bc061a-811e-43a3-b5cb-4c1514ea30e4.png">

