### PR TITLE
fix: array-flat-polyfill added

### DIFF
--- a/base-theme/assets/index.ts
+++ b/base-theme/assets/index.ts
@@ -14,6 +14,7 @@ import "./js/utils"
 import * as Sentry from "@sentry/browser"
 import { initSentry } from "./js/sentry"
 import PDFObject from "pdfobject"
+import "./js/polyfill"
 
 export interface OCWWindow extends Window {
   $: JQueryStatic

--- a/base-theme/assets/js/polyfill.ts
+++ b/base-theme/assets/js/polyfill.ts
@@ -1,0 +1,1 @@
+import "array-flat-polyfill"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@typescript-eslint/eslint-plugin": "^5.40.1",
     "ansi-colors": "^4.1.3",
     "archiver": "^5.0.0",
+    "array-flat-polyfill": "^1.0.1",
     "assets-webpack-plugin": "^7.1.1",
     "babel-loader": "^8.2.5",
     "bodybuilder": "^2.2.21",

--- a/www/assets/js/lib/search.ts
+++ b/www/assets/js/lib/search.ts
@@ -17,6 +17,7 @@ import {
   LearningResourceResult,
   ResourceJSON
 } from "../LearningResources"
+import "array-flat-polyfill"
 
 const formatCourseJSONTopics = (courseJSON: CourseJSON) =>
   courseJSON.topics ?

--- a/www/assets/js/lib/search.ts
+++ b/www/assets/js/lib/search.ts
@@ -17,7 +17,6 @@ import {
   LearningResourceResult,
   ResourceJSON
 } from "../LearningResources"
-import "array-flat-polyfill"
 
 const formatCourseJSONTopics = (courseJSON: CourseJSON) =>
   courseJSON.topics ?

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,6 +3539,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-flat-polyfill@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "array-flat-polyfill@npm:1.0.1"
+  checksum: 5d578b191a7f145a1351a4962df9a14d905060c7dfcd8f85062954b7a44b2bff1c9d2bff2d56b07756de774d5e9e4feafe4572f5641b1e9c8a968aca5cbe4902
+  languageName: node
+  linkType: hard
+
 "array-flatten@npm:1.1.1":
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1"
@@ -13095,6 +13102,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.40.1
     ansi-colors: ^4.1.3
     archiver: ^5.0.0
+    array-flat-polyfill: ^1.0.1
     assets-webpack-plugin: ^7.1.1
     babel-loader: ^8.2.5
     bodybuilder: ^2.2.21


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
might or might not close https://github.com/mitodl/ocw-hugo-themes/issues/901

#### What's this PR do?
- Uses `array-flat-polyfill` for `flat()`

#### How should this be manually tested?
- I'm having a hard time testing this change since we need to reproduce and test this locally on older browser [versions](https://caniuse.com/array-flat) that do not support flat and then verify that this change fixes that