### PR TITLE
fix: typo in mobile navbar

### DIFF
--- a/base-theme/layouts/partials/header.html
+++ b/base-theme/layouts/partials/header.html
@@ -43,7 +43,7 @@
           {{ partial "link.html" (dict "href" $giveNowUrl "class" "nav-link" "text" "Give Now") }}
         </li>
         <li class="nav-item">
-          {{ partial "link.html" (dict "href" $aboutUrl "class" "nav-link" "text" "Contact Us") }}
+          {{ partial "link.html" (dict "href" $aboutUrl "class" "nav-link" "text" "About OCW") }}
         </li>
         <li class="nav-item">
           {{ partial "link.html" (dict "href" $zenDeskUrl "class" "nav-link" "text" "Help & Faqs" "target" "_blank") }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-projects/issues/217

#### What's this PR do?
- Fixes a type in mobile navbar: `Contact us` changed to `About OCW`

#### How should this be manually tested?
- Checkout this branch
- Build any course or www OR view netlify deployed version
- Set screen size to mobile
- Click the hamburger and verify that the 2nd link is `About OCW` which redirects to the correct about page

#### Screenshots (if appropriate)

<img width="425" alt="image" src="https://user-images.githubusercontent.com/93309234/196405720-8faedee4-6627-4355-b202-83b7b7405b9f.png">

