### PR TITLE
feat: close mobile course drawers via swiping

### DIFF
--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -14,6 +14,7 @@ import { initVideoTranscriptTrack } from "./js/video_transcript_track"
 import { initPlayBackSpeedButton } from "./js/video_playback_speed"
 import { initVideoFullscreenToggle } from "./js/video_fullscreen_toggle"
 import { initDownloadButton } from "./js/video-download-button"
+import { initCourseDrawersClosingViaSwiping } from "./js/mobile_course_drawers"
 import {
   clearSolution,
   checkAnswer,
@@ -32,4 +33,5 @@ $(function() {
   checkAnswer()
   showSolution()
   initVideoFullscreenToggle()
+  initCourseDrawersClosingViaSwiping()
 })

--- a/course-v2/assets/js/mobile_course_drawers.ts
+++ b/course-v2/assets/js/mobile_course_drawers.ts
@@ -1,6 +1,19 @@
+enum SWIPE_DIRECTION {
+  Left = "L",
+  Right = "R"
+}
+
 export const initCourseDrawersClosingViaSwiping = () => {
-  elementSwiping("mobile-course-nav", "mobile-course-nav-toggle", "L")
-  elementSwiping("course-info-drawer", "mobile-course-info-toggle", "R")
+  elementSwiping(
+    "mobile-course-nav",
+    "mobile-course-nav-toggle",
+    SWIPE_DIRECTION.Left
+  )
+  elementSwiping(
+    "course-info-drawer",
+    "mobile-course-info-toggle",
+    SWIPE_DIRECTION.Right
+  )
 }
 
 /**
@@ -13,7 +26,7 @@ export const initCourseDrawersClosingViaSwiping = () => {
 const elementSwiping = (
   elementId: string,
   buttonId: string,
-  swipeDirection: string
+  swipeDirection: SWIPE_DIRECTION
 ) => {
   const element = document.getElementById(elementId)
   let touchstartX = 0
@@ -25,11 +38,11 @@ const elementSwiping = (
 
   element?.addEventListener("touchend", e => {
     touchendX = e.changedTouches[0].screenX
-    if (swipeDirection === "R") {
-      // checking if its a right swipe
-      if (touchendX > touchstartX) document.getElementById(buttonId)?.click()
-    } else {
-      if (touchendX < touchstartX) document.getElementById(buttonId)?.click()
+    if (
+      (swipeDirection === SWIPE_DIRECTION.Right && touchendX > touchstartX) ||
+      (swipeDirection === SWIPE_DIRECTION.Left && touchendX < touchstartX)
+    ) {
+      document.getElementById(buttonId)?.click()
     }
   })
 }

--- a/course-v2/assets/js/mobile_course_drawers.ts
+++ b/course-v2/assets/js/mobile_course_drawers.ts
@@ -1,0 +1,36 @@
+export const initCourseDrawersClosingViaSwiping = () => {
+  elementSwiping("mobile-course-nav", "mobile-course-nav-toggle", "L")
+  elementSwiping("course-info-drawer", "mobile-course-info-toggle", "R")
+}
+
+/**
+ * It adds touch event listener to the element and clicks the button when swiped in the mentioned direction.
+ *
+ * @param {string} elementId element on which touch eventlistenter is added.
+ * @param {string} buttonId This button will be clicked on swiping
+ * @param {string} swipeDirection L= Swipe left, R= Swipe Right
+ * @return {any} data fetched from localstorage
+ */
+const elementSwiping = (
+  elementId: string,
+  buttonId: string,
+  swipeDirection: string
+) => {
+  const element = document.getElementById(elementId)
+  let touchstartX = 0
+  let touchendX = 0
+
+  element?.addEventListener("touchstart", e => {
+    touchstartX = e.changedTouches[0].screenX
+  })
+
+  element?.addEventListener("touchend", e => {
+    touchendX = e.changedTouches[0].screenX
+    if (swipeDirection === "R") {
+      // checking if its a right swipe
+      if (touchendX > touchstartX) document.getElementById(buttonId)?.click()
+    } else {
+      if (touchendX < touchstartX) document.getElementById(buttonId)?.click()
+    }
+  })
+}

--- a/course-v2/assets/js/mobile_course_drawers.ts
+++ b/course-v2/assets/js/mobile_course_drawers.ts
@@ -1,18 +1,18 @@
-enum SWIPE_DIRECTION {
+enum SwipeDirection {
   Left = "L",
   Right = "R"
 }
 
 export const initCourseDrawersClosingViaSwiping = () => {
-  elementSwiping(
+  enableSwiping(
     "mobile-course-nav",
     "mobile-course-nav-toggle",
-    SWIPE_DIRECTION.Left
+    SwipeDirection.Left
   )
-  elementSwiping(
+  enableSwiping(
     "course-info-drawer",
     "mobile-course-info-toggle",
-    SWIPE_DIRECTION.Right
+    SwipeDirection.Right
   )
 }
 
@@ -23,26 +23,33 @@ export const initCourseDrawersClosingViaSwiping = () => {
  * @param {string} buttonId This button will be clicked on swiping
  * @param {string} swipeDirection L= Swipe left, R= Swipe Right
  */
-const elementSwiping = (
+const enableSwiping = (
   elementId: string,
   buttonId: string,
-  swipeDirection: SWIPE_DIRECTION
+  swipeDirection: SwipeDirection
 ) => {
   const element = document.getElementById(elementId)
+  if (!element) throw Error(`Element having ID: ${elementId} does not exist`)
+
   let touchstartX = 0
   let touchendX = 0
 
-  element?.addEventListener("touchstart", e => {
+  element.addEventListener("touchstart", e => {
     touchstartX = e.changedTouches[0].screenX
   })
 
-  element?.addEventListener("touchend", e => {
+  element.addEventListener("touchend", e => {
     touchendX = e.changedTouches[0].screenX
     if (
-      (swipeDirection === SWIPE_DIRECTION.Right && touchendX > touchstartX) ||
-      (swipeDirection === SWIPE_DIRECTION.Left && touchendX < touchstartX)
+      (swipeDirection === SwipeDirection.Right && touchendX > touchstartX) ||
+      (swipeDirection === SwipeDirection.Left && touchendX < touchstartX)
     ) {
-      document.getElementById(buttonId)?.click()
+      const buttonElement = document.getElementById(buttonId)
+      if (!buttonElement) {
+        throw Error(`Button element having ID: ${buttonId} does not exist`)
+      }
+
+      buttonElement.click()
     }
   })
 }

--- a/course-v2/assets/js/mobile_course_drawers.ts
+++ b/course-v2/assets/js/mobile_course_drawers.ts
@@ -9,7 +9,6 @@ export const initCourseDrawersClosingViaSwiping = () => {
  * @param {string} elementId element on which touch eventlistenter is added.
  * @param {string} buttonId This button will be clicked on swiping
  * @param {string} swipeDirection L= Swipe left, R= Swipe Right
- * @return {any} data fetched from localstorage
  */
 const elementSwiping = (
   elementId: string,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/895

#### What's this PR do?
- Makes the course menu drawer swipe-able such that it can be closed by swiping
- Makes the course info drawer swipe-able such that it can be closed by swiping
- Does it by adding `touchstart` and `touchend` event listeners

#### How should this be manually tested?
- Checkout this branch
- Build any course on v2 theme or view [netlify deployed version](https://ocw-hugo-themes-course-v2-pr-928--ocw-next.netlify.app/)
- Go to mobile screen on any course page.
- open course menu drawer, swipe it to left, and verify that it is closed smoothly by swiping
- open course info drawer, swipe it to right, and verify that it is closed smoothly by swiping
- Ideally: Open the netlify deployed version on your mobile, and test it there.

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/93309234/197763281-65f261d4-349e-4bdb-be10-655bad4007ac.mov
