### PR TITLE
feat: close course menu & info drawers with x button

### DIFF
--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -42,3 +42,8 @@ $panel-course-info-text-color: #464646;
 .show-course-info:hover {
   background-color: $course-info-btn-hover-color !important;
 }
+
+.close-mobile-course-info {
+  position: absolute;
+  right: 0;
+}

--- a/course-v2/layouts/partials/course_info_toggle.html
+++ b/course-v2/layouts/partials/course_info_toggle.html
@@ -2,7 +2,8 @@
 
 {{ if not $isCourseHomePage }}
   <button 
-    class="btn btn-link float-right mobile-course-info-toggle-btn toggle navbar-toggle offcanvas-toggle" 
+    class="btn btn-link float-right mobile-course-info-toggle-btn toggle navbar-toggle offcanvas-toggle"
+    id="mobile-course-info-toggle"
     data-toggle="offcanvas" 
     data-target="#course-info-drawer">
     More Info

--- a/course-v2/layouts/partials/mobile_course_info.html
+++ b/course-v2/layouts/partials/mobile_course_info.html
@@ -2,6 +2,21 @@
   id="course-info-drawer"
   class="bg-faded pt-3 bg-light navbar-offcanvas navbar-offcanvas-right medium-and-below-only drawer"
 >
+  <div class="col-12">
+    <button
+      class="btn close-mobile-course-info"
+      type="button"
+      aria-label="Close Course Info"
+      onclick="$('#mobile-course-info-toggle').click();"
+      >
+      <img
+        class=""
+        src="/images/close_small.svg"
+        alt=""
+        width="12px"
+      />
+    </button>
+  </div>
   {{ partial "course_info.html" (dict "context" . "inPanel" true) }}
   {{ partial "topics.html" (dict "context" . "inPanel" true) }}
   {{ partial "learning_resource_types.html" (dict "context" . "inPanel" true) }}

--- a/course-v2/layouts/partials/mobile_course_nav.html
+++ b/course-v2/layouts/partials/mobile_course_nav.html
@@ -1,25 +1,20 @@
 <div
   id="mobile-course-nav"
   class="navbar-offcanvas offcanvas-toggle offcanvas-toggle-close medium-and-below-only drawer">
-  <div class="mb-4 mt-4">
-    <div class="d-flex align-items-center">
-      <div>Browse Course Material</div>
-      <div class="ml-auto"> 
-        <button
-          class="btn"
-          type="button"
-          aria-label="Close Course Menu"
-          onclick="$('#mobile-course-nav-toggle').click();"
-          >
-          <img
-            class=""
-            src="/images/close_small.svg"
-            alt=""
-            width="12px"
-          />
-        </button>
-      </div>
-    </div>
-  </div>
+  <h3 class="my-4 d-flex align-items-center justify-content-between">
+    Browse Course Material
+    <button
+      class="btn"
+      type="button"
+      aria-label="Close Course Menu"
+      onclick="$('#mobile-course-nav-toggle').click();"
+      >
+      <img
+        src="/images/close_small.svg"
+        alt=""
+        width="12px"
+      />
+    </button>
+  </h3>
   {{ partial "nav.html" . }}
 </div>

--- a/course-v2/layouts/partials/mobile_course_nav.html
+++ b/course-v2/layouts/partials/mobile_course_nav.html
@@ -1,6 +1,25 @@
 <div
   id="mobile-course-nav"
-  class="navbar-offcanvas medium-and-below-only drawer">
-  <div class="mb-4 mt-4">Browse Course Material</div>
+  class="navbar-offcanvas offcanvas-toggle offcanvas-toggle-close medium-and-below-only drawer">
+  <div class="mb-4 mt-4">
+    <div class="d-flex align-items-center">
+      <div>Browse Course Material</div>
+      <div class="ml-auto"> 
+        <button
+          class="btn"
+          type="button"
+          aria-label="Close Course Menu"
+          onclick="$('#mobile-course-nav-toggle').click();"
+          >
+          <img
+            class=""
+            src="/images/close_small.svg"
+            alt=""
+            width="12px"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
   {{ partial "nav.html" . }}
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
part of https://github.com/mitodl/ocw-hugo-themes/issues/895

#### What's this PR do?
- Adds close (x) button to course menu drawer which closes the drawer when clicked.
- Adds close (x) button to course info drawer which closes the drawer when clicked.
- Note: This change is only done on `course-v2` theme.
 
#### How should this be manually tested?
- Checkout this branch
- Build any course on `course-v2` theme or view netlify deployed version
- Make the size of screen small so that course menu and info buttons show up. 
- Verify that both, the course menu and info drawers, when opened, have a close button, which closes the drawer when clicked.


#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/93309234/196175954-be19e0fa-005f-411c-98e9-9add14f11457.mov


