### PR TITLE
fix instructors search link on course home page

### DIFF
--- a/course-v2/layouts/partials/get_instructors.html
+++ b/course-v2/layouts/partials/get_instructors.html
@@ -8,7 +8,7 @@
       {{ partial "sentry_capture_message.html" $errorMessage }}
     {{ else }}
       {{ $data := (. | unmarshal).data }}
-      {{ $searchUrl := partial "get_search_url.html" (dict "key" "topic" "value" (title $data.title)) }}
+      {{ $searchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" (title $data.title)) }}
       {{ $instructor := merge $data (dict "url" $searchUrl) }}
       {{ $instructors = $instructors | append $instructor }}
     {{ end }}

--- a/course/layouts/partials/get_instructors.html
+++ b/course/layouts/partials/get_instructors.html
@@ -8,7 +8,7 @@
       {{ partial "sentry_capture_message.html" $errorMessage }}
     {{ else }}
       {{ $data := (. | unmarshal).data }}
-      {{ $searchUrl := partial "get_search_url.html" (dict "key" "topic" "value" (title $data.title)) }}
+      {{ $searchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" (title $data.title)) }}
       {{ $instructor := merge $data (dict "url" $searchUrl) }}
       {{ $instructors = $instructors | append $instructor }}
     {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested *No, but I made a note of this in #919 so we remember to add a test*
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#924 

#### What's this PR do?
Fixes the instructor search link on OCW course home pages

#### How should this be manually tested?
I wrote the instructions as if for [8.06-spring-2018](https://github.mit.edu/mitocwcontent/8.06-spring-2018), but any course with at least one instructor will work.

1. Visit https://ocw.mit.edu/courses/8-06-quantum-physics-iii-spring-2018/. Right-click the instructor link and inspect the link URL. It is https://ocw.mit.edu/search?t=Prof.+Barton+Zwiebach. Note the `t=` in search parameters. "t" is for topic. Martin Zwiebach is not a topic. The search param should be "q=...".
2. **Test for course theme**: Set your env var for `COURSE_HUGO_CONFIG_PATH` to point to `/ocw-hugo-projects/ocw-course/config.yaml`
3. `yarn start:course` and visit the course homepage
4. Right-click the instructor link and note that the search param is now `?q=Prof.+Barton+Zwiebach`.
5. I don't think we're set up right now to run www and a course simultaneously locally. But you can check that appending the query string above to https://ocw.mit.edu/search works as expected.
6. **Course v-2**: Repeat steps 2–5 after setting `COURSE_HUGO_CONFIG_PATH` to point to `/ocw-hugo-projects/ocw-course-v2/config.yaml`

#### Any background context you want to provide?

You may notice that clicking an instructor on course home page generates strings like `?q=Prof.+Barton+Zwiebach`, whereas clicking an instructor on search page generates strings like `q="Prof.%20Barton%20Zwiebach"`.

As search strings, I believe these are equivalent. The `+` versions are generated by Hugo. The `%20` versions are generated by `serializeSearchParams` from https://github.com/mitodl/course-search-utils. IMO we should use + for both versions just for consistency. (That's what `new URLSearchParams([...]).toString()` uses in javascript.) But, that's a separate issue.