### PR TITLE
feat: minimal footer on search page

### DIFF
--- a/www/assets/css/search.scss
+++ b/www/assets/css/search.scss
@@ -292,3 +292,14 @@
     display: none;
   }
 }
+
+.search-footer {
+  font-size: $font-xs;
+  margin-top: 50px;
+  div a {
+    text-decoration: underline !important;
+  }
+  div a:hover {
+    color: $dark-gray !important;
+  }
+}

--- a/www/assets/js/components/Footer.tsx
+++ b/www/assets/js/components/Footer.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+export default function Footer() {
+  return (
+   
+      <div className="search-footer px-2">
+         <img
+            src="/images/mit-ol.png"
+            width="140px"
+          />
+          <div className="mt-4">
+							<a className="text-muted" href="https://accessibility.mit.edu" target="_blank">Accessibility</a>
+						</div>
+						<div className="mt-2">
+							<a className="text-muted" href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">Creative Commons License</a>
+						</div>
+						<div className="mt-2">
+							<a  className="text-muted"href='/pages/privacy-and-terms-of-use/'>Terms and Conditions</a>
+						</div>
+            <div className="text-muted mt-4">
+            © 2001–{new Date().getFullYear()} Massachusetts Institute of Technology
+            </div>
+      </div>;
+  );
+}

--- a/www/assets/js/components/SearchFilterDrawer.tsx
+++ b/www/assets/js/components/SearchFilterDrawer.tsx
@@ -6,6 +6,7 @@ import { useDeviceCategory } from "../hooks/util"
 import { Aggregation, Facets } from "@mitodl/course-search-utils"
 import { FacetManifest } from "../LearningResources"
 import { SEARCH_COMPACT_UI, SEARCH_LIST_UI } from "../lib/constants"
+import Footer from "./Footer"
 
 interface Props {
   facetMap: FacetManifest
@@ -42,6 +43,9 @@ export default function SearchFilterDrawer(props: Props) {
     return (
       <div className="col-12 col-lg-3 mt-3 mt-lg-0 facet-display-wrapper pt-3">
         <FacetDisplay {...props} />
+        <div className="col-12">
+          <Footer />
+        </div>
       </div>
     )
   }
@@ -60,6 +64,9 @@ export default function SearchFilterDrawer(props: Props) {
       </div>
       <div className="contents">
         <FacetDisplay {...props} />
+      </div>
+      <div className="col-12 px-5 mt-3 pb-5">
+        <Footer />
       </div>
     </div>
   ) : (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/912

#### What's this PR do?
- Adds a minimal footer on search page.

#### How should this be manually tested?
- Checkout this branch
- Build www
- Open chrome with disabled web security to bypass cors error locally. 
    - Command: `open -n -a /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --args --user-data-dir="/tmp/chrome_dev_test" --disable-web-security` 
- OR Open netlify deployed www version
- Go to search page 
- Verify that a minimal footer is there underneath the facets.
- Verify that all links on footer works fine and redirect the user to correct target pages.
- Verify this on different screen sizes and different browsers.
- Since Search is a main and important module, so we need to make sure that everything else works fine and that these changes have no side effects. 

#### Screenshots (if appropriate)

<img width="353" alt="image" src="https://user-images.githubusercontent.com/93309234/196371987-cc6c5d48-a549-4758-abdb-c8b5ea85bd81.png">

<img width="224" alt="image" src="https://user-images.githubusercontent.com/93309234/196372060-85a948a6-efbd-44b1-8ef6-82042b24debb.png">

<img width="377" alt="image" src="https://user-images.githubusercontent.com/93309234/196372159-0c3914ac-561c-4a1b-9998-e58d8e12d8e2.png">

