### PR TITLE
Better isolate e2e sites from RC + add featured courses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ node_modules
 base-theme/data/webpack.json
 ocw-to-hugo.*.log
 .hugo_build.lock
+test-sites/tmp
 
 # Unit test / coverage reports
 htmlcov/

--- a/env.ts
+++ b/env.ts
@@ -160,6 +160,11 @@ const stringifyEnv = (
 dotenv.config()
 
 /**
+ * Validate `envObj` against expected environment variable schema.
+ */
+const cleanEnv = (envObj: Record<string, string | undefined>) => envalid.cleanEnv(envObj, envSchema, { reporter })
+
+/**
  * Validated environment variables, read from:
  *  1. `process.env`,
  *  2. falling back to `.env` if it exists,
@@ -171,6 +176,6 @@ dotenv.config()
  * This should only be used in NodeJS processes, not in the browser. See
  * {@link assertIsRunningInNode | more}.
  */
-const env = envalid.cleanEnv(process.env, envSchema, { reporter })
+const env = cleanEnv(process.env)
 
-export { env, envSchema, stringifyEnv }
+export { env, cleanEnv, envSchema, stringifyEnv }

--- a/env.ts
+++ b/env.ts
@@ -162,7 +162,8 @@ dotenv.config()
 /**
  * Validate `envObj` against expected environment variable schema.
  */
-const cleanEnv = (envObj: Record<string, string | undefined>) => envalid.cleanEnv(envObj, envSchema, { reporter })
+const cleanEnv = (envObj: Record<string, string | undefined>) =>
+  envalid.cleanEnv(envObj, envSchema, { reporter })
 
 /**
  * Validated environment variables, read from:

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "react-hot-loader": "^4.12.17",
     "react-infinite-scroller": "^1.2.4",
     "react-test-renderer": "^16.13.1",
+    "recursive-readdir": "^2.2.3",
     "rimraf": "^3.0.2",
     "sass": "^1.32.13",
     "sass-lint": "^1.13.1",

--- a/package_scripts/start.ts
+++ b/package_scripts/start.ts
@@ -27,7 +27,9 @@ const hugoServer = (
     renderToDisk: true,
     ...opts
   }
-  return `hugo server ${u.getOptions(allOpts)} --cacheDir="/Users/cchudzicki/dev/ocw-hugo-themes/woof"`
+  return `hugo server ${u.getOptions(
+    allOpts
+  )} --cacheDir="/Users/cchudzicki/dev/ocw-hugo-themes/woof"`
 }
 
 /**

--- a/package_scripts/start.ts
+++ b/package_scripts/start.ts
@@ -27,7 +27,7 @@ const hugoServer = (
     renderToDisk: true,
     ...opts
   }
-  return `hugo server ${u.getOptions(allOpts)}`
+  return `hugo server ${u.getOptions(allOpts)} --cacheDir="/Users/cchudzicki/dev/ocw-hugo-themes/woof"`
 }
 
 /**

--- a/package_scripts/util.ts
+++ b/package_scripts/util.ts
@@ -1,4 +1,8 @@
+import { ExecOptions } from "node:child_process"
 import * as fs from "node:fs"
+import execShCb from "exec-sh"
+
+const execSh = execShCb.promise
 
 const dirHasContent = async (dirpath: string): Promise<boolean> => {
   try {
@@ -30,13 +34,15 @@ const exists = async (filepath: string): Promise<boolean> => {
  * // => '--dog=woof --cat=meow --loud'
  * ```
  */
-const getOptions = <T extends Record<string, string | number | boolean>>(
+const getOptions = <T extends Record<string, string | number | boolean | undefined>>(
   opts: T
 ): string => {
   return Object.entries(opts)
     .map(([key, value]) => {
-      if (typeof value === "boolean" && value) {
-        return `--${key}`
+      if (typeof value === "boolean") {
+        return value ? `--${key}` : ""
+      } else if (value === undefined) {
+        return ""
       } else {
         return `--${key}=${value}`
       }
@@ -44,4 +50,24 @@ const getOptions = <T extends Record<string, string | number | boolean>>(
     .join(" ")
 }
 
-export { dirHasContent, getOptions, exists }
+type HugoOptions = {
+  baseURL?: string
+  themesDir: string
+  config: string
+  destination: string
+  verbose?: boolean,
+  environment?: "development" | "production"
+  cacheDir?: string
+}
+/**
+ * Run Hugo in a child process with the given options. See [hugo](https://gohugo.io/commands/hugo/)
+ * for more.
+ */
+const hugo = (hugoOptions: HugoOptions, execOptions: ExecOptions) => {
+  const flags = getOptions(hugoOptions)
+  console.log(flags)
+  return execSh(`yarn hugo ${flags} --verbose`, execOptions)
+}
+
+export type { HugoOptions }
+export { dirHasContent, getOptions, exists, hugo }

--- a/package_scripts/util.ts
+++ b/package_scripts/util.ts
@@ -67,7 +67,6 @@ type HugoOptions = {
  */
 const hugo = (hugoOptions: HugoOptions, execOptions: ExecOptions) => {
   const flags = getOptions(hugoOptions)
-  console.log(flags)
   return execSh(`yarn hugo ${flags} --verbose`, execOptions)
 }
 

--- a/package_scripts/util.ts
+++ b/package_scripts/util.ts
@@ -34,9 +34,11 @@ const exists = async (filepath: string): Promise<boolean> => {
  * // => '--dog=woof --cat=meow --loud'
  * ```
  */
-const getOptions = <T extends Record<string, string | number | boolean | undefined>>(
-  opts: T
-): string => {
+const getOptions = <
+  T extends Record<string, string | number | boolean | undefined>
+>(
+    opts: T
+  ): string => {
   return Object.entries(opts)
     .map(([key, value]) => {
       if (typeof value === "boolean") {
@@ -55,7 +57,7 @@ type HugoOptions = {
   themesDir: string
   config: string
   destination: string
-  verbose?: boolean,
+  verbose?: boolean
   environment?: "development" | "production"
   cacheDir?: string
 }

--- a/test-sites/__fixtures__/README.md
+++ b/test-sites/__fixtures__/README.md
@@ -22,7 +22,7 @@ then publishing will be deadlocked: the www build will fail for lack of course X
 
 Thus, it is likely that a **snapshot**[^1] of the OCW Markdown at a single point in time cannot be built in isolation by Hugo.
 
-[^1]: OCW Studio forces you to build the sites incrementally: Course A cannot be published until a WWW version has been published which includes the relevant instructors, and a course cannot be featured on WWW until it has been published.
+[^1]: OCW Studio forces you to build the sites incrementally: Course A cannot be published until a www version has been published which includes the relevant instructors, and a course cannot be featured on www until it has been published.
 
 ## Building a snapshot for e2e testing: `test-sites/__fixtures`
 

--- a/test-sites/__fixtures__/README.md
+++ b/test-sites/__fixtures__/README.md
@@ -1,0 +1,31 @@
+# Static API Mocks
+
+## Static API
+Our Hugo builds output json data files, and other builds consume these data
+files. For example:
+ - **Building ocw-www:**
+   - **produces** instructor data, e.g., https://ocw.mit.edu/instructors/a32373bc-8c78-e37a-f79e-1f15686d1a9b/index.json
+   - **consumes** course summary data (e.g., for the "Featured Courses" carousel)
+- **Building course sites:**
+  - **produces:** course summary data, e.g., https://ocw.mit.edu/courses/8-01sc-classical-mechanics-fall-2016/data.json
+  - **consumes:** instructor data (e.g., for the "Course Info" on course homepage)
+
+These data comprise our "static API". When Hugo consumes this data during the build, it does so via requests through `STATIC_API_BASE_URL`.
+
+## Circular dependencies when building a snapshot
+Because course builds depend on www data, and www builds depend on course data, it is possible (and likely) for builds to contain circular dependencies. For example, if
+ - Course A uses instructor X, and
+ - ocw-www markdown describes instructor X
+ - ocw-www features Course A as a featured course
+ - neither Course A nor ocw-www have ever been published
+then publishing will be deadlocked: the www build will fail for lack of course X, and the course X build will fail for lack of instructor data.
+
+Thus, it is likely that a **snapshot**[^1] of the OCW Markdown at a single point in time cannot be built in isolation by Hugo.
+
+[^1]: OCW Studio forces you to build the sites incrementally: Course A cannot be published until a WWW version has been published which includes the relevant instructors, and a course cannot be featured on WWW until it has been published.
+
+## Building a snapshot for e2e testing: `test-sites/__fixtures`
+
+For e2e testing we *do* want to build a snapshot of OCW markdown in isolation. But there's really only a circular dependency if the `STATIC_API_BASE_URL` is the Hugo output. So for e2e testing, we pre-construct the relevant JSON files (stored in `test-sites/__fixtures__`) and serve them for use during the Hugo builds.
+
+All JSON files in `test-sites/__fixtures__` are served during the e2e hugo builds. The API urls mirror the directory structure, except `/not/a/course/page` is redirected to the file `ocw-ci-www-test/not/a/course/path` . (I.e., www json is within its own folder, not at fixtures' root).

--- a/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
+++ b/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
@@ -1,0 +1,30 @@
+{
+  "course_title":"OCW CI Test Course",
+  "course_description":"This is a test course for use in CI pipelines. This course can be found:\n\n- On Github at  [https://github.mit.edu/ocw-content-rc/ocw-ci-test-course](https://github.mit.edu/ocw-content-rc/ocw-ci-test-course)\n- On OCW Studio at [https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course](https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course)\n\nThe content of this course is additionally checked into the `ocw-hugo-themes` repository.\n\n Recommended usage by OL Engineers:\n\n- Clone the github repository to your local.\n- When developing on `ocw-hugo-themes`, make edits in Studio as needed for the tests you want to write. Pull to local, and copy the files to `ocw-hugo-themes/test-sites/ocw-ci-test-course`.",
+  "site_uid":"06fbf309-8b5d-4219-b99e-de75fac8d476",
+  "legacy_uid":"","instructors": [{
+    "first_name":"Tester",
+    "last_name":"One",
+    "middle_initial":"",
+    "salutation":"Prof.",
+    "title":"Prof. Tester One"},{
+    "first_name":"Tester",
+    "last_name":"Two",
+    "middle_initial":"",
+    "salutation":"",
+    "title":"Dr. Tester Two"},{
+    "first_name":"Another",
+    "last_name":"Three",
+    "middle_initial":"T",
+    "salutation":"",
+    "title":"Another Tester Three"}],"department_numbers":["8","6","18"],
+  "learning_resource_types":["Activity Assignments","Exams with Solutions"],
+  "topics":[["Engineering","Computer Science","Software Design and Engineering"],["Science","Physics","Quantum Mechanics"]],
+  "primary_course_number":"123",
+  "extra_course_numbers":"456",
+  "term":"Fall",
+  "year":"2022",
+  "level":["Graduate","Undergraduate"],
+  "image_src":"https://live-qa.ocw.mit.edu/courses/123-ocw-ci-test-course-fall-2022/example_jpg.jpg",
+  "course_image_metadata":{"body":"","content_type":"resource","draft":false,"file":"/courses/123-ocw-ci-test-course-fall-2022/example_jpg.jpg","file_type":"image/jpeg","image_metadata":{"caption":"","credit":"","image-alt":""},"iscjklanguage":false,"learning_resource_types":[],"license":"https://creativecommons.org/licenses/by-nc-sa/4.0/","resourcetype":"Image","title":"example_jpg.jpg","uid":"4ff6cec7-9ef3-40e2-869a-313350053b32","video_files":{"video_captions_file":"","video_thumbnail_file":"","video_transcript_file":""},"video_metadata":{"video_speakers":"","video_tags":"","youtube_description":"","youtube_id":""}}}
+

--- a/test-sites/__fixtures__/ocw-ci-test-www/instructors/3caa0884-4fdd-4f3c-ba39-67a64c27d877/index.json
+++ b/test-sites/__fixtures__/ocw-ci-test-www/instructors/3caa0884-4fdd-4f3c-ba39-67a64c27d877/index.json
@@ -1,0 +1,10 @@
+{
+    "data":  {
+    "title":"Dr. Tester Two",
+    "first_name":"Tester",
+    "last_name":"Two",
+    "middle_initial":"",
+    "salutation":"",
+    "uid": "3caa0884-4fdd-4f3c-ba39-67a64c27d877"
+  } 
+  }

--- a/test-sites/__fixtures__/ocw-ci-test-www/instructors/588e4e64-823f-4e8e-a29e-0e695e2297ae/index.json
+++ b/test-sites/__fixtures__/ocw-ci-test-www/instructors/588e4e64-823f-4e8e-a29e-0e695e2297ae/index.json
@@ -1,0 +1,10 @@
+{
+  "data":  {
+  "title":"Prof. Tester One",
+  "first_name":"Tester",
+  "last_name":"One",
+  "middle_initial":"",
+  "salutation":"Prof.",
+  "uid": "588e4e64-823f-4e8e-a29e-0e695e2297ae"
+} 
+}

--- a/test-sites/__fixtures__/ocw-ci-test-www/instructors/d3c64374-bb1c-46bb-a1a1-827c336e4d8e/index.json
+++ b/test-sites/__fixtures__/ocw-ci-test-www/instructors/d3c64374-bb1c-46bb-a1a1-827c336e4d8e/index.json
@@ -1,0 +1,10 @@
+{
+  "data":  {
+  "title":"Another Tester Three",
+  "first_name":"Another",
+  "last_name":"Three",
+  "middle_initial":"T",
+  "salutation":"",
+  "uid": "d3c64374-bb1c-46bb-a1a1-827c336e4d8e"
+} 
+}

--- a/test-sites/ocw-ci-test-course/data/course.json
+++ b/test-sites/ocw-ci-test-course/data/course.json
@@ -20,11 +20,9 @@
   "legacy_uid": "",
   "instructors": {
     "content": [
-      "a16d0fec-adce-ec6a-10b1-d8153a7427e6",
-      "a32373bc-8c78-e37a-f79e-1f15686d1a9b",
-      "144c1f31-44a3-23a9-7819-21a612f6574f",
-      "0bb74f02-6e52-c6eb-1b90-fe7d782be397",
-      "c8b71de9-118e-b585-3e09-8cbe2bcfc6f2"
+      "588e4e64-823f-4e8e-a29e-0e695e2297ae",
+      "3caa0884-4fdd-4f3c-ba39-67a64c27d877",
+      "d3c64374-bb1c-46bb-a1a1-827c336e4d8e"
     ],
     "website": "ocw-www"
   },

--- a/test-sites/ocw-ci-test-www/content/course-lists/featured-courses-homepage.md
+++ b/test-sites/ocw-ci-test-www/content/course-lists/featured-courses-homepage.md
@@ -1,0 +1,10 @@
+---
+content_type: course-lists
+courses:
+- id: courses/ocw-ci-test-course
+  title: Blarglefraster
+description: ''
+draft: false
+title: featured-courses-homepage
+uid: 6cb0f708-5247-4d7d-b4cb-3ba6331a5862
+---

--- a/test-sites/ocw-ci-test-www/content/instructors/3caa0884-4fdd-4f3c-ba39-67a64c27d877.md
+++ b/test-sites/ocw-ci-test-www/content/instructors/3caa0884-4fdd-4f3c-ba39-67a64c27d877.md
@@ -1,0 +1,11 @@
+---
+content_type: instructor
+draft: false
+first_name: Tester
+headless: true
+last_name: Two
+middle_initial: ''
+salutation: ''
+title: Dr. Tester Two
+uid: 3caa0884-4fdd-4f3c-ba39-67a64c27d877
+---

--- a/test-sites/ocw-ci-test-www/content/instructors/588e4e64-823f-4e8e-a29e-0e695e2297ae.md
+++ b/test-sites/ocw-ci-test-www/content/instructors/588e4e64-823f-4e8e-a29e-0e695e2297ae.md
@@ -1,0 +1,11 @@
+---
+content_type: instructor
+draft: false
+first_name: Tester
+headless: true
+last_name: One
+middle_initial: ''
+salutation: Prof.
+title: Prof. Tester One
+uid: 588e4e64-823f-4e8e-a29e-0e695e2297ae
+---

--- a/test-sites/ocw-ci-test-www/content/instructors/d3c64374-bb1c-46bb-a1a1-827c336e4d8e.md
+++ b/test-sites/ocw-ci-test-www/content/instructors/d3c64374-bb1c-46bb-a1a1-827c336e4d8e.md
@@ -1,0 +1,11 @@
+---
+content_type: instructor
+draft: false
+first_name: Another
+headless: true
+last_name: Three
+middle_initial: T
+salutation: ''
+title: Another Tester Three
+uid: d3c64374-bb1c-46bb-a1a1-827c336e4d8e
+---

--- a/tests-e2e/fixtures.spec.ts
+++ b/tests-e2e/fixtures.spec.ts
@@ -10,19 +10,29 @@ import recursiveReaddir from "recursive-readdir"
 test("The fixtures are what Hugo would produce.", async () => {
   const fixtureDir = path.resolve(__dirname, "../test-sites/__fixtures__")
   const builtDir = path.resolve(__dirname, "../test-sites/tmp/dist")
-  const filepaths = await recursiveReaddir(path.resolve(__dirname, "../test-sites/__fixtures__"))
+  const filepaths = await recursiveReaddir(
+    path.resolve(__dirname, "../test-sites/__fixtures__")
+  )
   const jsonpaths = filepaths.filter(filepath => filepath.endsWith(".json"))
-  const comparisons = await Promise.all(jsonpaths.map(async filepath => {
-    const relative = path.relative(fixtureDir, filepath)
-    const fixtureText = await fs.readFile(filepath, "utf-8")
-    const builtText = await fs.readFile(path.join(builtDir, relative), "utf-8")
-    try {
-      return { fixture: JSON.parse(fixtureText), built: JSON.parse(builtText) }
-    } catch (err) {
-      console.error(`Error parsing content of file ${filepath}`)
-      throw err
-    }
-  }))
+  const comparisons = await Promise.all(
+    jsonpaths.map(async filepath => {
+      const relative = path.relative(fixtureDir, filepath)
+      const fixtureText = await fs.readFile(filepath, "utf-8")
+      const builtText = await fs.readFile(
+        path.join(builtDir, relative),
+        "utf-8"
+      )
+      try {
+        return {
+          fixture: JSON.parse(fixtureText),
+          built:   JSON.parse(builtText)
+        }
+      } catch (err) {
+        console.error(`Error parsing content of file ${filepath}`)
+        throw err
+      }
+    })
+  )
 
   comparisons.forEach(({ fixture, built }) => {
     expect(built).toEqual(fixture)

--- a/tests-e2e/fixtures.spec.ts
+++ b/tests-e2e/fixtures.spec.ts
@@ -1,0 +1,30 @@
+import * as path from "node:path"
+import { promises as fs } from "node:fs"
+import { test, expect } from "@playwright/test"
+import recursiveReaddir from "recursive-readdir"
+
+/**
+ * See [fixtures readme](test-sites/__fixtures__/README.md). We want to make sure
+ * that the fixtures are accurate
+ */
+test("The fixtures are what Hugo would produce.", async () => {
+  const fixtureDir = path.resolve(__dirname, "../test-sites/__fixtures__")
+  const builtDir = path.resolve(__dirname, "../test-sites/tmp/dist")
+  const filepaths = await recursiveReaddir(path.resolve(__dirname, "../test-sites/__fixtures__"))
+  const jsonpaths = filepaths.filter(filepath => filepath.endsWith(".json"))
+  const comparisons = await Promise.all(jsonpaths.map(async filepath => {
+    const relative = path.relative(fixtureDir, filepath)
+    const fixtureText = await fs.readFile(filepath, "utf-8")
+    const builtText = await fs.readFile(path.join(builtDir, relative), "utf-8")
+    try {
+      return { fixture: JSON.parse(fixtureText), built: JSON.parse(builtText) }
+    } catch (err) {
+      console.error(`Error parsing content of file ${filepath}`)
+      throw err
+    }
+  }))
+
+  comparisons.forEach(({ fixture, built }) => {
+    expect(built).toEqual(fixture)
+  })
+})

--- a/tests-e2e/global-setup.ts
+++ b/tests-e2e/global-setup.ts
@@ -6,12 +6,24 @@ import * as color from "ansi-colors"
 
 import { TEST_SITES, LOCAL_OCW_PORT, siteUrl, TestSiteAlias } from "./util"
 import SimpleServer, { RedirectionRule } from "./util/SimpleServer"
-import { env } from "../env"
+import { env, cleanEnv, stringifyEnv } from "../env"
 import { hugo } from "../package_scripts/util"
 
 const execSh = execShCb.promise
 
 const STATIC_API_PORT = 4321
+
+const testEnv = cleanEnv({
+  ...process.env,
+  OCW_STUDIO_BASE_URL: "http://ocw-studio-rc.odl.mit.edu",
+  SEARCH_API_URL:      "https://open.mit.edu/api/v0/search/",
+  RESOURCE_BASE_URL:   "https://live-qa.ocw.mit.edu/",
+  /**
+   * When building test sites, use local server at STATIC_API_PORT for static
+   * API requests. See test-sites/__fixtures__/README.md for more.
+   */
+  STATIC_API_BASE_URL: `http://localhost:${STATIC_API_PORT}`
+})
 
 /**
  * Resolve a path relative to package root.
@@ -37,7 +49,7 @@ const buildSite = (name: string, destInTmp: string, configPath: string) => {
       cwd: fromRoot(`./test-sites/${name}`),
       env: {
         ...process.env,
-        STATIC_API_BASE_URL: `http://localhost:${STATIC_API_PORT}`
+        ...stringifyEnv(testEnv),
       }
     }
   )

--- a/tests-e2e/global-setup.ts
+++ b/tests-e2e/global-setup.ts
@@ -49,7 +49,7 @@ const buildSite = (name: string, destInTmp: string, configPath: string) => {
       cwd: fromRoot(`./test-sites/${name}`),
       env: {
         ...process.env,
-        ...stringifyEnv(testEnv),
+        ...stringifyEnv(testEnv)
       }
     }
   )

--- a/tests-e2e/global-setup.ts
+++ b/tests-e2e/global-setup.ts
@@ -1,14 +1,17 @@
-import { ExecOptions } from "node:child_process"
-import * as http from "node:http"
 import * as path from "node:path"
 import execShCb from "exec-sh"
-import { TEST_SITES } from "./util"
 import handler from "serve-handler"
 import Table from "cli-table3"
 import * as color from "ansi-colors"
+
+import { TEST_SITES, LOCAL_OCW_PORT, siteUrl, TestSiteAlias  } from "./util"
+import SimpleServer, { RedirectionRule } from "./util/SimpleServer"
 import { env } from "../env"
+import { hugo } from "../package_scripts/util"
 
 const execSh = execShCb.promise
+
+const STATIC_API_PORT = 4321
 
 /**
  * Resolve a path relative to package root.
@@ -16,60 +19,118 @@ const execSh = execShCb.promise
 const fromRoot = (...pathFromRoot: string[]) => {
   return path.join(__dirname, "../", ...pathFromRoot)
 }
-interface HugoOptions {
-  baseURL: string
-  themesDir: string
-  config: string
-  destination: string
-}
-const hugo = (hugoOptions: HugoOptions, execOptions: ExecOptions) => {
-  const flags = Object.entries(hugoOptions)
-    .map(([key, value]) => `--${key}=${value}`)
-    .join(" ")
-  return execSh(`yarn hugo ${flags} --verbose`, execOptions)
+const fromTmp = (...pathFromTmp: string[]) => {
+  return  path.join(fromRoot("./test-sites/tmp"), ...pathFromTmp)
 }
 
-const buildSite = (name: string, configPath: string) => {
+const buildSite = (name: string, destInTmp: string, configPath: string) => {
   return hugo(
     {
       themesDir:   fromRoot("./"),
-      destination: fromRoot(`./test-sites/${name}/dist`),
-      baseURL:     `http://localhost:${env.WEBPACK_PORT}`,
-      config:      configPath
+      destination: fromTmp("dist", destInTmp),
+      cacheDir:    fromTmp("hugo_cache"),
+      config:      configPath,
+      baseURL:     destInTmp,
+      verbose:     true,
     },
     {
-      cwd: fromRoot(`./test-sites/${name}`)
+      cwd: fromRoot(`./test-sites/${name}`),
+      env: {
+        ...process.env,
+        STATIC_API_BASE_URL: `http://localhost:${STATIC_API_PORT}`
+      }
     }
   )
 }
 
-const setupTests = async () => {
-  const table = new Table({
-    head:  ["Site", "URL"],
-    style: { head: ["cyan", "bold"] }
-  })
+/**
+ * Redirect all requests /path/to/thing to /ocw-ci-test-www/path/to/thing,
+ * except requests to /courses/.
+ */
+const OCW_WWW_REDIRECT: RedirectionRule = {
+  type:      "rewrite",
+  match:     /^\/(?!(courses\/))/,
+  transform: url => `/ocw-ci-test-www${url}`,
+}
 
-  const sites = Object.values(TEST_SITES)
-  await Promise.all(sites.map(site => buildSite(site.name, site.configPath)))
-  sites.forEach(site => {
-    http
-      .createServer((request, response) => {
-        return handler(request, response, {
-          public: fromRoot(`./test-sites/${site.name}/dist`)
-        })
+const steps = {
+  /**
+   * Set up a sserver that:
+   *  - serves the contents of `test-sites/__fixtures__`
+   *  - redirects requests like /not/a/course/page to /ocw-ci-test-www/not/a/course/page
+   */
+  setupStaticApiFixtures: (): void => {
+    const server = new SimpleServer((request, response) => {
+      return handler(request, response, {
+        public: fromRoot(`./test-sites/__fixtures__`),
       })
-      .listen(site.port)
-    table.push([site.name, `http://localhost:${site.port}`])
-  })
+    }, {
+      rules: [OCW_WWW_REDIRECT]
+    })
+    server.listen(STATIC_API_PORT)
+  },
+  /**
+   * Build all sites with Hugo.
+   *
+   * The output will go in `test-sites/tmp/dist`.
+   */
+  buildAllSites: async (): Promise<void> => {
+    await Promise.all(Object.entries(TEST_SITES).map(([alias, site]) => {
+      const destInTmp = alias === "www" ? `/${site.name}` : `/courses/${site.name}`
+      return buildSite(site.name, destInTmp, site.configPath)
+    }))
+  },
+  /**
+   * Set up a server that:
+   *  - serves the contents of `test-sites/tmp/dist`
+   *  - redirects requests like /not/a/course/page to /ocw-ci-test-www/not/a/course/page
+   */
+  serveSites:  (): void => {
+    const server = new SimpleServer((request, response) => {
+      return handler(request, response, {
+        public: fromTmp("dist"),
+      })
+    }, {
+      rules: [
+        {
+          type:      "redirect",
+          match:     /^\/static\//,
+          transform: url => `http://localhost:${env.WEBPACK_PORT}${url}`,
+        },
+        OCW_WWW_REDIRECT
+      ]
+    })
+    server.listen(LOCAL_OCW_PORT)
+  },
+  /**
+   * Pretty-print a table to the terminal with the URLs of all the sites.
+   */
+  announceSites: (): void => {
+    const table = new Table({
+      head:  ["Site", "URL"],
+      style: { head: ["cyan", "bold"] }
+    })
+    Object.entries(TEST_SITES).forEach(([alias, site]) => {
+      table.push([site.name, siteUrl(alias as TestSiteAlias)])
+    })
+    console.log(
+      [
+        "\n",
+        color.bold("Now serving the following sites:\n"),
+        table.toString(),
+        "\n"
+      ].join("")
+    )
+  }
+}
 
-  console.log(
-    [
-      "\n",
-      color.bold("Now serving the following sites:\n"),
-      table.toString(),
-      "\n"
-    ].join("")
-  )
+const setupTests = async () => {
+  await execSh("rm -rf test-sites/tmp", { cwd: fromRoot("./") })
+
+  steps.setupStaticApiFixtures()
+  await steps.buildAllSites()
+  steps.serveSites()
+  steps.announceSites()
 }
 
 export default setupTests

--- a/tests-e2e/ocw-ci-test-course/homepage.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/homepage.spec.ts
@@ -13,18 +13,14 @@ test.describe("Course info", () => {
       label:    "Instructors",
       expected: {
         texts: [
-          "Prof. Deepto Chakrabarty",
-          "Dr. Peter Dourmashkin",
-          "Dr. Michelle Tomasik",
-          "Prof. Anna Frebel",
-          "Prof. Vladan Vuletic"
+          "Prof. Tester One",
+          "Dr. Tester Two",
+          "Another Tester Three",
         ],
         searchParams: [
-          "?q=Prof.+Deepto+Chakrabarty",
-          "?q=Dr.+Peter+Dourmashkin",
-          "?q=Dr.+Michelle+Tomasik",
-          "?q=Prof.+Anna+Frebel",
-          "?q=Prof.+Vladan+Vuletic"
+          "?q=Prof.+Tester+One",
+          "?q=Dr.+Tester+Two",
+          "?q=Another+Tester+Three"
         ]
       }
     },

--- a/tests-e2e/ocw-ci-test-course/homepage.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/homepage.spec.ts
@@ -12,11 +12,7 @@ test.describe("Course info", () => {
     {
       label:    "Instructors",
       expected: {
-        texts: [
-          "Prof. Tester One",
-          "Dr. Tester Two",
-          "Another Tester Three",
-        ],
+        texts:        ["Prof. Tester One", "Dr. Tester Two", "Another Tester Three"],
         searchParams: [
           "?q=Prof.+Tester+One",
           "?q=Dr.+Tester+Two",

--- a/tests-e2e/ocw-ci-test-course/shortcodes.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/shortcodes.spec.ts
@@ -22,9 +22,6 @@ test("Resource links include link to correct page", async ({ page }) => {
   const resourceLink = page.getByRole("link", {
     name: "Resource link to First Test Page"
   })
-  const url = new URL(
-    (await resourceLink.getAttribute("href")) ??
-      "invalid url, should never get here"
-  )
-  expect(url.pathname).toBe("/pages/first-test-page-title/")
+  const href = await resourceLink.getAttribute("href")
+  expect(href).toBe("/courses/ocw-ci-test-course/pages/first-test-page-title/")
 })

--- a/tests-e2e/ocw-ci-test-www/featured_courses.spec.ts
+++ b/tests-e2e/ocw-ci-test-www/featured_courses.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test"
+import { WwwPage } from "../util"
+
+test("Course Card lists Instructors", async ({ page }) => {
+  const www = new WwwPage(page)
+  await www.goto()
+  const card = www.getCourseCard("OCW CI Test Course")
+  await expect(card).toContainText("Instructors(s): Prof. Tester One, Dr. Tester Two, Another Tester Three")
+})

--- a/tests-e2e/ocw-ci-test-www/featured_courses.spec.ts
+++ b/tests-e2e/ocw-ci-test-www/featured_courses.spec.ts
@@ -5,5 +5,7 @@ test("Course Card lists Instructors", async ({ page }) => {
   const www = new WwwPage(page)
   await www.goto()
   const card = www.getCourseCard("OCW CI Test Course")
-  await expect(card).toContainText("Instructors(s): Prof. Tester One, Dr. Tester Two, Another Tester Three")
+  await expect(card).toContainText(
+    "Instructors(s): Prof. Tester One, Dr. Tester Two, Another Tester Three"
+  )
 })

--- a/tests-e2e/util/SimpleServer.ts
+++ b/tests-e2e/util/SimpleServer.ts
@@ -1,0 +1,95 @@
+import * as http from "http"
+
+type RedirectionRule = {
+  type: "rewrite"
+  match: RegExp,
+  /**
+   * Transform the url WITHOUT the origin.
+   */
+  transform: (url: string) => string
+} | {
+  type: "redirect"
+  match: RegExp,
+  /**
+   * Transform the url; must include origin.
+   */
+  transform: (url: string) => string
+}
+
+type Config = {
+  rules: RedirectionRule[],
+  verbose: boolean
+}
+
+const defaultConfig = {
+  rules:   [],
+  verbose: false
+}
+
+/**
+ * A simple HTTP server that can be configured to redirect/rewrite requests to
+ * other URLs.
+ *
+ * For example,
+ *  - redirect /static requests to Webpack dev server
+ *  - rewrite /not/a/course/page to /ocw-ci-test-www/not/a/course/page
+ *
+ * Rewrites do not create a new request; they modify `request.url` being handled.
+ *
+ * Elsewhere in our e2e tests, we use [serve-handler](https://github.com/vercel/serve-handler)
+ * which supports "rewrites" and redirections. However, the rewrites must be
+ * listed very verbosely. It is a real pain to rewrite ALL /static/ requests to
+ * Webpack, or ALL /not/a/course/page requests to /ocw-ci-test-www/not/a/course/page.
+ * Hence this thing.
+ */
+class SimpleServer {
+  private handleNotRedirected: http.RequestListener
+  private server: http.Server
+
+  private config: Config
+
+  constructor(handler: http.RequestListener, config: Partial<Config> = {}) {
+    this.config = { ...defaultConfig, ...config }
+    this.handleNotRedirected = handler
+    this.server = http.createServer(this.handler)
+  }
+
+  private handler: http.RequestListener = (request, response) => {
+    const { rules = [] } = this.config
+    const rule = rules.find(rule => rule.match.test(request.url ?? ""))
+    if (rule) {
+      const transformed = rule.transform(request.url ?? "")
+
+      if (rule.type === "redirect" && rules.filter(r => r.type === "redirect").some(rule => rule.match.test(transformed))) {
+        // We don't need this, so let's prevent potential confusion
+        throw new Error(`${request.url} would be redirected multiple times.`)
+      }
+
+      if (this.config.verbose) {
+        const verbing = rule.type === "redirect" ? "Redirecting" : "Rewriting"
+        console.log(`${verbing} ${request.method} ${request.url} to:`)
+        console.log(`  ${transformed}`)
+      }
+
+      if (rule.type === "rewrite") {
+        request.url = transformed
+      } else {
+        response.writeHead(302, { Location: transformed })
+        response.end()
+        return
+      }
+    }
+    this.handleNotRedirected(request, response)
+  }
+
+  listen(port: number) {
+    this.server.listen(port)
+  }
+
+  close() {
+    this.server.close()
+  }
+}
+
+export default SimpleServer
+export type { RedirectionRule }

--- a/tests-e2e/util/SimpleServer.ts
+++ b/tests-e2e/util/SimpleServer.ts
@@ -1,23 +1,25 @@
 import * as http from "http"
 
-type RedirectionRule = {
-  type: "rewrite"
-  match: RegExp,
-  /**
-   * Transform the url WITHOUT the origin.
-   */
-  transform: (url: string) => string
-} | {
-  type: "redirect"
-  match: RegExp,
-  /**
-   * Transform the url; must include origin.
-   */
-  transform: (url: string) => string
-}
+type RedirectionRule =
+  | {
+      type: "rewrite"
+      match: RegExp
+      /**
+       * Transform the url WITHOUT the origin.
+       */
+      transform: (url: string) => string
+    }
+  | {
+      type: "redirect"
+      match: RegExp
+      /**
+       * Transform the url; must include origin.
+       */
+      transform: (url: string) => string
+    }
 
 type Config = {
-  rules: RedirectionRule[],
+  rules: RedirectionRule[]
   verbose: boolean
 }
 
@@ -60,7 +62,12 @@ class SimpleServer {
     if (rule) {
       const transformed = rule.transform(request.url ?? "")
 
-      if (rule.type === "redirect" && rules.filter(r => r.type === "redirect").some(rule => rule.match.test(transformed))) {
+      if (
+        rule.type === "redirect" &&
+        rules
+          .filter(r => r.type === "redirect")
+          .some(rule => rule.match.test(transformed))
+      ) {
         // We don't need this, so let's prevent potential confusion
         throw new Error(`${request.url} would be redirected multiple times.`)
       }

--- a/tests-e2e/util/WwwPage.ts
+++ b/tests-e2e/util/WwwPage.ts
@@ -1,0 +1,52 @@
+import { Page, Response, Locator } from "@playwright/test"
+import { siteUrl } from "./test_sites"
+import { TestSiteAlias } from "./test_sites"
+import { closest, xPath } from "./locators"
+
+/**
+ * A [Page Object Model](https://playwright.dev/docs/pom) for www sites.
+ *
+ * Any page manipulation that
+ *  - is specific to www
+ *  - can be encapsulated and understood in isolation
+ * is a good candidate for addition to this class.
+ */
+class WwwPage {
+  readonly page: Page
+  readonly siteAlias: TestSiteAlias
+
+  constructor(page: Page, site: TestSiteAlias = "www") {
+    this.page = page
+    this.siteAlias = site
+  }
+
+  async goto(route = ""): Promise<Response | null> {
+    const fullRoute = siteUrl(this.siteAlias, route)
+    return this.page.goto(fullRoute)
+  }
+
+  /**
+   * Return a Locator for a Course Card by its title.
+   *
+   * Passing `{ expectedCount: 0 }` amounts to asserting that the CourseInfo
+   * section is not visible.
+   */
+  getCourseCard(title: string, { expectedCount = 1 } = {}): Locator {
+    const cardXPath = `div[${xPath.predicates.hasClass("course-card")}]`
+    const courseInfo = this.page
+      .getByRole("link", { name: title })
+      .locator(`${closest(cardXPath)} >> visible=true`)
+
+    courseInfo.count().then(count => {
+      if (count !== expectedCount) {
+        throw new Error(
+          `Expected ${expectedCount} Course Cards, got ${count}`
+        )
+      }
+    })
+
+    return courseInfo
+  }
+}
+
+export default WwwPage

--- a/tests-e2e/util/WwwPage.ts
+++ b/tests-e2e/util/WwwPage.ts
@@ -39,9 +39,7 @@ class WwwPage {
 
     courseInfo.count().then(count => {
       if (count !== expectedCount) {
-        throw new Error(
-          `Expected ${expectedCount} Course Cards, got ${count}`
-        )
+        throw new Error(`Expected ${expectedCount} Course Cards, got ${count}`)
       }
     })
 

--- a/tests-e2e/util/index.ts
+++ b/tests-e2e/util/index.ts
@@ -1,3 +1,4 @@
 export { default as CoursePage } from "./CoursePage"
+export { default as WwwPage } from "./WwwPage"
 export * from "./test_sites"
 export * from "./locators"

--- a/tests-e2e/util/locators.ts
+++ b/tests-e2e/util/locators.ts
@@ -73,4 +73,12 @@ const closest = (xpath: string) => {
   return `xpath=./ancestor-or-self::${xpath}[position() = 1]`
 }
 
-export { getFirstAfter, closest }
+const xPath = {
+  predicates: {
+    hasClass:  (className: string) => {
+      return `contains(concat(' ', normalize-space(@class), ' '), ' ${className} ')`
+    }
+  }
+}
+
+export { getFirstAfter, closest, xPath }

--- a/tests-e2e/util/locators.ts
+++ b/tests-e2e/util/locators.ts
@@ -75,7 +75,7 @@ const closest = (xpath: string) => {
 
 const xPath = {
   predicates: {
-    hasClass:  (className: string) => {
+    hasClass: (className: string) => {
       return `contains(concat(' ', normalize-space(@class), ' '), ' ${className} ')`
     }
   }

--- a/tests-e2e/util/test_sites.ts
+++ b/tests-e2e/util/test_sites.ts
@@ -1,32 +1,32 @@
-import * as path from "node:path"
 import { env } from "../../env"
+
+const LOCAL_OCW_PORT = 3010
 
 type TestSiteAlias = "course" | "www"
 type TestSite = {
   name: string
-  port: number
   configPath: string
 }
 const TEST_SITES: Record<TestSiteAlias, TestSite> = {
   course: {
     name:       "ocw-ci-test-course",
-    port:       3010,
     configPath: env.COURSE_HUGO_CONFIG_PATH
   },
   www: {
     name:       "ocw-ci-test-www",
-    port:       3011,
     configPath: env.WWW_HUGO_CONFIG_PATH
   }
 }
 
 /**
- * Return the path to an e2e test site.
+ * Return the path to an e2e test site path.
  */
-const siteUrl = (siteName: TestSiteAlias, ...paths: string[]) => {
-  const testSite = TEST_SITES[siteName]
-  const baseURL = `http://localhost:${testSite.port}`
-  return path.join(baseURL, ...paths)
+const siteUrl = (siteAlias: TestSiteAlias, ...paths: string[]) => {
+  const site = TEST_SITES[siteAlias]
+
+  const relDest = siteAlias === "www" ? "" : `courses/${site.name}`
+  const pathname = [relDest, ...paths].join("/")
+  return `http://localhost:${LOCAL_OCW_PORT}/${pathname}`
 }
 
-export { TEST_SITES, siteUrl, TestSiteAlias }
+export { TEST_SITES, LOCAL_OCW_PORT, siteUrl, TestSiteAlias }

--- a/tests-e2e/util/test_sites.ts
+++ b/tests-e2e/util/test_sites.ts
@@ -19,13 +19,23 @@ const TEST_SITES: Record<TestSiteAlias, TestSite> = {
 }
 
 /**
- * Return the path to an e2e test site path.
+ * Returns the URL for a site page.
+ * @param siteAlias Alias of the site
+ * @param relPath Path to the page relative to site root. Can be given as a string or an array of strings.
+ * @returns URL for the page.
+ *
+ * @example
+ * ```ts
+ * siteUrl("www", "about") // "http://localhost:3010/about"
+ * siteUrl("course", "pages/some/page") // "http://localhost:3010/courses/ocw-ci-test-course/pages/some/page"
+ * siteUrl("course", ["pages", "some", "page"]) // "http://localhost:3010/courses/ocw-ci-test-course/pages/some/page"
+ * ```
  */
-const siteUrl = (siteAlias: TestSiteAlias, ...paths: string[]) => {
+const siteUrl = (siteAlias: TestSiteAlias, ...relPath: string[]) => {
   const site = TEST_SITES[siteAlias]
 
   const relDest = siteAlias === "www" ? "" : `courses/${site.name}`
-  const pathname = [relDest, ...paths].join("/")
+  const pathname = [relDest, ...relPath].join("/")
   return `http://localhost:${LOCAL_OCW_PORT}/${pathname}`
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13168,6 +13168,7 @@ __metadata:
     react-hot-loader: ^4.12.17
     react-infinite-scroller: ^1.2.4
     react-test-renderer: ^16.13.1
+    recursive-readdir: ^2.2.3
     rimraf: ^3.0.2
     sass: ^1.32.13
     sass-lint: ^1.13.1
@@ -15547,6 +15548,15 @@ __metadata:
   dependencies:
     resolve: ^1.9.0
   checksum: 2a04aab4e28c05fcd6ee6768446bc8b859d8f108e71fc7f5bcbc5ef25e53330ce2c11d10f82a24591a2df4c49c4f61feabe1fd11f844c66feedd4cd7bb61146a
+  languageName: node
+  linkType: hard
+
+"recursive-readdir@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "recursive-readdir@npm:2.2.3"
+  dependencies:
+    minimatch: ^3.0.5
+  checksum: 88ec96e276237290607edc0872b4f9842837b95cfde0cdbb1e00ba9623dfdf3514d44cdd14496ab60a0c2dd180a6ef8a3f1c34599e6cf2273afac9b72a6fb2b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#980 

#### What's this PR do?
Previously the e2e tests were pulling in a fair amount of data from RC (e.g., featured courses, instructors, images, new courses). Now we set `STATIC_API_BASE_URL` to a local value, so the e2e test sites are built more in isolation.

Some data is still being pulled from RC (e.g., "New Courses" and images). The infrastructure in this PR should also be helpful for dealing with that. _Although, using RC images may be desirable._

I also changed a bit how the `global-setup.ts` file serves the sites. Previously each site was served by a separate http server. Now all sites are served by one server, so behaves much more like rc/prod.

#### How should this be manually tested?
`yarn test:e2e` should pass locally and on its github action.

#### Where should the reviewer start?
Start with [test-sites/__fixtures__/README.md](https://github.com/mitodl/ocw-hugo-themes/blob/a92d46f0b077aefd3b87a6052ec418159a512041/test-sites/__fixtures__/README.md), which explains a thorny issue the PR tackles.
