### PR TITLE
better tree-shaking... compile ts to ESM (before bundling)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
       "dom"
     ],
     "jsx": "react",
-    "module": "commonjs",
+    "module": "ES6",
     "moduleResolution": "node",
     "typeRoots": [
       "node_modules/@types",
@@ -41,6 +41,9 @@
   ],
   "ts-node": {
     "files": true,
-    "swc": true
+    "swc": true,
+    "compilerOptions": {
+      "module": "commonjs"
+    },
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested *I have not tested that sentry actually reads these source maps; I think we can wait till for QA servers for that.*

#### What are the relevant tickets?
Related to #1033, #1034


#### What's this PR do?
This PR changes the way we compile TS *before* being bundled by webpack: In our tsconfig, we had `module` set to CommonJS, whereas it should be set to ES6 As the Webpack Typescript docs say,

> **Warning**
> `ts-loader` uses `tsc`, the TypeScript compiler, and relies on your `tsconfig.json` configuration. Make sure to avoid setting [module](https://www.typescriptlang.org/tsconfig#module) to "CommonJS", or webpack won't be able to [tree-shake your code](https://webpack.js.org/guides/tree-shaking).

### How should this be tested

There should be no noticeable changes, other than that the output of `yarn build:webpack` should be a bit smaller.

You could...
1. Check the site still looks ok at on the [netlify builds](https://github.com/mitodl/ocw-hugo-themes/pull/1044#issuecomment-1398735619)
2. If you want:
    - Run `yarn build:wepback`. It should succeed and the js file sizes (`ls -lh base-theme/dist/js`) should be a bit smaller than they are on `main` branch.
    - Run a site in production mode on this branch, e.g., by
        1. Build a site for production. Assuming your ocw-content-rc and ocw-hugo-projects directories adjacent to ocw-hugo-themes, `yarn build abs/path/to/9.40-spring-2018  abs/path/to/ocw-hugo-projects/ocw-course-v2/config.yaml`
        2. Serve the built course: `npx serve path/to/9.40-spring-2018/dist`.
        3. Open the url that `serve` displayed in your terminal and check that the soruce code is viewable:

        Again, there should be no noticeable changes.

### Background Info
The "module" config setting tells Typescript what module syntax to use when compiling TS files into JS files. Specifying ES6 means use ES6 `import`/`export`. **Note:** This ES6 import syntax **does not end up in the final bundles**. Again, from Webpack docs](https://webpack.js.org/concepts/manifest/):

> No matter which [module syntax](https://webpack.js.org/api/module-methods) you have chosen, those import or require statements have now become __webpack_require__ methods that point to module identifiers.

The advantage of compiling TS to JS is better tree-shaking (removal of unused code). It's not a huge difference at the moment:
```
                commonjs    es6
main.js	        323 kb	    313 kb																							
www.js	        580 kb	    516 kb      <-- biggest difference																				
course_v2.js	866 kb	    864 kb																							
```
but it's free, and I expect in the future it could matter more. (For example: I came across this issue while working on #1037, which I have decided to set aside. While working on #1037 , I found that because of [changes](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#restructuring-of-package-content) in how Sentry organizes their code in v7, we Sentry v7's footprint on our bundle would be 54kb instead of 20kb without this config change.)

