### PR TITLE
Fix .Err errors, elevate sentry severity

### DIFF
--- a/base-theme/layouts/partials/featured_course_cards.html
+++ b/base-theme/layouts/partials/featured_course_cards.html
@@ -25,7 +25,7 @@
               {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) $urlPath "/data.json") "" -}}
               {{ with resources.GetRemote $url }}
                 {{ with .Err }}
-                  {{ $errorMessage := printf "Featured courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url .Err }}
+                  {{ $errorMessage := printf "Featured courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url . }}
                   {{ partial "sentry_capture_message.html" $errorMessage }}
                 {{ else }}
                   {{- $courseData := . | unmarshal -}}

--- a/base-theme/layouts/partials/sentry_capture_message.html
+++ b/base-theme/layouts/partials/sentry_capture_message.html
@@ -1,6 +1,8 @@
 <script type="text/javascript">
   window.addEventListener("load", (event) => {
     console.error("{{ . }}")
-    window.Sentry.captureMessage("{{ . }}")
+    window.Sentry.captureMessage("{{ . }}", {
+      level: Sentry.Severity.Error,
+    })
   })
 </script>

--- a/fields/layouts/home.html
+++ b/fields/layouts/home.html
@@ -39,7 +39,7 @@
         {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $id "/data.json") "" -}}
         {{ with resources.GetRemote $url }}
           {{ with .Err }}
-            {{- $errorMessage := printf "Failed to fetch sub-fields on %v via %v with error: %v" site.BaseURL $url .Err -}}
+            {{- $errorMessage := printf "Failed to fetch sub-fields on %v via %v with error: %v" site.BaseURL $url . -}}
               {{- partial "sentry_capture_message.html" $errorMessage -}}
           {{ else }}
             {{- $data := . | unmarshal -}}

--- a/fields/layouts/subfields/single.html
+++ b/fields/layouts/subfields/single.html
@@ -16,7 +16,7 @@
       {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" .id "/data.json") "" -}}
       {{ with resources.GetRemote $url }}
         {{ with .Err }}
-          {{- $errorMessage := printf "Failed to fetch sub-field on %v via %v with error: %v" site.BaseURL $url .Err -}}
+          {{- $errorMessage := printf "Failed to fetch sub-field on %v via %v with error: %v" site.BaseURL $url . -}}
           {{- partial "sentry_capture_message.html" $errorMessage -}}
         {{ else }}
           {{- $data := . | unmarshal -}}

--- a/www/layouts/collections/single.html
+++ b/www/layouts/collections/single.html
@@ -39,7 +39,7 @@
         {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $id "/data.json") "" -}}
         {{ with resources.GetRemote $url }}
           {{ with .Err }}
-            {{- $errorMessage := printf "Failed to fetch collections on %v via %v with error: %v" site.BaseURL $url .Err -}}
+            {{- $errorMessage := printf "Failed to fetch collections on %v via %v with error: %v" site.BaseURL $url . -}}
             {{- partial "sentry_capture_message.html" $errorMessage -}}
           {{ else }}
             {{- $data := . | unmarshal -}}

--- a/www/layouts/course-lists/single.html
+++ b/www/layouts/course-lists/single.html
@@ -16,7 +16,7 @@
       {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $id "/data.json") "" -}}
       {{ with resources.GetRemote $url }}
         {{ with .Err }}
-          {{- $errorMessage := printf "Something went wrong while fetching course list on %v via %v with error: %v" site.BaseURL $url .Err -}}
+          {{- $errorMessage := printf "Something went wrong while fetching course list on %v via %v with error: %v" site.BaseURL $url . -}}
           {{- partial "sentry_capture_message.html" $errorMessage -}}
         {{ else }}
           {{- $data := . | unmarshal -}}

--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -29,7 +29,7 @@
                   {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.url_path "/data.json") "" -}}
                   {{ with resources.GetRemote $url }}
                     {{ with .Err }}
