### PR TITLE
Cc/disallow failed requests

### DIFF
--- a/base-theme/layouts/partials/featured_course_cards.html
+++ b/base-theme/layouts/partials/featured_course_cards.html
@@ -25,15 +25,13 @@
               {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) $urlPath "/data.json") "" -}}
               {{ with resources.GetRemote $url }}
                 {{ with .Err }}
-                  {{ $errorMessage := printf "Featured courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url . }}
-                  {{ partial "sentry_capture_message.html" $errorMessage }}
+                  {{ errorf "Featured courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url . }}
                 {{ else }}
                   {{- $courseData := . | unmarshal -}}
                   {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "urlPath" $urlPath "numCourses" (len $courses))}}
                 {{ end }}
               {{ else }}
-                {{ $errorMessage := printf "Failed to fetch featured courses through %v on %v" $url site.BaseURL }}
-                {{ partial "sentry_capture_message.html" $errorMessage }}
+                {{ errorf "Failed to fetch featured courses through %v on %v" $url site.BaseURL }}
               {{ end }}
             {{ end }}
           </div>

--- a/base-theme/layouts/partials/featured_course_cards.html
+++ b/base-theme/layouts/partials/featured_course_cards.html
@@ -25,13 +25,13 @@
               {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) $urlPath "/data.json") "" -}}
               {{ with resources.GetRemote $url }}
                 {{ with .Err }}
-                  {{ errorf "Featured courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url . }}
+                  {{ errorf "Failed to fetch featured course info from %v with error %v" $url . }}
                 {{ else }}
                   {{- $courseData := . | unmarshal -}}
                   {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "urlPath" $urlPath "numCourses" (len $courses))}}
                 {{ end }}
               {{ else }}
-                {{ errorf "Failed to fetch featured courses through %v on %v" $url site.BaseURL }}
+                {{ errorf "Failed to fetch featured course info from %v" $url }}
               {{ end }}
             {{ end }}
           </div>

--- a/course-v2/layouts/partials/get_instructors.html
+++ b/course-v2/layouts/partials/get_instructors.html
@@ -4,7 +4,7 @@
   {{ $url := (print (strings.TrimSuffix "/" $staticApiBaseUrl) "/instructors/" . "/index.json") }}
   {{ with resources.GetRemote $url }}
     {{ with .Err }}
