### PR TITLE
Revert "only show download button if zip exists"

### DIFF
--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -1,37 +1,22 @@
-{{- $courseData := site.Data.course -}}
-{{- $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-" -}}
-{{- $trimmedBaseUrl := strings.TrimSuffix "/" site.BaseURL -}}
-{{- $shortId := printf "%v-%v-%v" $courseData.primary_course_number (lower $courseData.term) $courseData.year -}}
-{{- $downloadCourseUrl := printf "%v/%v.zip" $trimmedBaseUrl $shortId -}}
-{{- $headResponse := resources.GetRemote $downloadCourseUrl (dict "method" "head") -}}
-<!-- 
-  It may seem unintuitive to look explicitly for "unexpected EOF" here. Unfortunately while 
-  Hugo supports setting "method" "head" to perform a HEAD request, it doesn't support checking 
-  the response headers. If we just perform a normal GET here the entire ZIP file will be 
-  downloaded during the build which could vastly balloon the build time or make the build fail.
-
-  A 404 on the OCW site returns an empty body with a 404 status code, which Hugo properly 
-  interprets as nil. In this case the "unexpected EOF" means "I found a file and got a 200 
-  in the response, but the file was empty."
-  
-  The file is empty because we only made a HEAD request.
--->
-{{- if in $headResponse "unexpected EOF" -}}
+{{ $courseData := site.Data.course }}
+{{ $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-" }}
+{{ $trimmedBaseUrl := strings.TrimSuffix "/" site.BaseURL }}
+{{ $shortId := printf "%v-%v-%v" $courseData.primary_course_number (lower $courseData.term) $courseData.year }}
+{{ $downloadCourseUrl := printf "%v/%v.zip" $trimmedBaseUrl $shortId }}
 <div class="mb-2">
   <h2>Download</h2>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
     <div class="row">
       <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
-        <a class="download-course-button p-2" href="{{- $downloadCourseUrl -}}">
+        <a class="download-course-button p-2" href="{{ $downloadCourseUrl }}">
           <span class="material-icons">file_download</span> Download course
         </a>
       </div>
       <div class="col-12 col-md-9">
         This package contains the same content as the online version of the course,
         <em>except for the audio/video materials</em>. These can be downloaded below. For help
-        downloading and using course materials, read our {{- partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") -}}.
+        downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
       </div>
     </div>
   </div>
 </div>
-{{- end -}}


### PR DESCRIPTION
Reverts mitodl/ocw-hugo-themes#960

During testing I found that this solution doesn't quite work in our deployed environments because `baseUrl` is root-relative. `resources.GetRemote` doesn't have the context to make the request to the file, so the link will never be shown.