### PR TITLE
make failing e2e tests fail on ci

### DIFF
--- a/package_scripts/with-env.test.ts
+++ b/package_scripts/with-env.test.ts
@@ -1,0 +1,16 @@
+import execShCb from "exec-sh"
+
+describe("with-env", () => {
+  it("Exits successfully if subcommand exits with 0", async () => {
+    const command = `yarn with-env --dev -- exit 0`
+    await execShCb.promise(command)
+  })
+
+  it("Exits with error if subcommand exits with 1", async () => {
+    const command = `yarn with-env --dev -- exit 1`
+    expect.assertions(1)
+    await expect(execShCb.promise(command)).rejects.toThrow(
+      "Shell command exit with non zero code: 1"
+    )
+  })
+})

--- a/package_scripts/with-env.ts
+++ b/package_scripts/with-env.ts
@@ -53,9 +53,11 @@ const runCommand = async () => {
     ...stringified
   } as NodeJS.ProcessEnv
 
-  await execShCb.promise(command, { env: envCopy, stdio: "inherit" })
+  try {
+    await execShCb.promise(command, { env: envCopy, stdio: "inherit" })
+  } catch (err) {
+    process.exit(1)
+  }
 }
 
-runCommand().catch(() => {
-  process.exit(1)
-})
+runCommand()

--- a/package_scripts/with-env.ts
+++ b/package_scripts/with-env.ts
@@ -52,7 +52,10 @@ const runCommand = async () => {
     ...process.env,
     ...stringified
   } as NodeJS.ProcessEnv
-  execShCb(command, { env: envCopy, stdio: "inherit" })
+
+  await execShCb.promise(command, { env: envCopy, stdio: "inherit" })
 }
 
-runCommand()
+runCommand().catch(() => {
+  process.exit(1)
+})

--- a/tests-e2e/ocw-ci-test-course/shortcodes.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/shortcodes.spec.ts
@@ -24,5 +24,4 @@ test("Resource links include link to correct page", async ({ page }) => {
   })
   const href = await resourceLink.getAttribute("href")
   expect(href).toBe("/courses/ocw-ci-test-course/pages/first-test-page-title/")
-  expect(1).toBe(2)
 })

--- a/tests-e2e/ocw-ci-test-course/shortcodes.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/shortcodes.spec.ts
@@ -24,4 +24,5 @@ test("Resource links include link to correct page", async ({ page }) => {
   })
   const href = await resourceLink.getAttribute("href")
   expect(href).toBe("/courses/ocw-ci-test-course/pages/first-test-page-title/")
+  expect(1).toBe(2)
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1012 

#### What's this PR do?
in #964 we added a `with-env` command that was supposed to behave like [dotenv-cli](https://www.npmjs.com/package/dotenv-cli) but with some improvements. That command should exit with the same exit code as its subcommand, but instead it was always exiting with code 0. Oops.

#### How should this be manually tested?
1. Run the command below... the echo should be "0"
    ```sh
    yarn with-env --dev -- exit 0
    echo $?
    ```
2. Run the command below... the echo should be "1"
    ```sh
    yarn with-env --dev -- exit 1
    echo $?
    ```
3. If you want, introduce an artificial error into some e2e test, like `expect(1).toBe(2)`, and check that `CI=true yarn test:e2e` exits with code 1. (Again, use `echo $?` to check the exit code). *Note: it seems that without CI=true, Playwright will open a browser with a failed test report and never actually exit. There's probably another way to avoid that.) 

#### Any background context you want to provide?
We've only been using `with-env` in CI and for local dev commands, so this has not affected any deployments.
