### PR TITLE
fail build on get_instructor errors

### DIFF
--- a/course-v2/layouts/partials/get_instructors.html
+++ b/course-v2/layouts/partials/get_instructors.html
@@ -4,8 +4,7 @@
   {{ $url := (print (strings.TrimSuffix "/" $staticApiBaseUrl) "/instructors/" . "/index.json") }}
   {{ with resources.GetRemote $url }}
     {{ with .Err }}
-      {{ $errorMessage := printf "Something went wrong while fetching instructors on %v via %v with error: %v" site.BaseURL $url .Err }}
-      {{ partial "sentry_capture_message.html" $errorMessage }}
+      {{ errorf "Something went wrong while fetching instructors on %v via %v with error: %v" site.BaseURL $url . }}
     {{ else }}
       {{ $data := (. | unmarshal).data }}
       {{ $searchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" (title $data.title)) }}
@@ -13,8 +12,7 @@
       {{ $instructors = $instructors | append $instructor }}
     {{ end }}
   {{ else }}
-    {{ $errorMessage := printf "Failed to fetch course instructors through %v on %v" $url site.BaseURL }}
-    {{ partial "sentry_capture_message.html" $errorMessage }}
+    {{ errorf "Failed to fetch course instructors through %v on %v" $url site.BaseURL }}
   {{ end }}
 {{ end }}
 {{ return $instructors }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested *We could test this behavior. Opening PR first for some discussion.*
  - [x] Changes have been manually tested

#### What are the relevant tickets?
*I should make a ticket, but toward discussion https://github.com/mitodl/hq/discussions/366*

#### What's this PR do?
This PR changes / fixes how we handle errors that occur during `get_instructors.html` getRemote call. See comments for details.

#### How should this be manually tested?
On this branch:
1. `yarn start course`. The course should build successfully.
2. **Simulate an error other than 'not found':** (not an error in response) Edit https://github.com/mitodl/ocw-hugo-themes/blob/ccacdd1d4d6969b490481fc2277f58b8d6a0dfbb/course-v2/layouts/partials/get_instructors.html#L5  Change $url to "meow" or some other invalid url. Your course should now fail to build, and you should get a meaningful error. (You might get one per instructor.) *Alternatively, cause an http error any other way you can think of.*
3. Revert the change from step (2).
4. **Now simulate a 'not found' response:** For example, in your local copy of the course repository you can edit `course.json` and change one of the instructor UUIDs to something bogus. 
