### PR TITLE
style: titles style updated

### DIFF
--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -99,6 +99,15 @@ h4 {
   }
 }
 
+h5 {
+  font-size: $heading-five-font-lg;
+  color: $black;
+
+  @include media-breakpoint-down(xs) {
+    font-size: $heading-five-font-xs;
+  }
+}
+
 .standard-width {
   max-width: $max-home-width;
 }

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -72,18 +72,24 @@ $font-md: 1.125rem; /* 18px */
 $font-normal: 1rem; /* 16px */
 $font-sm: 0.875rem; /* 14px */
 $font-xs: 0.75rem; /* 12px */
+
+// calculated pixel values for headings below are for courses theme
+// to calculate them for www theme, multiply rem value with 16px
 // h1
-$heading-one-font-lg: 2.25rem; /* 36px */
-$heading-one-font-xs: 2rem; /* 32px */
+$heading-one-font-lg: 2.28rem; /* 32px */
+$heading-one-font-xs: 1.71rem; /* 24px */
 // h2
-$heading-two-font-lg: 1.75rem; /* 28px */
-$heading-two-font-xs: 1.5rem; /* 24px */
+$heading-two-font-lg: 1.6rem; /* 22.4px */
+$heading-two-font-xs: 1.43rem; /* 20px */
 // h3
-$heading-three-font-lg: 1.5rem; /* 24px */
-$heading-three-font-xs: 1.25rem; /* 20px */
+$heading-three-font-lg: 1.14rem; /* 16px */
+$heading-three-font-xs: 1.14rem; /* 16px */
 // h4
-$heading-four-font-lg: 1.25rem; /* 20px */
-$heading-four-font-xs: 1rem; /* 16px */
+$heading-four-font-lg: 1rem; /* 14px */
+$heading-four-font-xs: 1rem; /* 14px */
+// h5
+$heading-five-font-lg: 0.86rem; /* 12px */
+$heading-five-font-xs: 0.86rem; /* 12px */
 // material icon
 $material-icon-font-normal: 1.5rem; /* Preferred icon size = 24px */
 $material-icon-font-lg: 1.75rem; /* 28px */

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -130,69 +130,6 @@ pre {
   margin-bottom: 10px;
 }
 
-// not using font variables here as we need different font sizes on course pages
-// these font sizes are yet to be confirmed
-h1 {
-  font-size: 2.286rem !important; // 32px
-  color: $black;
-
-  @include media-breakpoint-down(xs) {
-    font-size: 1.715rem !important; // 24px
-  }
-}
-
-h2 {
-  font-size: 1.715rem !important; // 24px
-  color: $black !important;
-
-  @include media-breakpoint-down(xs) {
-    font-size: 1.429rem !important; // 16px
-  }
-
-  &.branded {
-    font-family: Helvetica, sans-serif;
-    font-weight: 300;
-
-    span {
-      color: $orange;
-      font-weight: 600;
-    }
-  }
-}
-
-h3 {
-  font-size: 1.143rem !important; // 16px
-  color: $black;
-}
-
-a + h3 {
-  margin-top: 1rem;
-}
-
-@include media-breakpoint-down(xs) {
-  h3 {
-    font-size: 1.143rem !important; // 16px
-  }
-}
-
-h4 {
-  font-size: 1rem !important; // 14px
-  color: $black;
-
-  @include media-breakpoint-down(xs) {
-    font-size: 1rem !important; // 12px
-  }
-}
-
-h5 {
-  font-size: 0.858rem !important; // 14px
-  color: $black;
-
-  @include media-breakpoint-down(xs) {
-    font-size: 0.858rem !important; // 12px
-  }
-}
-
 // TODO: overriding some css of header and footer in this new theme
 // when we roll out this theme completely then we can move this css to thier respective files in base-theme
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/991

#### What's this PR do?
- Updates titles/headings font-sizes according to the updated [style guide](https://projects.invisionapp.com/d/main?origin=v7#/console/21537330/468374061/preview?scrollOffset=63.5)
- Note: rem values in this PR and style guide are different, because: in style guide, it's assumed that the root font size is 16px so rem values are calculated accordingly, but in actuality, the root font size for course theme is 14px and for www theme is 16px (px values should be the same)

#### How should this be manually tested?
- Checkout this branch
- Build any course or view the netlify deployed version
- Visit several pages where and verify that all headings are according to the style guide.
