### PR TITLE
produce source-maps in prod build

### DIFF
--- a/base-theme/assets/webpack/webpack.prod.ts
+++ b/base-theme/assets/webpack/webpack.prod.ts
@@ -7,7 +7,8 @@ import MiniCssExtractPlugin from "mini-css-extract-plugin"
 import common from "./webpack.common"
 
 const prodOverrides: Configuration = {
-  mode: "production",
+  mode:    "production",
+  devtool: "source-map",
 
   output: {
     path:       path.join(__dirname, "../../dist/static"),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,12 +7,8 @@
       "dom"
     ],
     "jsx": "react",
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    "module": "commonjs",
+    "moduleResolution": "node",
     "typeRoots": [
       "node_modules/@types",
       "base-theme/assets/types"
@@ -20,34 +16,9 @@
     "allowJs": true,
     "checkJs": true,
     "resolveJsonModule": true,
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
+    "sourceMap": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested *I have not tested that sentry actually reads these source maps; I think we can wait till for QA servers for that.*

#### What are the relevant tickets?
#1036 

#### What's this PR do?
This PR changes our ts+webpack configs to generate sourcemaps during the production builds.

#### How should this be manually tested?
**First:** Verify that this does not noticeably affect the size of the production webpack build.
1. Generate an env file if you don't have one. You can do this with `yarn with-env --dev --print-env '' > .env`. *Most of our commands, e.g., `yarn start course`, run with default environment variables, but **only in development**, and we want to run some production-like commands.
2. Clear your webpack dist folder: `rm -rf base-theme/dist`
3. On `main` branch: run production webpack build `yarn build:webpack`
4. On this branch, run production webpack build: `yarn build:webpack`
5. view the file sizes, `ls -lh base-theme/dist/static/js`. The `.js` file sizes should not be noticeably different.

_There should be no noticeable difference in filesizes. The sourcemap build does add a few dozen characters to the end of the `.js` file specifying where the sourcemaps are located in relation to the js file itself._


**Now:** verify that sourcemaps work
1. Build a site for production. Assuming your ocw-content-rc and ocw-hugo-projects directories adjacent to ocw-hugo-themes, `yarn build abs/path/to/9.40-spring-2018  abs/path/to/ocw-hugo-projects/ocw-course-v2/config.yaml`
2. Serve the built course: `npx serve path/to/9.40-spring-2018/dist`.
3. Open the url that `serve` displayed in your terminal and check that the soruce code is viewable:

<img width="400" alt="Screenshot 2023-01-19 at 2 19 17 PM" src="https://user-images.githubusercontent.com/9010790/213539899-d50644c2-b602-4314-9522-6a2ac69611a4.png">


### Any background context you want to provide?

#### Two places to Turn on Source Maps
There are two places we "turn on" sourcemaps:
1.  Setting `devtool: source-map` in the webpack config tells webpack to generate separate sourcemaps for the multiple *JS* files that it concatenates/minifies/bundles into one (or a few) JS files. This setting affects the JS that is output by the Typescript compiler.
3. Setting `sourceMap: true` in the TS config tells the TS compiler to generate sourcemaps for the compiled JS back to the original TS.

So if you only turn on the webpack sourceMaps, you end up with sourcemaps to the compiled TS, not to the real source code.

#### Should we upload them to Sentry?
We would need to upload sourcemaps if, say, Sentry was monitoring a backend written in Typescript but running as compiled JS. With a browser environment, Sentry can read publicly hosted sourcemaps. They do *recommend* uploading the sourcemaps. From [Sentry Docs, "Hosting Publicly"](https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/hosting-publicly/)
> While making source maps available to Sentry from your servers is the most natural integration, it is not always advisable:
>
>  - Sentry may not always be able to reach your servers.
> - If you do not specify versions in your asset URLs, there may be a version mismatch
> - The additional latency may mean that source mappings are not available for all errors. 

I think we should start with hosting publicly: (1) our assets are versioned, (2) fastly/s3 is reliable, and (3) Avoids us having to generate/manage auth tokens to do the uploading.