### PR TITLE
only show download button if zip exists

### DIFF
--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -1,5 +1,5 @@
-{{- $courseData := site.Data.course --}}
-{{- $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-" --}}
+{{- $courseData := site.Data.course -}}
+{{- $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-" -}}
 {{- $trimmedBaseUrl := strings.TrimSuffix "/" site.BaseURL -}}
 {{- $shortId := printf "%v-%v-%v" $courseData.primary_course_number (lower $courseData.term) $courseData.year -}}
 {{- $downloadCourseUrl := printf "%v/%v.zip" $trimmedBaseUrl $shortId -}}

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -1,25 +1,37 @@
-{{ $courseData := site.Data.course }}
-{{ $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-" }}
-{{ $trimmedBaseUrl := strings.TrimSuffix "/" site.BaseURL }}
-{{ $shortId := printf "%v-%v-%v" $courseData.primary_course_number (lower $courseData.term) $courseData.year }}
-{{ $downloadCourseUrl := printf "%v/%v.zip" $trimmedBaseUrl $shortId }}
-{{ $headResponse := resources.GetRemote $downloadCourseUrl }}
-{{ if $headResponse }}
+{{- $courseData := site.Data.course --}}
+{{- $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-" --}}
+{{- $trimmedBaseUrl := strings.TrimSuffix "/" site.BaseURL -}}
+{{- $shortId := printf "%v-%v-%v" $courseData.primary_course_number (lower $courseData.term) $courseData.year -}}
+{{- $downloadCourseUrl := printf "%v/%v.zip" $trimmedBaseUrl $shortId -}}
+{{- $headResponse := resources.GetRemote $downloadCourseUrl (dict "method" "head") -}}
+<!-- 
+  It may seem unintuitive to look explicitly for "unexpected EOF" here. Unfortunately while 
+  Hugo supports setting "method" "head" to perform a HEAD request, it doesn't support checking 
+  the response headers. If we just perform a normal GET here the entire ZIP file will be 
+  downloaded during the build which could vastly balloon the build time or make the build fail.
+
+  A 404 on the OCW site returns an empty body with a 404 status code, which Hugo properly 
+  interprets as nil. In this case the "unexpected EOF" means "I found a file and got a 200 
+  in the response, but the file was empty."
+  
+  The file is empty because we only made a HEAD request.
+-->
+{{- if in $headResponse "unexpected EOF" -}}
 <div class="mb-2">
   <h2>Download</h2>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
     <div class="row">
       <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
-        <a class="download-course-button p-2" href="{{ $downloadCourseUrl }}">
+        <a class="download-course-button p-2" href="{{- $downloadCourseUrl -}}">
           <span class="material-icons">file_download</span> Download course
         </a>
       </div>
       <div class="col-12 col-md-9">
         This package contains the same content as the online version of the course,
         <em>except for the audio/video materials</em>. These can be downloaded below. For help
-        downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
+        downloading and using course materials, read our {{- partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") -}}.
       </div>
     </div>
   </div>
 </div>
-{{ end }}
+{{- end -}}

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -3,6 +3,8 @@
 {{ $trimmedBaseUrl := strings.TrimSuffix "/" site.BaseURL }}
 {{ $shortId := printf "%v-%v-%v" $courseData.primary_course_number (lower $courseData.term) $courseData.year }}
 {{ $downloadCourseUrl := printf "%v/%v.zip" $trimmedBaseUrl $shortId }}
+{{ $headResponse := resources.GetRemote $downloadCourseUrl }}
+{{ if $headResponse }}
 <div class="mb-2">
   <h2>Download</h2>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
@@ -20,3 +22,4 @@
     </div>
   </div>
 </div>
+{{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/937

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/931, we added a "course download" button to the resources download page with a URL based off the work done in `ocw-studio` to create Concourse pipelines that build offline versions of each course and ZIP them up. This PR makes the visibility of that download conditional on Hugo being able to make a `HEAD` request against the ZIP URL to confirm its existence.

#### How should this be manually tested?
 - Clone any course you want from https://github.mit.edu/mitocwcontent/ and point to it in your env using `COURSE_CONTENT_PATH` and `OCW_TEST_COURSE`
 - Clone `ocw-hugo-projects` on the `cg/allow-head-zip` branch
 - In `ocw-hugo-projects/course-v2/config.yaml`, we need to temporarily set the `baseUrl` setting to http://localhost:3000/. Hugo automatically sets it to `//localhost:3000` which ironically causes `resources.GetRemote` to throw an error about the protocol not being specified.
 - Download the ZIP file for the course you're testing using the formula https://ocw.mit.edu/courses/9-40-introduction-to-neural-computation-spring-2018/9.40-spring-2018.zip, replacing the `name` and `short_id` properties with whatever course you're using, or create a dummy ZIP file with the same name matching the `short_id`
 - Place the ZIP file in the root of the `public` folder inside your course content repo
 - Run `yarn start:course`
 - Visit http://localhost:3000/download and verify that you see a download button
 - In `course-v2/layouts/partials/resources_header.html`, make a temporary edit to spoof requesting a file that doesn't exist by adding a `-2` to the filename like this: `{{- $downloadCourseUrl := printf "%v/%v-2.zip" $trimmedBaseUrl $shortId -}}`
 - Save the file to refresh the page, and the download button should disappear

#### Screenshots (if appropriate)
![chrome_2022-11-03_19-47-48](https://user-images.githubusercontent.com/12089658/199855967-740dd052-bd2e-4c29-9c5b-b21847e84bb8.png)
![chrome_2022-11-03_19-48-25](https://user-images.githubusercontent.com/12089658/199856019-8d5b3ac3-316f-4162-b92f-1087cd87247f.png)
