### PR TITLE
rename /resources to /download

### DIFF
--- a/course-v2/content/learning_resource_types/_index.md
+++ b/course-v2/content/learning_resource_types/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Resources
-url: /resources/
+url: /download/
 kind: taxonomy
 ---

--- a/course-v2/content/resources/_index.md
+++ b/course-v2/content/resources/_index.md
@@ -1,0 +1,5 @@
+---
+_build:
+  list: never
+  render: never
+---


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-themes/issues/938

#### What's this PR do?
In [this](https://github.com/mitodl/hq/discussions/92) discussion, it was decided that the resource index page would be generated via a taxonomy based on `learning_resource_types`. As part of that work, the root taxonomy page was mounted at `/resources` so it had the same root as the rest of the resource pages. As part of https://github.com/mitodl/ocw-hugo-themes/issues/938, it is expected that this page will be available at `/download` instead. This PR changes the `url` property of the `learning_resource_types` taxonomy so it is rendered at `/download` instead of `/resources` and adds a markdown file at `course-v2/content/resources/_index.md` with some front matter that prevents Hugo from automatically trying to render an index page at `/resources`.

#### How should this be manually tested?
 - Clone a course from `mitocwcontent` that has some resources in it like `9.40-spring-2018`
 - Point to the course in your `.env` with:
```
COURSE_CONTENT_PATH=/path/to/mitocwcontent/
OCW_TEST_COURSE=9.40-spring-2018
```
 - If you have run this course before (especially if you've tested recent PR's) you'll want to remove the `public` directory created in the content repo by Hugo, as we'll be testing the removal of a page
 - Run the course site with `yarn start:course`
 - Visit http://localhost:3000/download and verify that you see the download page
 - Visit http://localhost:3000/resources and verify that you get a 404