### PR TITLE
Resizing download button layout for mobile

### DIFF
--- a/course-v2/assets/css/course-resources.scss
+++ b/course-v2/assets/css/course-resources.scss
@@ -2,6 +2,11 @@ h4 {
   color: $highlight-red !important;
 }
 
+.download-mobile-margin {
+  @media only screen and (max-width: 768px) {
+  margin: 5px; }
+}
+
 .download-course-container {
   border-radius: 3px;
 

--- a/course-v2/assets/css/course-resources.scss
+++ b/course-v2/assets/css/course-resources.scss
@@ -2,12 +2,6 @@ h4 {
   color: $highlight-red !important;
 }
 
-.download-mobile-margin {
-  @media only screen and (max-width: 768px) {
-    margin: 5px;
-  }
-}
-
 .download-course-container {
   border-radius: 3px;
 

--- a/course-v2/assets/css/course-resources.scss
+++ b/course-v2/assets/css/course-resources.scss
@@ -4,7 +4,8 @@ h4 {
 
 .download-mobile-margin {
   @media only screen and (max-width: 768px) {
-  margin: 5px; }
+    margin: 5px;
+  }
 }
 
 .download-course-container {

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -12,7 +12,7 @@
           <span class="material-icons">file_download</span> Download course
         </a>
       </div>
-      <div class="col-12 col-md-9 pr-3">
+      <div class="col-12 col-md-9">
         This package contains the same content as the online version of the course,
         <em>except for the audio/video materials</em>. These can be downloaded below. For help
         downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -7,12 +7,11 @@
   <h2>Download</h2>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
     <div class="row">
-      <div class="d-flex justify-content-center col-12 col-md-3 px-3">
+      <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
         <a class="download-course-button p-2" href="{{ $downloadCourseUrl }}">
           <span class="material-icons">file_download</span> Download course
         </a>
       </div>
-      <div class="download-mobile-margin"></div>
       <div class="col-12 col-md-9 pr-3">
         This package contains the same content as the online version of the course,
         <em>except for the audio/video materials</em>. These can be downloaded below. For help

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -7,14 +7,15 @@
   <h2>Download</h2>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
     <div class="row">
-      <div class="d-flex justify-content-center col-3 px-3">
+      <div class="d-flex justify-content-center col-12 col-md-3 px-3">
         <a class="download-course-button p-2" href="{{ $downloadCourseUrl }}">
           <span class="material-icons">file_download</span> Download course
         </a>
       </div>
-      <div class="col-9 pl-0 pr-3">
-        This package contains the same content as the online version of the course, 
-        <em>except for the audio/video materials</em>. These can be downloaded below. For help 
+      <div class="download-mobile-margin"></div>
+      <div class="col-12 col-md-9 pr-3">
+        This package contains the same content as the online version of the course,
+        <em>except for the audio/video materials</em>. These can be downloaded below. For help
         downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
       </div>
     </div>


### PR DESCRIPTION
#### Pre-Flight checklist
- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/943.

#### What's this PR do?
Modifies the mobile layout of the download button and related text, so that there is no overlap between the button and the text.

#### How should this be manually tested?
Start the course with `yarn start:course` and verify that the layout looks as expected in both desktop (unchanged by this PR) and mobile views. It may be necessary to first delete the `public` subfolder in the course content, to make sure that no prior layouts are cached.

#### Screenshots (if appropriate)

![mobile_download](https://user-images.githubusercontent.com/1553279/199274512-608d93a9-16a7-4749-af27-4082c59a0cdd.png)