### PR TITLE
hide text about video / audio materials if they aren't detected

### DIFF
--- a/course-v2/layouts/partials/contains_videos.html
+++ b/course-v2/layouts/partials/contains_videos.html
@@ -1,0 +1,11 @@
+{{- $containsVideos := false -}}
+{{- with (.context.GetPage (printf "/%s" .taxonomy)) -}}
+    {{- with .Pages -}}
+      {{- range . -}}
+        {{- if in .Title "Video" -}}
+          {{- $containsVideos = true -}}
+        {{- end -}}
+      {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- return $containsVideos -}}

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -2,6 +2,7 @@
 {{- $downloadCourseUrl := partial "get_course_download_url.html" . -}}
 {{- $zipExists := partial "file_exists_at_url.html" (dict "context" . "url" $downloadCourseUrl ) -}}
 {{- $noResourcesFound := partial "show_no_resources_found.html" (dict "context" . "taxonomy" "learning_resource_types") -}}
+{{- $containsVideos := partial "contains_videos.html" (dict "context" . "taxonomy" "learning_resource_types") -}}
 {{- if $zipExists -}}
 <div class="mb-2">
   <h2>Download</h2>
@@ -13,9 +14,9 @@
         </a>
       </div>
       <div class="col-12 col-md-9">
-        This package contains the same content as the online version of the course,
-        <em>except for the audio/video materials</em>. These can be downloaded below. For help
-        downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
+        This package contains the same content as the online version of the course
+        {{- if $containsVideos }}, <em>except for the audio/video materials</em>. These can be downloaded below{{ end }}. 
+        For help downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/999

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/979, we added the "download course" link button to the course home page and course info drawer. Some courses either do not have videos or do not have the videos tagged with `learning_resource_type` taxonomy tags, causing no videos to appear on the download page. The messaging next to the download button indicates that videos can be downloaded below, when on these courses that is not the case. This PR removes this messaging if no videos are detected in the course.

#### How should this be manually tested?
 - Make a temporary edit to `resources_header.html` and change `{{- $zipExists := partial "file_exists_at_url.html" (dict "context" . "url" $downloadCourseUrl ) -}}` to `{{- $zipExists := true -}}`. This is necessary because when running the dev server Hugo will be unable to locate a ZIP file and will hide the download button.
 - Spin up a course without video resources, like `10.302-fall-2004`
 - Browse to http://localhost:3000/download and verify that the text regarding the video resources has been removed
 - Spin up a different course with video resources, like `18.086-spring-2006`
 - Browse to the download page again and verify that the text is back

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/203396759-dd1a8efc-f93d-4740-bad8-5ee1858ffda4.png)
![image](https://user-images.githubusercontent.com/12089658/203401853-d9cefba6-b72a-421b-985c-9a4195c7a10b.png)
