### PR TITLE
Display time on single line, don't clash with vol

### DIFF
--- a/course-v2/assets/css/videojs_player.scss
+++ b/course-v2/assets/css/videojs_player.scss
@@ -33,7 +33,7 @@ $slider-color: $pink;
   }
 
   .vjs-control {
-    width: 3.5em;
+    min-width: 3.5em
   }
 
   .vjs-volume-panel {

--- a/course-v2/assets/css/videojs_player.scss
+++ b/course-v2/assets/css/videojs_player.scss
@@ -33,7 +33,7 @@ $slider-color: $pink;
   }
 
   .vjs-control {
-    min-width: 3.5em
+    min-width: 3.5em;
   }
 
   .vjs-volume-panel {

--- a/course/assets/css/videojs_player.scss
+++ b/course/assets/css/videojs_player.scss
@@ -32,10 +32,6 @@ $slider-color: $pink;
     margin: 2.1em 0.45em;
   }
 
-  .vjs-control {
-    width: 3.5em;
-  }
-
   .vjs-volume-panel {
     min-width: 50px;
   }
@@ -74,7 +70,6 @@ $slider-color: $pink;
 
   .vjs-time-control {
     font-size: 1.4em;
-    padding-left: 0.3em;
     padding-right: 0.3em;
 
     @include media-breakpoint-down(xs) {

--- a/course/assets/css/videojs_player.scss
+++ b/course/assets/css/videojs_player.scss
@@ -32,6 +32,10 @@ $slider-color: $pink;
     margin: 2.1em 0.45em;
   }
 
+  .vjs-control {
+    min-width: 3.5em
+  }
+
   .vjs-volume-panel {
     min-width: 50px;
   }
@@ -71,7 +75,7 @@ $slider-color: $pink;
   .vjs-time-control {
     font-size: 1.4em;
     padding-right: 0.3em;
-
+    padding-left: 0.3em;
     @include media-breakpoint-down(xs) {
       display: none !important;
     }

--- a/course/assets/css/videojs_player.scss
+++ b/course/assets/css/videojs_player.scss
@@ -33,7 +33,7 @@ $slider-color: $pink;
   }
 
   .vjs-control {
-    min-width: 3.5em
+    min-width: 3.5em;
   }
 
   .vjs-volume-panel {


### PR DESCRIPTION
Removes defined width so that the timestamp will always display on a single line in the video player.  Also removes the padding specified which made the volume slider and time elapsed hit each other.

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/982

#### What's this PR do?
Ensures that the video duration is completely displayed when the time is X:XX:XX.

#### How should this be manually tested?

1. Pull this branch.
2. gh repo clone github.mit.edu/ocw-content-rc/18.s096-fall-2013.
3. Set `OCW_TEST_COURSE=18.s096-fall-2013` in your .env file for `ocw-hugo-themes`.
4. Run `yarn start course` from the root directory of `ocw-hugo-themes`.
5. Navigate to http://localhost:3000/resources/lecture-1-introduction-financial-terms-and-concepts/ and ensure that the video duration is correctly displayed.
6. Activate the volume slider and ensure it does not overlap with the video duration.

The duration is hidden when viewed on a mobile screen.

#### Screenshots

**Before:**
![Screen Shot 2022-11-17 at 7 26 30](https://user-images.githubusercontent.com/8311573/202446788-0d435e2c-cf09-4daf-83ea-e3dcf6c9cb96.png)

**After**
![Screen Shot 2022-11-17 at 7 26 24](https://user-images.githubusercontent.com/8311573/202446791-fa567999-1ff9-4f0f-9323-f0d66ad2647d.png)
