### PR TITLE
fix: expand/collapse arrow removed and full title shown

### DIFF
--- a/base-theme/layouts/partials/content_header_v2.html
+++ b/base-theme/layouts/partials/content_header_v2.html
@@ -4,7 +4,7 @@
       {{ with .Params.parent_title }}
       <div class="course-content-parent-title">{{ . }}</div>
       {{ end }}
-      <h2 class="font-weight-bold pb-1 mb-1">{{ .Title }}</h2>
+      <h2 class="pb-1 mb-1">{{ .Title }}</h2>
     </div>
   </div>
 </header>

--- a/base-theme/layouts/partials/content_header_v2.html
+++ b/base-theme/layouts/partials/content_header_v2.html
@@ -1,27 +1,10 @@
-{{ $shouldCollapseTitle := gt (len .Title) 120 }}
 <header>
   <div class="course-section-title-container ">
-    <div class="{{ if $shouldCollapseTitle }}collapse{{ end }}" id="course-title">
+    <div id="course-title">
       {{ with .Params.parent_title }}
       <div class="course-content-parent-title">{{ . }}</div>
       {{ end }}
       <h2 class="text-uppercase font-weight-bold pb-1 mb-1">{{ .Title }}</h2>
-    </div>
-    <div class="d-flex">
-      {{ if $shouldCollapseTitle }}
-      <div class="collapse-btn-section ml-auto pt-2 px-3">
-        <a
-          role="button"
-          class="collapsed"
-          data-toggle="collapse"
-          href="#course-title"
-          aria-expanded="false"
-          aria-controls="course-title"
-        >
-          <span class="material-icons"></span>
-        </a>
-      </div>
-      {{ end }}
     </div>
   </div>
 </header>

--- a/base-theme/layouts/partials/content_header_v2.html
+++ b/base-theme/layouts/partials/content_header_v2.html
@@ -4,7 +4,7 @@
       {{ with .Params.parent_title }}
       <div class="course-content-parent-title">{{ . }}</div>
       {{ end }}
-      <h2 class="text-uppercase font-weight-bold pb-1 mb-1">{{ .Title }}</h2>
+      <h2 class="font-weight-bold pb-1 mb-1">{{ .Title }}</h2>
     </div>
   </div>
 </header>

--- a/course-v2/layouts/partials/course_content.html
+++ b/course-v2/layouts/partials/course_content.html
@@ -1,4 +1,3 @@
-{{ $shouldCollapseTitle := gt (len .Title) 75 }}
 <div class="mb-2">
   {{ partial "content_header_v2.html" . }}
   <article class="content pt-3 mt-1">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-themes/issues/955
ref: https://github.com/mitodl/ocw-hugo-themes/issues/955#issuecomment-1301280575

#### What's this PR do?
- Removes expand/collapse arrow
- Full content title shown

#### How should this be manually tested?
- Checkout this branch or view netlify deployed version
- Go to resources/courses page which have long titles
- Verify that full title is being shown 

#### Screenshots (if appropriate)

<img width="1413" alt="image" src="https://user-images.githubusercontent.com/93309234/199974069-018edd60-2b2e-4575-8a8f-a28a67ea48bd.png">

<img width="1386" alt="image" src="https://user-images.githubusercontent.com/93309234/199974287-311463fe-d91b-4c18-8ebb-34e90330d919.png">


