### PR TITLE
rename OCW_IMPORT_STARTER_SLUG to OCW_COURSE_STARTER_SLUG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 GTM_ACCOUNT_ID=
-OCW_IMPORT_STARTER_SLUG=ocw-course
+OCW_COURSE_STARTER_SLUG=ocw-course-v2
 SEARCH_API_URL=https://discussions-rc.odl.mit.edu/api/v0/search/
 OCW_STUDIO_BASE_URL=http://ocw-studio-rc.odl.mit.edu/
 STATIC_API_BASE_URL=https://live-qa.ocw.mit.edu/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}
-          OCW_IMPORT_STARTER_SLUG: ${{ secrets.OCW_IMPORT_STARTER_SLUG }}
+          OCW_COURSE_STARTER_SLUG: ${{ secrets.OCW_COURSE_STARTER_SLUG }}
           STATIC_API_BASE_URL: ${{ secrets.STATIC_API_BASE_URL }}
           RESOURCE_BASE_URL: ${{ secrets.RESOURCE_BASE_URL }}
       
@@ -63,7 +63,7 @@ jobs:
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}
-          OCW_IMPORT_STARTER_SLUG: ${{ secrets.OCW_IMPORT_STARTER_SLUG }}
+          OCW_COURSE_STARTER_SLUG: ${{ secrets.OCW_COURSE_STARTER_SLUG }}
           STATIC_API_BASE_URL: ${{ secrets.STATIC_API_BASE_URL }}
           RESOURCE_BASE_URL: ${{ secrets.RESOURCE_BASE_URL }}
 
@@ -72,7 +72,7 @@ jobs:
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}
-          OCW_IMPORT_STARTER_SLUG: ${{ secrets.OCW_IMPORT_STARTER_SLUG }}
+          OCW_COURSE_STARTER_SLUG: ${{ secrets.OCW_COURSE_STARTER_SLUG }}
           STATIC_API_BASE_URL: ${{ secrets.STATIC_API_BASE_URL }}
           RESOURCE_BASE_URL: ${{ secrets.RESOURCE_BASE_URL }}
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ An example environment file can be found at `.env.example`.  To further explain 
 | `WWW_CONTENT_PATH` | `www` | `/path/to/ocw-content-rc/ocw-www` | A path to a Hugo site that will be rendered when running `npm run start:www` |
 | `COURSE_CONTENT_PATH` | `course` | `/path/to/ocw-content-rc/` | A path to a base folder containing `ocw-course` type Hugo sites |
 | `OCW_TEST_COURSE` | `course` | `18.06-spring-2010` | The name of a folder in `COURSE_CONTENT_PATH` containing a Hugo site that will be rendered when running `npm run start:course` |
-| `OCW_IMPORT_STARTER_SLUG` | `www` | `ocw-course` | When generating "New Courses" cards on the home page, the `ocw-studio` API is queried using `OCW_STUDIO_BASE_URL`.  This value determines the `type` used in the query string against the API |
+| `OCW_COURSE_STARTER_SLUG` | `www` | `ocw-course` | When generating "New Courses" cards on the home page, the `ocw-studio` API is queried using `OCW_STUDIO_BASE_URL`.  This value determines the `type` used in the query string against the API |
 | `COURSE_BASE_URL` | N/A | `http://localhost:3000/courses` | Used in `build_all_courses.sh`, this is the `--baseUrl` argument passed to each course build iterated by the script |
 | `FIELDS_HUGO_CONFIG_PATH` | `fields` | `/path/to/ocw-hugo-projects/mit-fields/config.yaml` | A path to the `mit-fields` Hugo configuration file |
 | `FIELDS_CONTENT_PATH` | `fields` | `/path/to/ocw-content-rc/philosophy` | A path to a Hugo site that will be rendered when running `npm run start:fields` |

--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -1,7 +1,7 @@
 {{- $staticApiBaseUrl := partial "static_api_base_url.html" -}}
 <div class="new-courses course-cards standard-width container mx-auto mt-3">
 {{ $studioBaseUrl := partial "ocw_studio_base_url.html" }}
-{{ $courseStarterSlug := getenv "OCW_IMPORT_STARTER_SLUG" }}
+{{ $courseStarterSlug := getenv "OCW_COURSE_STARTER_SLUG" }}
 {{ $typeQuery := querify "type" $courseStarterSlug }}
 {{ if and $studioBaseUrl $courseStarterSlug }}
 {{ $coursesURL := (print (strings.TrimSuffix "/" $studioBaseUrl) "/api/websites/?" $typeQuery) }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/956

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1560, we deprecated the `OCW_IMPORT_STARTER_SLUG` environment variable's use as a filtering mechanism, which will be finalized in this PR. Going forward, `OCW_COURSE_STARTER_SLUG` will be used to denote the slug of the `WebsiteStarter` object in `ocw-studio` used to create sites to be rendered with the course theme. Currently this is used when querying the `ocw-studio` API for new courses.

#### How should this be manually tested?
 - Clone `ocw-hugo-themes` on the `cg/ocw-course-starter-slug` branch
 - Point at `ocw-hugo-projects` on the branch of the same name using the `WWW_HUGO_CONFIG_PATH` and `COURSE_HUGO_CONFIG_PATH` env variables
 - Replace `OCW_IMPORT_STARTER_SLUG` with `OCW_COURSE_STARTER_SLUG` in your env and make sure it's set to `ocw-course-v2`
 - Set `OCW_STUDIO_BASE_URL=https://ocw-studio.odl.mit.edu/`
 - Set `RESOURCE_BASE_URL=https://ocw.mit.edu/` in your env
 - Set `STATIC_API_BASE_URL=https://ocw.mit.edu/` in your env
 - Spin up any course site using `yarn start:course`, ensuring the site builds and is accessible at http://localhost:3000
 - Spin up `ocw-www` with `yarn start:www`, ensuring the site builds and is accessible at http://localhost:3000 and you see new courses in the "New Courses" section.