-                      {{ $errorMessage := printf "New courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url .Err }}
+                      {{ $errorMessage := printf "New courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url . }}
                       {{ partial "sentry_capture_message.html" $errorMessage }}
                     {{ else }}
                       {{- $courseData := . | unmarshal -}}

--- a/www/layouts/partials/ocw_news.html
+++ b/www/layouts/partials/ocw_news.html
@@ -4,7 +4,7 @@
   {{- $url := (print (strings.TrimSuffix "/" $studioBaseUrl) "/api/news/") -}}
   {{ with resources.GetRemote $url }}
     {{ with .Err }}
-      {{ $errorMessage := printf "OCW News on %v failed to fetch %v with error: %v" site.BaseURL $url .Err }}
+      {{ $errorMessage := printf "OCW News on %v failed to fetch %v with error: %v" site.BaseURL $url . }}
       {{ partial "sentry_capture_message.html" $errorMessage }}
     {{ else }}
       {{ $items := (. | unmarshal).items }}

--- a/www/layouts/resource_collections/single.html
+++ b/www/layouts/resource_collections/single.html
@@ -26,7 +26,7 @@
         {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $urlPath "/content_map.json") "" -}}
           {{- with resources.GetRemote $url -}}
             {{ with .Err }}
-              {{- $errorMessage := printf "Failed to fetch resource collections on %v via %v with error: %v" site.BaseURL $url .Err -}}
+              {{- $errorMessage := printf "Failed to fetch resource collections on %v via %v with error: %v" site.BaseURL $url . -}}
               {{- partial "sentry_capture_message.html" $errorMessage -}}
             {{ else }}
               {{- $mapData := . | unmarshal -}}
@@ -42,7 +42,7 @@
         {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $urlPath "/data.json") "" -}}
         {{- with resources.GetRemote $url -}}
           {{ with .Err }}
-            {{- $errorMessage := printf "Failed to fetch resource collections on %v via %v with error: %v" site.BaseURL $url .Err -}}
+            {{- $errorMessage := printf "Failed to fetch resource collections on %v via %v with error: %v" site.BaseURL $url . -}}
             {{- partial "sentry_capture_message.html" $errorMessage -}}
           {{ else }}
             {{- $data := . | unmarshal -}}
@@ -58,7 +58,7 @@
       {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) $courseJSONRelpath) "" -}}
       {{- with resources.GetRemote $url -}}
         {{ with .Err }}
-          {{- $errorMessage := printf "Failed to fetch resource collections on %v via %v with error: %v" site.BaseURL $url .Err -}}
+          {{- $errorMessage := printf "Failed to fetch resource collections on %v via %v with error: %v" site.BaseURL $url . -}}
           {{- partial "sentry_capture_message.html" $errorMessage -}}
         {{ else }}
           {{- $resourceJSON := . | unmarshal -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1014 

#### What's this PR do?
This PR fixes errors in our error handling and raises the severity of sentry messages.

#### How should this be manually tested?
I don't think it's worth testing all 11 error handlers locally. One thing you could do to test them is:
1.  set your STATIC_API_BASE_URL to some bogus value like "moooooo",
2. Run `yarn start www`, and Hugo should tell you that the URL scheme is not recognized. *Previously, Hugo would tell you something useless like "cannot read property .Err of Error"*.
3. Re sentry, see screenshot below. If you want to test sentry error severity, change our Sentry.init call (sentry.js) to something like:
    ```js
      Sentry.init({
        release:     RELEASE_VERSION,
        // dsn is not secret
        dsn:         "https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953",
        environment: "YOUR NAME HERE"  })
    ```
    and check https://sentry.io/organizations/mit-office-of-digital-learning/projects/ocw-studio/?project=5304953, filtered to your environment

#### Screenshots (if appropriate)
<img width="1317" alt="Screenshot 2022-12-20 at 3 19 51 PM" src="https://user-images.githubusercontent.com/9010790/208758970-5c0db4c2-6629-4eb2-af41-08f3225fe2d7.png">
