### PR TITLE
fix: removing absolute cache directory path

### DIFF
--- a/package_scripts/start.ts
+++ b/package_scripts/start.ts
@@ -27,9 +27,7 @@ const hugoServer = (
     renderToDisk: true,
     ...opts
   }
-  return `hugo server ${u.getOptions(
-    allOpts
-  )}`
+  return `hugo server ${u.getOptions(allOpts)}`
 }
 
 /**

--- a/package_scripts/start.ts
+++ b/package_scripts/start.ts
@@ -29,7 +29,7 @@ const hugoServer = (
   }
   return `hugo server ${u.getOptions(
     allOpts
-  )} --cacheDir="/Users/cchudzicki/dev/ocw-hugo-themes/woof"`
+  )}`
 }
 
 /**


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
- Removes absolute cache directory path since Hugo already defaults it to `$TMPDIR/hugo_cache/` 

#### How should this be manually tested?
- Go to main branch
- Build www (yarn start www)
- See that the build fails since this path is hardcoded and absolute
- Checkout this branch
- Build www 
- Verify that the build is successful

#### Screenshots
<img width="684" alt="image" src="https://user-images.githubusercontent.com/93309234/206159500-0a93d54d-ce1c-4cc7-bbb3-2bab239b02eb.png">
