### PR TITLE
hide download button if zip doesn't exist v2

### DIFF
--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -23,14 +23,14 @@
   <div class="hide-offline download-course-container background-color-light-grey p-3">
     <div class="row">
       <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
-        <a class="download-course-button p-2" href="{{- $downloadCourseUrl -}}">
+        <a class="download-course-button p-2" href="{{ $downloadCourseUrl }}">
           <span class="material-icons">file_download</span> Download course
         </a>
       </div>
       <div class="col-12 col-md-9">
         This package contains the same content as the online version of the course,
         <em>except for the audio/video materials</em>. These can be downloaded below. For help
-        downloading and using course materials, read our {{- partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") -}}.
+        downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
       </div>
     </div>
   </div>

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -1,22 +1,38 @@
-{{ $courseData := site.Data.course }}
-{{ $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-" }}
-{{ $trimmedBaseUrl := strings.TrimSuffix "/" site.BaseURL }}
-{{ $shortId := printf "%v-%v-%v" $courseData.primary_course_number (lower $courseData.term) $courseData.year }}
-{{ $downloadCourseUrl := printf "%v/%v.zip" $trimmedBaseUrl $shortId }}
+{{- $courseData := site.Data.course -}}
+{{- $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-" -}}
+{{- $trimmedBaseUrl := strings.TrimPrefix "/" (strings.TrimSuffix "/" site.BaseURL) -}}
+{{- $shortId := site.Data.course.site_short_id -}}
+{{- $domain := strings.TrimSuffix "/" (getenv "STATIC_API_BASE_URL") -}}
+{{- $downloadCourseUrl := printf "%v/%v/%v.zip" $domain $trimmedBaseUrl $shortId -}}
+{{- $headResponse := resources.GetRemote $downloadCourseUrl (dict "method" "head") -}}
+<!-- 
+  It may seem unintuitive to look explicitly for "unexpected EOF" here. Unfortunately while 
+  Hugo supports setting "method" "head" to perform a HEAD request, it doesn't support checking 
+  the response headers. If we just perform a normal GET here the entire ZIP file will be 
+  downloaded during the build which could vastly balloon the build time or make the build fail.
+
+  A 404 on the OCW site returns an empty body with a 404 status code, which Hugo properly 
+  interprets as nil. In this case the "unexpected EOF" means "I found a file and got a 200 
+  in the response, but the file was empty."
+  
+  The file is empty because we only made a HEAD request.
+-->
+{{- if in $headResponse "unexpected EOF" -}}
 <div class="mb-2">
   <h2>Download</h2>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
     <div class="row">
       <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
-        <a class="download-course-button p-2" href="{{ $downloadCourseUrl }}">
+        <a class="download-course-button p-2" href="{{- $downloadCourseUrl -}}">
           <span class="material-icons">file_download</span> Download course
         </a>
       </div>
       <div class="col-12 col-md-9">
         This package contains the same content as the online version of the course,
         <em>except for the audio/video materials</em>. These can be downloaded below. For help
-        downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
+        downloading and using course materials, read our {{- partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") -}}.
       </div>
     </div>
   </div>
 </div>
+{{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/937

#### What's this PR do?
This PR revises the code in https://github.com/mitodl/ocw-hugo-themes/pull/960. Instead of manually constructing the `short_id` from info already in the course metadata, the `short_id` was explicitly added to JSON files published by `ocw-studio` (https://github.com/mitodl/ocw-studio/pull/1566) and that is being used instead. This was done because `short_id` is customizable upon site creation and the OCW team has changed their format, and may do so again in the future. This is the most foolproof way to ensure that the link to the ZIP archive of a given course is correct.

#### How should this be manually tested?
Testing this is a little bit tricky, since `hugo server` overrides any `baseUrl` setting to be prefixed with `//localhost:3000/`. We need to make a tiny edit for our test to work. Therefore, testing this particular functionality with `yarn start course` isn't going to work here. The best way to test this is by using a locally running instance of `ocw-studio`.

 - First of all, make sure you've taken care of the following prerequisites in `ocw-studio` and check the readme if you're unsure about any of them:
   - Custom Github test organization configured
   - Minio support configured
   - Concourse support configured
   - Recent database restore on your local DB
   - Set the following environment variables in your `.env`:
```
OCW_HUGO_PROJECTS_BRANCH=main
OCW_HUGO_THEMES_BRANCH=cg/download-testing
STATIC_API_BASE_URL=https://live.ocw.mit.edu
```
   - Make a small edit to `websites/views.py` at line 341 to limit the mass build to just the site we are testing (you can use any course in your database that uses `ocw-course-v2`): `sites = sites.prefetch_related("starter").order_by("name").filter(name="21l-011-the-film-experience-fall-2013")`
 - Spin up `ocw-studio` with `docker-compose up`
 - Run the following management commands, given a test course with the name `21l-011-the-film-experience-fall-2013`:
```
docker-compose exec web ./manage.py upsert_theme_assets_pipeline
docker-compose exec web ./manage.py backpopulate_pipelines --filter ocw-www
docker-compose exec web ./manage.py upsert_mass_build_pipeline --offline --starter ocw-course-v2
```
 - Browse to http://localhost:8080 and log into your local Concourse instance, finding the theme assets pipeline and triggering a build
 - After the theme assets pipeline has completed, find `ocw-www` in the `ocw-studio` UI and publish the site live
 - Change your `STATIC_API_BASE_URL` env variable to `http://10.1.0.102:8045` and run the following management commands:
```
docker-compose exec web ./manage.py backpopulate_pipelines --filter 21l-011-the-film-experience-fall-2013
docker-compose exec web ./manage.py reset_sync_states --filter 21l-011-the-film-experience-fall-2013 --skip_sync
docker-compose exec web ./manage.py sync_website_to_backend --filter 21l-011-the-film-experience-fall-2013
```
 - Find your test course in the `ocw-studio` UI at http://localhost:8043/sites and publish the site live
 - Click the publish button again once the build is finished and follow the link to the site, appending `/download` to the end to visit the download page which should be something like http://localhost:8045/courses/21l-011-the-film-experience-fall-2013/download/
 - You should not see a "download course" section on the page because we have not generated the ZIP file yet
 - Find the offline mass build pipeline that we pushed up earlier and trigger a build, which should only build the course we are testing because of our edit above
 - Trigger another build of our test site by making a small edit to a page and saving, then publishing again
 - Check the download page again and you should see the download course section