### PR TITLE
Fixed issue with course card links caused by delimiter.

### DIFF
--- a/base-theme/layouts/partials/course_cards_instructors.html
+++ b/base-theme/layouts/partials/course_cards_instructors.html
@@ -4,9 +4,6 @@
     {{ $title := $instructorObject.title | default "" }}
     {{ $instructorName := $instructorObject.instructor | default $title }}
     {{ $instructorSearchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" $instructorName) }}
-    {{ partial "link.html" (dict "href" $instructorSearchUrl "text" $instructorName "stripLinkOffline" true) }}
-    {{ if ne (add $index 1) $numInstructors }}
-    ,&nbsp;
-    {{ end }}
+    {{ partial "link.html" (dict "href" $instructorSearchUrl "text" $instructorName "stripLinkOffline" true "class" "link-items") }}
   {{ end }}
 {{ end }}

--- a/base-theme/layouts/partials/course_cards_level.html
+++ b/base-theme/layouts/partials/course_cards_level.html
@@ -10,10 +10,7 @@
     {{ end }}
     {{ range $index, $level := . }}
       {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $level) }}
-      {{ partial "link.html" (dict "href" $levelSearchUrl "text" $level "stripLinkOffline" true) }}
-      {{ if ne (add $index 1) $numLevels }}
-      ,&nbsp;
-      {{ end }}
+      {{ partial "link.html" (dict "href" $levelSearchUrl "text" $level "stripLinkOffline" true "class" "link-items") }}
     {{ end }}
   {{ end }}
 {{ end }}

--- a/base-theme/layouts/partials/course_cards_topics.html
+++ b/base-theme/layouts/partials/course_cards_topics.html
@@ -9,8 +9,5 @@
 {{- range $index, $rawTopic := $topics -}}
   {{- $topic := title $rawTopic -}}
   {{- $topicSearchUrl := partial "get_search_url.html" (dict "key" "topic" "value" $topic) -}}
-  {{ partial "link.html" (dict "href" $topicSearchUrl "text" $topic "stripLinkOffline" true) }}
-  {{- if ne (add $index 1) $numTopics -}}
-  ,&nbsp;
-  {{- end -}}
+  {{ partial "link.html" (dict "href" $topicSearchUrl "text" $topic "stripLinkOffline" true "class" "link-items") }}
 {{- end -}}

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -326,6 +326,13 @@ $searchbox-height: 50px;
         @include line-clamp(1.125rem, 2, 0.5rem);
       }
 
+      .link-items::after {
+        content: ",";
+      }
+      .link-items:last-child::after {
+        content: "";
+      }
+
       .card-label {
         color: $dark-gray;
       }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Part of #949 

#### What's this PR do?
- Removes delimiter "," which were added in html template.
- Added css class to add delimiter

#### How should this be manually tested?
- Run ocw-www
- Verify topics in course card have valid spacings.
- Verify instructors in course card ave valid spacings.
- Verify course levels ave valid spacing.
- Verify any other partial using link.html remains same

#### Any background context you want to provide?

As per [the discussion](https://github.com/mitodl/ocw-hugo-themes/issues/949#issuecomment-1305732892), This PR just fixes the problem in course cards which is not caused by using ` {{ }} ` but because of the delimiter.
#### Screenshots (if appropriate)
(Optional)
<img width="1365" alt="Screenshot 2022-11-10 at 12 33 26 PM" src="https://user-images.githubusercontent.com/87968618/201028006-ee6ed3a2-1e88-48de-9727-db99ce9b4255.png">
