### PR TITLE
pass .context to webpack_url in mathjax_if_necessary

### DIFF
--- a/base-theme/layouts/partials/mathjax_if_necessary.html
+++ b/base-theme/layouts/partials/mathjax_if_necessary.html
@@ -18,5 +18,5 @@
       }
     }
 </script>
-<script src="{{ partial "webpack_url.html" (dict "context" . "url" "/static/mathjax/tex-svg.js") }}" defer></script>
+<script src="{{ partial "webpack_url.html" (dict "context" .context "url" "/static/mathjax/tex-svg.js") }}" defer></script>
 {{ end }}

--- a/base-theme/layouts/partials/mathjax_if_necessary.html
+++ b/base-theme/layouts/partials/mathjax_if_necessary.html
@@ -1,3 +1,4 @@
+{{ $context := .context }}
 {{ with findRE `\\\(.*?\\\)|\\[.*?\\]` .context.Page.Content 1 }}
 <script>
   window.MathJax = {
@@ -18,5 +19,5 @@
       }
     }
 </script>
-<script src="{{ partial "webpack_url.html" (dict "context" .context "url" "/static/mathjax/tex-svg.js") }}" defer></script>
+<script src="{{ partial "webpack_url.html" (dict "context" $context "url" "/static/mathjax/tex-svg.js") }}" defer></script>
 {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/932

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/906, we introduced a change that conditionally loads MathJax. This new partial, `mathjax_if_necessary.html`, calls `webpack_url.html`. The Hugo `.` object is passed as the `context` parameter, when the context being passed to `mathjax_if_necessary.html` itself is stored in `.context`. This same object should be passed on as the context object, not the parameter dict itself.

#### How should this be manually tested?
 - Clone https://github.mit.edu/mitocwcontent/res.8-004-january-iap-2015
 - Clone [`ocw-hugo-projects`](https://github.com/mitodl/ocw-hugo-projects)
 - Run `npm run build /path/to/mitocwcontent/res.8-004-january-iap-2015 /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml
 - Verify the build completes successfully
 - Browse to the course content folder and look in the `dist` folder for `index.html`. Double click it and verify that the page loads and you can click around the site. Some resources like the course image will not load unless you pull down the static assets prior to building, but that's not necessary for this test.