-      {{ errorf "Something went wrong while fetching instructors on %v via %v with error: %v" site.BaseURL $url . }}
+      {{ errorf "Failed to fetch instructors from %v with error %v" $url . }}
     {{ else }}
       {{ $data := (. | unmarshal).data }}
       {{ $searchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" (title $data.title)) }}
@@ -12,7 +12,7 @@
       {{ $instructors = $instructors | append $instructor }}
     {{ end }}
   {{ else }}
-    {{ errorf "Failed to fetch course instructors through %v on %v" $url site.BaseURL }}
+    {{ errorf "Failed to fetch instructors from %v" $url }}
   {{ end }}
 {{ end }}
 {{ return $instructors }}

--- a/env.ts
+++ b/env.ts
@@ -27,6 +27,10 @@ const envSchema = {
   /**
    * Dev-only defaults
    */
+  API_BEARER_TOKEN: envalid.str({
+    desc:       "The bearer token to use when making requests to the OCW Studio API.",
+    devDefault: ""
+  }),
   GIT_CONTENT_SOURCE: envalid.str({
     desc:       "Git organization/user URL from which to pull Hugo site content repositories.",
     devDefault: "git@github.mit.edu:ocw-content-rc"

--- a/test-sites/__fixtures__/api/websites.json
+++ b/test-sites/__fixtures__/api/websites.json
@@ -1,0 +1,19 @@
+{
+    "count": 2500,
+    "next": null,
+    "previous": null,
+    "results": [
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/some-new-course" },
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/ocw-ci-test-course" },
+        { "url_path": "courses/ocw-ci-test-course" }
+    ]
+}

--- a/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
+++ b/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
@@ -1,30 +1,88 @@
 {
-  "course_title":"OCW CI Test Course",
-  "course_description":"This is a test course for use in CI pipelines. This course can be found:\n\n- On Github at  [https://github.mit.edu/ocw-content-rc/ocw-ci-test-course](https://github.mit.edu/ocw-content-rc/ocw-ci-test-course)\n- On OCW Studio at [https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course](https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course)\n\nThe content of this course is additionally checked into the `ocw-hugo-themes` repository.\n\n Recommended usage by OL Engineers:\n\n- Clone the github repository to your local.\n- When developing on `ocw-hugo-themes`, make edits in Studio as needed for the tests you want to write. Pull to local, and copy the files to `ocw-hugo-themes/test-sites/ocw-ci-test-course`.",
-  "site_uid":"06fbf309-8b5d-4219-b99e-de75fac8d476",
-  "legacy_uid":"","instructors": [{
-    "first_name":"Tester",
-    "last_name":"One",
-    "middle_initial":"",
-    "salutation":"Prof.",
-    "title":"Prof. Tester One"},{
-    "first_name":"Tester",
-    "last_name":"Two",
-    "middle_initial":"",
-    "salutation":"",
-    "title":"Dr. Tester Two"},{
-    "first_name":"Another",
-    "last_name":"Three",
-    "middle_initial":"T",
-    "salutation":"",
-    "title":"Another Tester Three"}],"department_numbers":["8","6","18"],
-  "learning_resource_types":["Activity Assignments","Exams with Solutions"],
-  "topics":[["Engineering","Computer Science","Software Design and Engineering"],["Science","Physics","Quantum Mechanics"]],
-  "primary_course_number":"123",
-  "extra_course_numbers":"456",
-  "term":"Fall",
-  "year":"2022",
-  "level":["Graduate","Undergraduate"],
-  "image_src":"https://live-qa.ocw.mit.edu/courses/123-ocw-ci-test-course-fall-2022/example_jpg.jpg",
-  "course_image_metadata":{"body":"","content_type":"resource","draft":false,"file":"/courses/123-ocw-ci-test-course-fall-2022/example_jpg.jpg","file_type":"image/jpeg","image_metadata":{"caption":"","credit":"","image-alt":""},"iscjklanguage":false,"learning_resource_types":[],"license":"https://creativecommons.org/licenses/by-nc-sa/4.0/","resourcetype":"Image","title":"example_jpg.jpg","uid":"4ff6cec7-9ef3-40e2-869a-313350053b32","video_files":{"video_captions_file":"","video_thumbnail_file":"","video_transcript_file":""},"video_metadata":{"video_speakers":"","video_tags":"","youtube_description":"","youtube_id":""}}}
-
+  "course_title": "OCW CI Test Course",
+  "course_description": "This is a test course for use in CI pipelines. This course can be found:\n\n- On Github at  [https://github.mit.edu/ocw-content-rc/ocw-ci-test-course](https://github.mit.edu/ocw-content-rc/ocw-ci-test-course)\n- On OCW Studio at [https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course](https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course)\n\nThe content of this course is additionally checked into the `ocw-hugo-themes` repository.\n\n Recommended usage by OL Engineers:\n\n- Clone the github repository to your local.\n- When developing on `ocw-hugo-themes`, make edits in Studio as needed for the tests you want to write. Pull to local, and copy the files to `ocw-hugo-themes/test-sites/ocw-ci-test-course`.",
+  "site_uid": "06fbf309-8b5d-4219-b99e-de75fac8d476",
+  "legacy_uid": "",
+  "instructors": [
+    {
+      "first_name": "Tester",
+      "last_name": "One",
+      "middle_initial": "",
+      "salutation": "Prof.",
+      "title": "Prof. Tester One"
+    },
+    {
+      "first_name": "Tester",
+      "last_name": "Two",
+      "middle_initial": "",
+      "salutation": "",
+      "title": "Dr. Tester Two"
+    },
+    {
+      "first_name": "Another",
+      "last_name": "Three",
+      "middle_initial": "T",
+      "salutation": "",
+      "title": "Another Tester Three"
+    }
+  ],
+  "department_numbers": [
+    "8",
+    "6",
+    "18"
+  ],
+  "learning_resource_types": [
+    "Activity Assignments",
+    "Exams with Solutions"
+  ],
+  "topics": [
+    [
+      "Engineering",
+      "Computer Science",
+      "Software Design and Engineering"
+    ],
+    [
+      "Science",
+      "Physics",
+      "Quantum Mechanics"
+    ]
+  ],
+  "primary_course_number": "123",
+  "extra_course_numbers": "456",
+  "term": "Fall",
+  "year": "2022",
+  "level": [
+    "Graduate",
+    "Undergraduate"
+  ],
+  "image_src": "https://live-qa.ocw.mit.edu/courses/123-ocw-ci-test-course-fall-2022/example_jpg.jpg",
+  "course_image_metadata": {
+    "body": "",
+    "content_type": "resource",
+    "draft": false,
+    "file": "/courses/123-ocw-ci-test-course-fall-2022/example_jpg.jpg",
+    "file_type": "image/jpeg",
+    "image_metadata": {
+      "caption": "",
+      "credit": "",
+      "image-alt": ""
+    },
+    "iscjklanguage": false,
+    "learning_resource_types": [],
+    "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+    "resourcetype": "Image",
+    "title": "example_jpg.jpg",
+    "uid": "4ff6cec7-9ef3-40e2-869a-313350053b32",
+    "video_files": {
+      "video_captions_file": "",
+      "video_thumbnail_file": "",
+      "video_transcript_file": ""
+    },
+    "video_metadata": {
+      "video_speakers": "",
+      "video_tags": "",
+      "youtube_description": "",
+      "youtube_id": ""
+    }
+  }
+}

--- a/test-sites/__fixtures__/courses/some-featured-course/data.json
+++ b/test-sites/__fixtures__/courses/some-featured-course/data.json
@@ -1,0 +1,49 @@
+{
+    "course_title": "Some Featured Course for Testing",
+    "course_description": "A dummy featured course for testing. Does not have full course page.",
+    "site_uid": "8da985fa-d3cb-4ac0-9446-c1c115b9d4e1",
+    "legacy_uid": "",
+    "instructors": [],
+    "department_numbers": ["18"],
+    "learning_resource_types": [
+      "Activity Assignments"
+    ],
+    "topics": [],
+    "primary_course_number": "123",
+    "extra_course_numbers": "456",
+    "term": "Fall",
+    "year": "1999",
+    "level": [
+      "Graduate"
+    ],
+    "image_src": "https://draft-qa.ocw.mit.edu/courses/123-another-test-course-fall-1999/leo.jpeg",
+    "course_image_metadata": {
+      "body": "",
+      "content_type": "resource",
+      "draft": false,
+      "file": "/courses/123-another-test-course-fall-1999/leo.jpeg",
+      "file_type": "image/jpeg",
+      "image_metadata": {
+        "caption": "",
+        "credit": "",
+        "image-alt": ""
+      },
+      "iscjklanguage": false,
+      "learning_resource_types": [],
+      "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+      "resourcetype": "Image",
+      "title": "neutrino.jpg",
+      "uid": "98063548-f150-4d44-834b-41d4de40a3c6",
+      "video_files": {
+        "video_captions_file": "",
+        "video_thumbnail_file": "",
+        "video_transcript_file": ""
+      },
+      "video_metadata": {
+        "video_speakers": "",
+        "video_tags": "",
+        "youtube_description": "",
+        "youtube_id": ""
+      }
+    }
+  }

--- a/test-sites/__fixtures__/courses/some-new-course/data.json
+++ b/test-sites/__fixtures__/courses/some-new-course/data.json
@@ -1,0 +1,49 @@
+{
+    "course_title": "Some New Course",
+    "course_description": "A dummy new course for testing. Does not have full course page.",
+    "site_uid": "1a99e1b3-5070-41dd-97f5-2b511bdc44de",
+    "legacy_uid": "",
+    "instructors": [],
+    "department_numbers": ["18"],
+    "learning_resource_types": [
+      "Activity Assignments"
+    ],
+    "topics": [],
+    "primary_course_number": "123",
+    "extra_course_numbers": "456",
+    "term": "Fall",
+    "year": "1999",
+    "level": [
+      "Graduate"
+    ],
+    "image_src": "https://draft-qa.ocw.mit.edu/courses/123-another-test-course-fall-1999/neutrino.jpg",
+    "course_image_metadata": {
+      "body": "",
+      "content_type": "resource",
+      "draft": false,
+      "file": "/courses/123-another-test-course-fall-1999/neutrino.jpg",
+      "file_type": "image/jpeg",
+      "image_metadata": {
+        "caption": "",
+        "credit": "",
+        "image-alt": ""
+      },
+      "iscjklanguage": false,
+      "learning_resource_types": [],
+      "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+      "resourcetype": "Image",
+      "title": "neutrino.jpg",
+      "uid": "50321ac4-3ef7-4815-a602-b637e69a9503",
+      "video_files": {
+        "video_captions_file": "",
+        "video_thumbnail_file": "",
+        "video_transcript_file": ""
+      },
+      "video_metadata": {
+        "video_speakers": "",
+        "video_tags": "",
+        "youtube_description": "",
+        "youtube_id": ""
+      }
+    }
+  }

--- a/test-sites/ocw-ci-test-www/content/course-lists/featured-courses-homepage.md
+++ b/test-sites/ocw-ci-test-www/content/course-lists/featured-courses-homepage.md
@@ -2,7 +2,17 @@
 content_type: course-lists
 courses:
 - id: courses/ocw-ci-test-course
-  title: Blarglefraster
+  title: OCW CI Test Course
+- id: courses/some-featured-course
+  title: Some Featured Course for Testing
+- id: courses/ocw-ci-test-course
+  title: OCW CI Test Course
+- id: courses/ocw-ci-test-course
+  title: OCW CI Test Course
+- id: courses/ocw-ci-test-course
+  title: OCW CI Test Course
+- id: courses/ocw-ci-test-course
+  title: OCW CI Test Course
 description: ''
 draft: false
 title: featured-courses-homepage

--- a/tests-e2e/LocalOcw.ts
+++ b/tests-e2e/LocalOcw.ts
@@ -32,13 +32,20 @@ const OCW_WWW_REWRITE: RedirectionRule = {
   transform: url => `/ocw-ci-test-www${url}`
 }
 
+/**
+ * Redirects requests to
+ *  original: /api/websites?type=course-v2
+ *  rewritten: /api/websites.json?type=course-v2
+ * so our static file server can serve the JSON.
+ */
 const API_JSON_REWRITE: RedirectionRule = {
   type:      "rewrite",
   match:     /^\/api\//,
   transform: urlText => {
-    const url = new URL(urlText, "http://ocw.mit.edu") // basename is needed but not used
+    // We need to provide some baseurl, but we will not use it.
+    const url = new URL(urlText, "http://fakesite.mit.edu")
     url.pathname = `${url.pathname.replace(/\/$/, "")}.json`
-    return url.toString()
+    return [url.pathname, url.search, url.hash].join("")
   }
 }
 

--- a/tests-e2e/LocalOcw.ts
+++ b/tests-e2e/LocalOcw.ts
@@ -157,7 +157,8 @@ class LocalOCW {
                * When building test sites, use local server at fixturesPort for static
                * API requests. See test-sites/__fixtures__/README.md for more.
                */
-              STATIC_API_BASE_URL: `http://localhost:${this.fixturesPort}`
+              STATIC_API_BASE_URL: `http://localhost:${this.fixturesPort}`,
+              API_BEARER_TOKEN:    ""
             })
           )
         }

--- a/tests-e2e/fixtures.spec.ts
+++ b/tests-e2e/fixtures.spec.ts
@@ -8,15 +8,28 @@ import recursiveReaddir from "recursive-readdir"
  * that the fixtures are accurate
  */
 test("The fixtures are what Hugo would produce.", async () => {
+  const SKIP_DIRS = [
+    "api/",
+    /**
+     * The two courses below are not built, they are just used as previews on
+     * the test homepage.
+     */
+    "courses/some-featured-course",
+    "courses/some-new-course"
+  ]
+
   const fixtureDir = path.resolve(__dirname, "../test-sites/__fixtures__")
   const builtDir = path.resolve(__dirname, "../test-sites/tmp/dist")
-  const filepaths = await recursiveReaddir(
+  const filepaths: string[] = await recursiveReaddir(
     path.resolve(__dirname, "../test-sites/__fixtures__")
   )
   const jsonpaths = filepaths.filter(filepath => filepath.endsWith(".json"))
   const comparisons = await Promise.all(
     jsonpaths.map(async filepath => {
       const relative = path.relative(fixtureDir, filepath)
+      if (SKIP_DIRS.some(dir => relative.startsWith(dir))) {
+        return { fixture: null, built: null }
+      }
       const fixtureText = await fs.readFile(filepath, "utf-8")
       const builtText = await fs.readFile(
         path.join(builtDir, relative),

--- a/tests-e2e/global-setup.ts
+++ b/tests-e2e/global-setup.ts
@@ -3,11 +3,11 @@ import LocalOCW, { fromRoot } from "./LocalOcw"
 const setupTests = async () => {
   const ocw = new LocalOCW({
     rootDestinationDir: fromRoot("./test-sites/tmp/dist"),
-    staticApiPort:      4321
+    fixturesPort:       4321
   })
 
   await ocw.rmrfTmp()
-  ocw.staticApiServer.listen()
+  ocw.fixturesServer.listen()
   await ocw.buildAllSites()
   ocw.serveSites()
   ocw.announceSites()

--- a/tests-e2e/jest/build-failures.test.ts
+++ b/tests-e2e/jest/build-failures.test.ts
@@ -8,7 +8,11 @@ interface ExecError extends Error {
   stderr: string
 }
 
-const expectBuildError = async (ocw: LocalOCW, alias: TestSiteAlias, msg: string | RegExp) => {
+const expectBuildError = async (
+  ocw: LocalOCW,
+  alias: TestSiteAlias,
+  msg: string | RegExp
+) => {
   let error: ExecError
 
   try {
@@ -23,7 +27,7 @@ const expectBuildError = async (ocw: LocalOCW, alias: TestSiteAlias, msg: string
 describe("OCW Build Failures", () => {
   const ocw = new LocalOCW({
     rootDestinationDir: path.join(__dirname, "tmp"),
-    fixturesPort:       4322,
+    fixturesPort:       4322
   })
 
   beforeEach(async () => {
@@ -53,7 +57,8 @@ describe("OCW Build Failures", () => {
   ])(
     "Instructor static API errors crash build",
     async ({ statusCode, match }) => {
-      const shouldPatch = (req: IncomingMessage) => req.url?.includes("3caa0884-4fdd-4f3c-ba39-67a64c27d877")
+      const shouldPatch = (req: IncomingMessage) =>
+        req.url?.includes("3caa0884-4fdd-4f3c-ba39-67a64c27d877")
       ocw.fixturesServer.patchHandler((req, res) => {
         if (shouldPatch(req)) {
           res.writeHead(statusCode)
@@ -75,7 +80,8 @@ describe("OCW Build Failures", () => {
       match:      /Featured courses carousel .* with error/
     }
   ])("Featured course static API failures", async ({ statusCode, match }) => {
-    const shouldPatch = (req: IncomingMessage) => req.url?.includes("some-featured-course")
+    const shouldPatch = (req: IncomingMessage) =>
+      req.url?.includes("some-featured-course")
     ocw.fixturesServer.patchHandler((req, res) => {
       if (shouldPatch(req)) {
         res.writeHead(statusCode)
@@ -96,7 +102,8 @@ describe("OCW Build Failures", () => {
       match:      /New courses carousel .* with error/
     }
   ])("Featured course static API failures", async ({ statusCode, match }) => {
-    const shouldPatch = (req: IncomingMessage) => req.url?.includes("some-new-course")
+    const shouldPatch = (req: IncomingMessage) =>
+      req.url?.includes("some-new-course")
     ocw.fixturesServer.patchHandler((req, res) => {
       if (shouldPatch(req)) {
         res.writeHead(statusCode)

--- a/tests-e2e/jest/build-failures.test.ts
+++ b/tests-e2e/jest/build-failures.test.ts
@@ -1,29 +1,43 @@
 import * as path from "node:path"
+import { IncomingMessage } from "node:http"
 import LocalOCW from "../LocalOcw"
+import { TestSiteAlias } from "../util/test_sites"
 
 interface ExecError extends Error {
   stdout: string
   stderr: string
 }
 
+const expectBuildError = async (ocw: LocalOCW, alias: TestSiteAlias, msg: string | RegExp) => {
+  let error: ExecError
+
+  try {
+    await ocw.buildSite(alias, { execOptions: { stdio: undefined } })
+  } catch (err) {
+    error = err as ExecError
+  }
+
+  expect(error!.stdout).toMatch(msg)
+}
+
 describe("OCW Build Failures", () => {
   const ocw = new LocalOCW({
     rootDestinationDir: path.join(__dirname, "tmp"),
-    staticApiPort:      4322
+    fixturesPort:       4322,
   })
 
   beforeEach(async () => {
     await ocw.rmrfTmp()
   })
   beforeAll(() => {
-    ocw.staticApiServer.listen()
+    ocw.fixturesServer.listen()
   })
   afterAll(() => {
-    ocw.staticApiServer.close()
+    ocw.fixturesServer.close()
   })
 
   afterEach(() => {
-    ocw.staticApiServer.resetHandler()
+    ocw.fixturesServer.resetHandler()
   })
 
   test.each([
@@ -39,23 +53,57 @@ describe("OCW Build Failures", () => {
   ])(
     "Instructor static API errors crash build",
     async ({ statusCode, match }) => {
-      const badInstructor = "3caa0884-4fdd-4f3c-ba39-67a64c27d877"
-      ocw.staticApiServer.patchHandler((req, res) => {
-        if (req.url?.includes(badInstructor)) {
+      const shouldPatch = (req: IncomingMessage) => req.url?.includes("3caa0884-4fdd-4f3c-ba39-67a64c27d877")
+      ocw.fixturesServer.patchHandler((req, res) => {
+        if (shouldPatch(req)) {
           res.writeHead(statusCode)
           res.end()
         }
       })
 
-      let error: ExecError
-
-      try {
-        await ocw.buildSite("course", { execOptions: { stdio: undefined } })
-      } catch (err) {
-        error = err as ExecError
-      }
-
-      expect(error!.stdout).toMatch(match)
+      await expectBuildError(ocw, "course", match)
     }
   )
+
+  test.each([
+    {
+      statusCode: 404,
+      match:      /Failed to fetch featured courses/
+    },
+    {
+      statusCode: 504,
+      match:      /Featured courses carousel .* with error/
+    }
+  ])("Featured course static API failures", async ({ statusCode, match }) => {
+    const shouldPatch = (req: IncomingMessage) => req.url?.includes("some-featured-course")
+    ocw.fixturesServer.patchHandler((req, res) => {
+      if (shouldPatch(req)) {
+        res.writeHead(statusCode)
+        res.end()
+      }
+    })
+
+    await expectBuildError(ocw, "www", match)
+  })
+
+  test.each([
+    {
+      statusCode: 404,
+      match:      /Failed to fetch new course card/
+    },
+    {
+      statusCode: 504,
+      match:      /New courses carousel .* with error/
+    }
+  ])("Featured course static API failures", async ({ statusCode, match }) => {
+    const shouldPatch = (req: IncomingMessage) => req.url?.includes("some-new-course")
+    ocw.fixturesServer.patchHandler((req, res) => {
+      if (shouldPatch(req)) {
+        res.writeHead(statusCode)
+        res.end()
+      }
+    })
+
+    await expectBuildError(ocw, "www", match)
+  })
 })

--- a/tests-e2e/ocw-ci-test-www/featured_courses.spec.ts
+++ b/tests-e2e/ocw-ci-test-www/featured_courses.spec.ts
@@ -4,7 +4,9 @@ import { WwwPage } from "../util"
 test("Course Card lists Instructors", async ({ page }) => {
   const www = new WwwPage(page)
   await www.goto()
-  const card = www.getCourseCard("OCW CI Test Course")
+  const card = www
+    .getCourseCard("OCW CI Test Course", { expectedCount: 6 })
+    .first()
   await expect(card).toContainText(
     "Instructors(s): Prof. Tester One, Dr. Tester Two, Another Tester Three"
   )

--- a/tests-e2e/util/WwwPage.ts
+++ b/tests-e2e/util/WwwPage.ts
@@ -27,23 +27,20 @@ class WwwPage {
 
   /**
    * Return a Locator for a Course Card by its title.
-   *
-   * Passing `{ expectedCount: 0 }` amounts to asserting that the CourseInfo
-   * section is not visible.
    */
   getCourseCard(title: string, { expectedCount = 1 } = {}): Locator {
     const cardXPath = `div[${xPath.predicates.hasClass("course-card")}]`
-    const courseInfo = this.page
+    const courseCard = this.page
       .getByRole("link", { name: title })
       .locator(`${closest(cardXPath)} >> visible=true`)
 
-    courseInfo.count().then(count => {
+    courseCard.count().then(count => {
       if (count !== expectedCount) {
         throw new Error(`Expected ${expectedCount} Course Cards, got ${count}`)
       }
     })
 
-    return courseInfo
+    return courseCard
   }
 }
 

--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -28,13 +28,13 @@
                   {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.url_path "/data.json") "" -}}
                   {{ with resources.GetRemote $url }}
                     {{ with .Err }}
-                      {{ errorf "New courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url . }}
+                      {{ errorf "Failed to fetch new course info from %v with error %v" $url . }}
                     {{ else }}
                       {{- $courseData := . | unmarshal -}}
                       {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "urlPath" $courseItem.url_path "numCourses" (len $resultsSlice))}}
                     {{ end }}
                   {{ else }}
-                    {{ errorf "Failed to fetch new course card through %v on %v" $url site.BaseURL }}
+                    {{ errorf "Failed to fetch new course info from %v" $url }}
                   {{ end }}
                 {{- end -}}
               {{ end }}
@@ -47,6 +47,6 @@
     {{ end }}
   {{ end }}
 {{ else }}
-  {{ errorf "Failed to fetch new courses through %v on %v" $coursesURL site.BaseURL }}
+  {{ errorf "Failed to fetch new courses list from %v" $coursesURL }}
 {{ end }}
 </div>

--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -3,7 +3,6 @@
 {{ $studioBaseUrl := partial "ocw_studio_base_url.html" }}
 {{ $courseStarterSlug := getenv "OCW_COURSE_STARTER_SLUG" }}
 {{ $typeQuery := querify "type" $courseStarterSlug }}
-{{ if and $studioBaseUrl $courseStarterSlug }}
 {{ $coursesURL := (print (strings.TrimSuffix "/" $studioBaseUrl) "/api/websites/?" $typeQuery) }}
 {{ with resources.GetRemote $coursesURL }}
   {{ if not .Err }}
@@ -50,7 +49,4 @@
 {{ else }}
   {{ errorf "Failed to fetch new courses through %v on %v" $coursesURL site.BaseURL }}
 {{ end }}
-{{ else }}
-OCW Studio URL not configured
-{{  end  }}
 </div>

--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -29,15 +29,13 @@
                   {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.url_path "/data.json") "" -}}
                   {{ with resources.GetRemote $url }}
                     {{ with .Err }}
-                      {{ $errorMessage := printf "New courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url . }}
-                      {{ partial "sentry_capture_message.html" $errorMessage }}
+                      {{ errorf "New courses carousel on %v failed to fetch %v with error: %v" site.BaseURL $url . }}
                     {{ else }}
                       {{- $courseData := . | unmarshal -}}
                       {{ partial "course_carousel_card.html" (dict "itemsInCarousel" $itemsInCarousel "courseData" $courseData "index" $index "urlPath" $courseItem.url_path "numCourses" (len $resultsSlice))}}
                     {{ end }}
                   {{ else }}
-                    {{ $errorMessage := printf "Failed to fetch new course card through %v on %v" $url site.BaseURL }}
-                    {{ partial "sentry_capture_message.html" $errorMessage }}
+                    {{ errorf "Failed to fetch new course card through %v on %v" $url site.BaseURL }}
                   {{ end }}
                 {{- end -}}
               {{ end }}
@@ -50,8 +48,7 @@
     {{ end }}
   {{ end }}
 {{ else }}
-  {{ $errorMessage := printf "Failed to fetch new courses through %v on %v" $coursesURL site.BaseURL }}
-  {{ partial "sentry_capture_message.html" $errorMessage }}
+  {{ errorf "Failed to fetch new courses through %v on %v" $coursesURL site.BaseURL }}
 {{ end }}
 {{ else }}
 OCW Studio URL not configured


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1026 

#### What's this PR do?
This PR makes the build fail in a few scenarios where we were previously generating runtime errors.
1. when fetching the new courses list **from ocw studio** on ocw-www fails
2. when fetching course info for a new course via STATIC_API_BASE_URL
3. when fetching course info for a featured course via STATIC_API_BASE_URL

#### How should this be manually tested?

Below i've suggested some ways you could make the HTTP requests fail that would trigger the codepaths in this PR. You could make them fail in other ways. Or you can trust the tests.

1. Run `yarn start ocw-www`; it should start successfully
2. **fail to fetch new courses list:** Manually make `$coursesURL` something invalid in `www/layouts/partials/new_course_cards.html`
3. **fail to fetch a new course:** You could edit www/layouts/partials/new_course_cards.html so that the individual course URLs are wrong. E.g., add after line 28 `{{- $url = print $url "meow" -}}`.
4. **fail to fetch featured course:** Manually edit your local copy of ocw-www, change an id in `content/course-lists/featured-courses-homepage.md` to be invalid. The build should now fail.

