### PR TITLE
Ab/set compact UI live

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "browserslist": "> 0.25%, not dead",
   "dependencies": {
-    "@mitodl/course-search-utils": "^2.0.1",
+    "@mitodl/course-search-utils": "^2.0.4",
     "@mitodl/ocw-to-hugo": "1.36.0",
     "@sentry/browser": "^5.19.0",
     "@testing-library/react-hooks": "^7.0.2",

--- a/www/assets/css/learning-resource-card.scss
+++ b/www/assets/css/learning-resource-card.scss
@@ -424,8 +424,11 @@
       color: $medium-gray;
       a {
         color: $medium-gray;
-        float: right;
+        @include breakpoint(desktop) {
+          float: right;
+        }
       }
+
       @include breakpoint(mobile) {
         width: 100%;
         display: block;

--- a/www/assets/css/search.scss
+++ b/www/assets/css/search.scss
@@ -264,7 +264,6 @@
 .layout-buttons {
   padding-left: 35px;
   padding-right: 16px;
-  display: none !important;
 
   button {
     height: 41px;

--- a/www/assets/js/components/SearchFilterDrawer.tsx
+++ b/www/assets/js/components/SearchFilterDrawer.tsx
@@ -5,7 +5,7 @@ import { DESKTOP } from "../lib/constants"
 import { useDeviceCategory } from "../hooks/util"
 import { Aggregation, Facets } from "@mitodl/course-search-utils"
 import { FacetManifest } from "../LearningResources"
-import { SEARCH_COMPACT_UI, SEARCH_LIST_UI } from "../lib/constants"
+import { SEARCH_COMPACT_UI } from "../lib/constants"
 import Footer from "./Footer"
 
 interface Props {
@@ -15,7 +15,7 @@ interface Props {
   onUpdateFacets: React.ChangeEventHandler<HTMLInputElement>
   clearAllFilters: () => void
   toggleFacet: (name: string, value: string, isEnabled: boolean) => void
-  updateUI: (newUI: string) => void
+  updateUI: (newUI: string | null) => void
 }
 
 export default function SearchFilterDrawer(props: Props) {
@@ -78,10 +78,7 @@ export default function SearchFilterDrawer(props: Props) {
         </div>
       </div>
       <div className="layout-buttons layout-buttons-mobile">
-        <button
-          onClick={() => updateUI(SEARCH_LIST_UI)}
-          className="layout-button-left"
-        >
+        <button onClick={() => updateUI(null)} className="layout-button-left">
           <img
             src="/images/icons/list_ui_icon.png"
             alt="search results with thumbnails"

--- a/www/assets/js/components/SearchPage.test.tsx
+++ b/www/assets/js/components/SearchPage.test.tsx
@@ -12,14 +12,14 @@ import InfiniteScroll from "react-infinite-scroller"
 
 import SearchPage from "./SearchPage"
 
-import { LIST_UI_PAGE_SIZE, COMPACT_UI_PAGE_SIZE } from "../lib/constants"
+import { DEFAULT_UI_PAGE_SIZE, COMPACT_UI_PAGE_SIZE } from "../lib/constants"
 
 import { makeCourseResult } from "../factories/search"
 import { createMemoryHistory, InitialEntry } from "history"
 import FilterableSearchFacets from "./FilterableFacet"
 
 const mockGetResults = () =>
-  times(makeCourseResult, LIST_UI_PAGE_SIZE).map(result => ({
+  times(makeCourseResult, DEFAULT_UI_PAGE_SIZE).map(result => ({
     _source: result
   }))
 
@@ -94,7 +94,7 @@ describe("SearchPage component", () => {
         {
           text:         params.text,
           from:         0,
-          size:         LIST_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: {
             ...defaultCourseFacets,
             ...params.activeFacets
@@ -122,7 +122,7 @@ describe("SearchPage component", () => {
         {
           text:         "",
           from:         0,
-          size:         LIST_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: defaultCourseFacets,
           sort:         null
         }
@@ -131,14 +131,14 @@ describe("SearchPage component", () => {
         {
           text:         "New Search Text",
           from:         0,
-          size:         LIST_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: defaultCourseFacets,
           sort:         null
         }
       ]
     ])
     wrapper.update()
-    expect(wrapper.find("SearchResult").length).toBe(LIST_UI_PAGE_SIZE)
+    expect(wrapper.find("SearchResult").length).toBe(DEFAULT_UI_PAGE_SIZE)
   })
 
   test("the user can switch to resource search", async () => {
@@ -164,7 +164,7 @@ describe("SearchPage component", () => {
         {
           text:         parameters.text,
           from:         0,
-          size:         LIST_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: { ...defaultCourseFacets, ...parameters.activeFacets },
           sort:         null
         }
@@ -173,7 +173,7 @@ describe("SearchPage component", () => {
         {
           text:         parameters.text,
           from:         0,
-          size:         LIST_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: {
             ...defaultResourceFacets,
             ...{ topics: ["Mathematics"] }
@@ -183,7 +183,7 @@ describe("SearchPage component", () => {
       ]
     ])
     wrapper.update()
-    expect(wrapper.find("SearchResult").length).toBe(LIST_UI_PAGE_SIZE)
+    expect(wrapper.find("SearchResult").length).toBe(DEFAULT_UI_PAGE_SIZE)
   })
 
   test("should show suggestions if present on the search result", async () => {
@@ -248,7 +248,7 @@ describe("SearchPage component", () => {
         .simulate("click")
     })
 
-    expect(spySearch.mock.calls[0][0].size).toEqual(LIST_UI_PAGE_SIZE)
+    expect(spySearch.mock.calls[0][0].size).toEqual(DEFAULT_UI_PAGE_SIZE)
     expect(spySearch.mock.calls[1][0].size).toEqual(COMPACT_UI_PAGE_SIZE)
   })
 
@@ -315,7 +315,7 @@ describe("SearchPage component", () => {
         {
           text:         "",
           from:         0,
-          size:         LIST_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: defaultCourseFacets,
           sort:         null
         }
@@ -323,8 +323,8 @@ describe("SearchPage component", () => {
       [
         {
           text:         "",
-          from:         LIST_UI_PAGE_SIZE,
-          size:         LIST_UI_PAGE_SIZE,
+          from:         DEFAULT_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: defaultCourseFacets,
           sort:         null
         }
@@ -332,14 +332,14 @@ describe("SearchPage component", () => {
       [
         {
           text:         "",
-          from:         2 * LIST_UI_PAGE_SIZE,
-          size:         LIST_UI_PAGE_SIZE,
+          from:         2 * DEFAULT_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: defaultCourseFacets,
           sort:         null
         }
       ]
     ])
-    expect(wrapper.find("SearchResult").length).toBe(3 * LIST_UI_PAGE_SIZE)
+    expect(wrapper.find("SearchResult").length).toBe(3 * DEFAULT_UI_PAGE_SIZE)
   })
 
   test("InfiniteScroll should only trigger one search request at a time", async () => {
@@ -364,7 +364,7 @@ describe("SearchPage component", () => {
         {
           text:         "",
           from:         0,
-          size:         LIST_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: defaultCourseFacets,
           sort:         null
         }
@@ -372,14 +372,14 @@ describe("SearchPage component", () => {
       [
         {
           text:         "",
-          from:         LIST_UI_PAGE_SIZE,
-          size:         LIST_UI_PAGE_SIZE,
+          from:         DEFAULT_UI_PAGE_SIZE,
+          size:         DEFAULT_UI_PAGE_SIZE,
           activeFacets: defaultCourseFacets,
           sort:         null
         }
       ]
     ])
-    expect(wrapper.find("SearchResult").length).toBe(2 * LIST_UI_PAGE_SIZE)
+    expect(wrapper.find("SearchResult").length).toBe(2 * DEFAULT_UI_PAGE_SIZE)
   })
 
   test("should show spinner during initial load", async () => {

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -20,8 +20,7 @@ import {
   COURSENUM_SORT_FIELD,
   CONTACT_URL,
   SEARCH_COMPACT_UI,
-  SEARCH_LIST_UI,
-  LIST_UI_PAGE_SIZE,
+  DEFAULT_UI_PAGE_SIZE,
   COMPACT_UI_PAGE_SIZE,
   OCW_PLATFORM
 } from "../lib/constants"
@@ -65,8 +64,7 @@ export default function SearchPage(props: SearchPageProps) {
         // Default is LR_TYPE_ALL, don't want that here. course or resourcefile only
         activeFacets["type"] = [LearningResourceType.Course]
       }
-      const pageSize =
-        ui === SEARCH_COMPACT_UI ? COMPACT_UI_PAGE_SIZE : LIST_UI_PAGE_SIZE
+      const pageSize = getPageSizeFromUIParam(ui)
       setRequestInFlight(true)
       const newResults = await search({
         text,
@@ -123,6 +121,14 @@ export default function SearchPage(props: SearchPageProps) {
     ]
   )
 
+  const getPageSizeFromUIParam = (ui: string | null) => {
+    if (ui === SEARCH_COMPACT_UI) {
+      return COMPACT_UI_PAGE_SIZE
+    } else {
+      return DEFAULT_UI_PAGE_SIZE
+    }
+  }
+
   const clearSearch = useCallback(() => {
     setSearchResults([])
     setCompletedInitialLoad(false)
@@ -153,7 +159,7 @@ export default function SearchPage(props: SearchPageProps) {
     // this is the 'loaded' value, which is what useCourseSearch uses
     // to determine whether to fire off a request or not.
     completedInitialLoad && !requestInFlight,
-    LIST_UI_PAGE_SIZE,
+    getPageSizeFromUIParam,
     history
   )
 
@@ -194,8 +200,7 @@ export default function SearchPage(props: SearchPageProps) {
     LearningResourceType.ResourceFile
   )
   const facetMap = isResourceSearch ? RESOURCE_FACETS : COURSE_FACETS
-  const pageSize =
-    ui === SEARCH_COMPACT_UI ? COMPACT_UI_PAGE_SIZE : LIST_UI_PAGE_SIZE
+  const pageSize = getPageSizeFromUIParam(ui)
   return (
     <div className="search-page w-100">
       <div className="container">
@@ -313,7 +318,7 @@ export default function SearchPage(props: SearchPageProps) {
                 ) : null}
                 <div className="layout-buttons layout-buttons-desktop">
                   <button
-                    onClick={() => updateUI(SEARCH_LIST_UI)}
+                    onClick={() => updateUI(null)}
                     className="layout-button-left"
                   >
                     <img

--- a/www/assets/js/lib/constants.ts
+++ b/www/assets/js/lib/constants.ts
@@ -33,9 +33,8 @@ export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"
 const ocwPlatform = "ocw"
 
 export const SEARCH_COMPACT_UI = "compact"
-export const SEARCH_LIST_UI = "list"
 
-export const LIST_UI_PAGE_SIZE = 10
+export const DEFAULT_UI_PAGE_SIZE = 10
 export const COMPACT_UI_PAGE_SIZE = 50
 
 export const platforms = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,9 +1128,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "@mitodl/course-search-utils@npm:2.0.2"
+"@mitodl/course-search-utils@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@mitodl/course-search-utils@npm:2.0.4"
   dependencies:
     bodybuilder: ^2.5.0
     history: ^4.9 || ^5.0.0
@@ -1138,7 +1138,7 @@ __metadata:
     ramda: ^0.27.1
   peerDependencies:
     react: ^16.13.1
-  checksum: 79735b608cce70bc7b8307b0239177c120b1ad952380605f3cdd4f466fcacfd2d824697f96de6efecc6aaddd0c0ae6d0dca3542ea39da71a73e9f5e25874e084
+  checksum: f3350f6d577d87a796035a00a1c91acbc148496cec0f387578ddc83d25c898b50d0861fc5c608c1eea61b889b1f1578c646251024d15ae6e295bcd2ffe4c5a48
   languageName: node
   linkType: hard
 
@@ -12608,7 +12608,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ocw-hugo-themes@workspace:."
   dependencies:
-    "@mitodl/course-search-utils": ^2.0.1
+    "@mitodl/course-search-utils": ^2.0.4
     "@mitodl/ocw-to-hugo": 1.36.0
     "@sentry/browser": ^5.19.0
     "@testing-library/react-hooks": ^7.0.2


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
<img width="1629" alt="Screen Shot 2022-11-02 at 4 23 46 PM" src="https://user-images.githubusercontent.com/1934992/199604163-11735342-70be-47c2-b8c7-ea51c7569187.png">
<img width="1620" alt="Screen Shot 2022-11-02 at 4 24 11 PM" src="https://user-images.githubusercontent.com/1934992/199604169-a8b51311-9f4a-4405-9f01-687ecdd48cc9.png">
<img width="379" alt="Screen Shot 2022-11-02 at 4 31 06 PM" src="https://user-images.githubusercontent.com/1934992/199604200-99675e50-5a14-485f-aa11-032bf79728a6.png">
<img width="377" alt="Screen Shot 2022-11-02 at 4 31 14 PM" src="https://user-images.githubusercontent.com/1934992/199604201-dec1e24c-4066-4421-a6e2-bff4c5beec56.png">

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/79

#### What's this PR do?
This pr unhides the toggle for the compact search view to enable the feature. This pr is currently up to test https://github.com/mitodl/course-search-utils/pull/45 which needs to be merged first. The test failure should be fixed by updating course-search-utils.