### PR TITLE
Adding High School to allowed list for filtering search results

### DIFF
--- a/www/assets/js/lib/constants.ts
+++ b/www/assets/js/lib/constants.ts
@@ -468,7 +468,7 @@ export const FACET_OPTIONS: Facets = {
   department_name: Object.values(departments).map(
     department => department.title
   ),
-  level:               ["Undergraduate", "Graduate", "Non Credit"],
+  level:               ["Undergraduate", "Graduate", "Non Credit", "High School"],
   course_feature_tags: RESOURCE_TYPES,
   resource_type:       RESOURCE_TYPES
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/994.

#### What's this PR do?
Allows for filtering search results by "High School" level.

#### How should this be manually tested?

Set `SEARCH_API_URL=https://open.mit.edu/api/v0/search/` in the `.env` file for `ocw_hugo_themes`, and start an instance of OCW Studio locally. Start a browser with CORS security disabled, and navigate to `http://localhost:3000/search/`. Verify that filtering by `High School` level works as intended.