### PR TITLE
display 12 new courses, not 10

### DIFF
--- a/www/layouts/partials/new_course_cards.html
+++ b/www/layouts/partials/new_course_cards.html
@@ -2,8 +2,8 @@
 <div class="new-courses course-cards standard-width container mx-auto mt-3">
 {{ $studioBaseUrl := partial "ocw_studio_base_url.html" }}
 {{ $courseStarterSlug := getenv "OCW_COURSE_STARTER_SLUG" }}
-{{ $typeQuery := querify "type" $courseStarterSlug }}
-{{ $coursesURL := (print (strings.TrimSuffix "/" $studioBaseUrl) "/api/websites/?" $typeQuery) }}
+{{ $coursesQuery := querify "type" $courseStarterSlug "limit" 12 }}
+{{ $coursesURL := (print (strings.TrimSuffix "/" $studioBaseUrl) "/api/websites/?" $coursesQuery) }}
 {{ with resources.GetRemote $coursesURL }}
   {{ if not .Err }}
     {{ $results := (. | unmarshal).results }}
@@ -22,7 +22,7 @@
               {{ partial "carousel_controls.html" $carouselId }}
             </div>
             <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-2 px-0">
-              {{ $resultsSlice := first 10 $results }}
+              {{ $resultsSlice := first 12 $results }}
               {{ range $index, $courseItem := $resultsSlice  }}
                 {{- if $courseItem.url_path -}}
                   {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) "/" $courseItem.url_path "/data.json") "" -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1025 

#### What's this PR do?
Changes "New Courses" carousel to have 12 items, which divides nicely into 1/2/3/4 items per page at various widths.

#### How should this be manually tested?
Run `yarn start www` and verify that the New Courses carousel has 12 items and looks good at various widths.

**Note:** The Featured Courses carousel has a number of items determined by OCW authors, via Studio.

