### PR TITLE
remove the usage of partialCached

### DIFF
--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -10,9 +10,9 @@
     <!-- End Google Tag Manager (noscript) -->
   {{ end }}
   <div class="overflow-auto">
-    {{ partialCached "mobile_course_nav.html" . }}
-    {{ partialCached "mobile_course_info.html" . }}
-    {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
+    {{ partial "mobile_course_nav.html" . }}
+    {{ partial "mobile_course_info.html" . }}
+    {{ block "header" . }}{{ partial "header" . }}{{ end }}
     {{ $isCourseHomePage := (eq .Params.layout "course_home") }}
     {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
 
@@ -33,7 +33,7 @@
       </div>
       <div class="row course-cards">
         <div class="col-2 course-home-grid large-and-above-only">  
-          {{ partialCached "desktop_nav.html" . }}
+          {{ partial "desktop_nav.html" . }}
         </div>
         <div class="col-sm-12 col-lg-10 course-home-grid">
           <div class="">
@@ -58,7 +58,7 @@
                 via script written below hence hidden at the start to avoid a quick glitch  */}}
                 <div class="p-0 large-and-above-only d-none" id="desktop-course-drawer">
                   {{ if not $isCourseHomePage }}
-                    {{ partialCached "desktop_course_info.html" . }}
+                    {{ partial "desktop_course_info.html" . }}
                   {{ end }}
                 </div>
               </div>
@@ -70,7 +70,7 @@
 
     {{ block "footer" . }}{{ partial "footer-v2" . }}{{end}}
   </div>
-  {{ partialCached "hide_offline_links.html" . }}
+  {{ partial "hide_offline_links.html" . }}
   <script>
     // Script for maintaining and toggling course drawer state
     // note: This script is placed here instead of being in the bundle so it runs as soon as the HTML is rendered 
@@ -176,8 +176,8 @@
     }
   </script>
 
-  {{ partialCached "navigation_js.html" . }}
-  {{ partialCached "responsive_tables_js.html" . }}
+  {{ partial "navigation_js.html" . }}
+  {{ partial "responsive_tables_js.html" . }}
   {{- $theme := .Site.Data.webpack.main -}}
   {{- $courseTheme := .Site.Data.webpack.course_v2 -}}
   {{ partial "include_js.html" (dict "context" . "url" $theme.js) }}

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -12,9 +12,9 @@
   {{ end }}
   
   <div class="overflow-auto">
-    {{ partialCached "mobile_course_nav.html" . }}
-    {{ partialCached "mobile_course_info.html" . }}
-    {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
+    {{ partial "mobile_course_nav.html" . }}
+    {{ partial "mobile_course_info.html" . }}
+    {{ block "header" . }}{{ partial "header" . }}{{ end }}
     {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
 
   <div id="course-main-content">
@@ -27,22 +27,22 @@
     </div>
     <div class="row course-cards">
       <div class="col-2 course-home-grid large-and-above-only">  
-        {{ partialCached "desktop_nav.html" . }}
+        {{ partial "desktop_nav.html" . }}
       </div>
       <div class="col-12 col-md-8 col-lg-7 course-home-grid">
-        {{ partialCached "course_detail.html" . }}
+        {{ partial "course_detail.html" . }}
       </div>
       <div class="col-12 col-md-4 col-lg-3 mb-3 mb-md-0 course-home-grid">
-        {{ partialCached "course_image_section.html" . }}
+        {{ partial "course_image_section.html" . }}
       </div>
     </div>
   </div>
   
   {{ block "footer" . }}{{ partial "footer-v2" . }}{{end}}
-  {{ partialCached "hide_offline_links.html" . }}
+  {{ partial "hide_offline_links.html" . }}
   </div>
-  {{ partialCached "navigation_js.html" . }}
-  {{ partialCached "responsive_tables_js.html" . }}
+  {{ partial "navigation_js.html" . }}
+  {{ partial "responsive_tables_js.html" . }}
   {{- $theme := .Site.Data.webpack.main -}}
   {{- $courseTheme := .Site.Data.webpack.course_v2 -}}
 

--- a/course-v2/layouts/partials/course_image_section.html
+++ b/course-v2/layouts/partials/course_image_section.html
@@ -16,7 +16,7 @@
         </div>
       </div>
       <div>
-        {{ partialCached "download_course_link_button.html" (dict "context" . "inPanel" true) }}
+        {{ partial "download_course_link_button.html" (dict "context" . "inPanel" true) }}
       </div>
     </div>
   </div>

--- a/course-v2/layouts/partials/desktop_course_info.html
+++ b/course-v2/layouts/partials/desktop_course_info.html
@@ -4,7 +4,7 @@
     <div class="px-3">
       {{ partial "topics.html" (dict "context" . "inPanel" true) }}
       {{ partial "learning_resource_types.html" (dict "context" . "inPanel" true) }}
-      {{ partialCached "download_course_link_button.html" (dict "context" . "inPanel" true) }}
+      {{ partial "download_course_link_button.html" (dict "context" . "inPanel" true) }}
     </div>
   </div>
 </div>

--- a/course-v2/layouts/partials/mobile_course_info.html
+++ b/course-v2/layouts/partials/mobile_course_info.html
@@ -20,5 +20,5 @@
   {{ partial "course_info.html" (dict "context" . "inPanel" true) }}
   {{ partial "topics.html" (dict "context" . "inPanel" true) }}
   {{ partial "learning_resource_types.html" (dict "context" . "inPanel" true) }}
-  {{ partialCached "download_course_link_button.html" (dict "context" . "inPanel" true) }}
+  {{ partial "download_course_link_button.html" (dict "context" . "inPanel" true) }}
 </div>

--- a/course/layouts/_default/baseof.html
+++ b/course/layouts/_default/baseof.html
@@ -10,9 +10,9 @@
     <!-- End Google Tag Manager (noscript) -->
   {{ end }}
   <div class="overflow-auto">
-    {{ partialCached "mobile_course_nav.html" . }}
-    {{ partialCached "mobile_course_info.html" . }}
-    {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
+    {{ partial "mobile_course_nav.html" . }}
+    {{ partial "mobile_course_info.html" . }}
+    {{ block "header" . }}{{ partial "header" . }}{{ end }}
     {{ $isCourseHomePage := (eq .Params.layout "course_home") }}
     {{ if not $isCourseHomePage }}
     <div class="course-info-toggle medium-and-below-only bg-light shadow-sm border border-right-0 rounded-left">
@@ -25,7 +25,7 @@
     {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
     <div class="container-fluid">
       <div class="row outer-wrapper">
-        {{ partialCached "desktop_nav.html" . }}
+        {{ partial "desktop_nav.html" . }}
         <div class="left-col-bg"></div>
         <div id="main-content-wrapper" class="col-lg-9 p-0 bg-white">
           <main>
@@ -42,7 +42,7 @@
                   {{ block "main" . }}{{ end }}
                 </div>
                 {{ if not $isCourseHomePage }}
-                {{ partialCached "desktop_course_info.html" . }}
+                {{ partial "desktop_course_info.html" . }}
                 {{ end }}
               </div>
             </div>
@@ -51,10 +51,10 @@
       </div>
     </div>
     {{ block "footer" . }}{{ partial "footer" . }}{{end}}
-    {{ partialCached "hide_offline_links.html" . }}
+    {{ partial "hide_offline_links.html" . }}
   </div>
-  {{ partialCached "navigation_js.html" . }}
-  {{ partialCached "responsive_tables_js.html" . }}
+  {{ partial "navigation_js.html" . }}
+  {{ partial "responsive_tables_js.html" . }}
   {{- $theme := .Site.Data.webpack.main -}}
   {{- $courseTheme := .Site.Data.webpack.course -}}
 

--- a/course/layouts/home.html
+++ b/course/layouts/home.html
@@ -14,13 +14,13 @@
     <!-- End Google Tag Manager (noscript) -->
   {{ end }}
   <div class="overflow-auto">
-    {{ partialCached "mobile_course_nav.html" . }}
-    {{ partialCached "mobile_course_info.html" . }}
-    {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
+    {{ partial "mobile_course_nav.html" . }}
+    {{ partial "mobile_course_info.html" . }}
+    {{ block "header" . }}{{ partial "header" . }}{{ end }}
     {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
     <div class="container-fluid">
       <div class="row outer-wrapper">
-        {{ partialCached "desktop_nav.html" . }}
+        {{ partial "desktop_nav.html" . }}
         <div class="left-col-bg"></div>
         <div id="main-content-wrapper" class="col-lg-9 p-0 bg-white">
           <main>
@@ -93,10 +93,10 @@
       </div>
     </div>
     {{ block "footer" . }}{{ partial "footer" . }}{{end}}
-    {{ partialCached "hide_offline_links.html" . }}
+    {{ partial "hide_offline_links.html" . }}
   </div>
-  {{ partialCached "navigation_js.html" . }}
-  {{ partialCached "responsive_tables_js.html" . }}
+  {{ partial "navigation_js.html" . }}
+  {{ partial "responsive_tables_js.html" . }}
   {{- $theme := .Site.Data.webpack.main -}}
   {{- $courseTheme := .Site.Data.webpack.course -}}
 

--- a/fields/layouts/home.html
+++ b/fields/layouts/home.html
@@ -3,7 +3,7 @@
 {{ $field := . }}
 <div>
   {{ block "header" . }}
-  {{ partialCached "header" . }}
+  {{ partial "header" . }}
   {{ end }}
   {{ partial "collection_cover_image" $field }}
   <div class="container collection-outer-container standard-width mx-auto mt-5">
@@ -59,7 +59,7 @@
   </script>
 </div>
 {{ block "footer" . }}
-  {{ partialCached "footer" . }}
+  {{ partial "footer" . }}
 {{end}}
 {{ end }}
 {{ end }}

--- a/fields/layouts/subfields/single.html
+++ b/fields/layouts/subfields/single.html
@@ -2,12 +2,12 @@
 {{- $courselist := . -}}
 <div>
   {{ block "header" . }}
-  {{ partialCached "header" . }}
+  {{ partial "header" . }}
   {{ end }}
   <div class="container standard-width mx-auto mt-5">
     {{ partial "course_list" . }}
   </div>
-  {{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+  {{ block "footer" . }} {{ partial "footer" . }} {{end}}
   {{- $staticApiBaseUrl := partial "static_api_base_url.html" -}}
   {{- $courseListData := (slice) -}}
   {{ with $courselist.Params.courses }}

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{ block "header" . }} {{ partialCached "header" . }} {{end}}
+{{ block "header" . }} {{ partial "header" . }} {{end}}
 <div
   id="about-us"
   class="page-single"
@@ -628,5 +628,5 @@
     </div>
   </div>
 </div>
-{{ block "footer" . }} {{ partialCached "footer" . }} {{ end }}
+{{ block "footer" . }} {{ partial "footer" . }} {{ end }}
 {{end}}

--- a/www/layouts/collections/single.html
+++ b/www/layouts/collections/single.html
@@ -2,7 +2,7 @@
 {{- $collection := . -}}
 <div>
   {{ block "header" . }}
-  {{ partialCached "header" . }}
+  {{ partial "header" . }}
   {{ end }}
   {{ partial "collection_cover_image" $collection }}
   <div class="container collection-outer-container standard-width mx-auto mt-5">
@@ -59,6 +59,6 @@
   </script>
 </div>
   {{ block "footer" . }}
-    {{ partialCached "footer" . }}
+    {{ partial "footer" . }}
   {{end}}
 {{ end }}

--- a/www/layouts/contact/section.html
+++ b/www/layouts/contact/section.html
@@ -1,4 +1,4 @@
-{{ define "main" }} {{ block "header" . }} {{ partialCached "header" . }} {{end}}
+{{ define "main" }} {{ block "header" . }} {{ partial "header" . }} {{end}}
 
 <div id="contact-main-section" class="page-single">
   <div class="px-lg-5 px-3 mt-6">
@@ -95,5 +95,5 @@
     </div>
   </div>
 </div>
-{{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+{{ block "footer" . }} {{ partial "footer" . }} {{end}}
 {{ end }}

--- a/www/layouts/course-lists/single.html
+++ b/www/layouts/course-lists/single.html
@@ -2,12 +2,12 @@
 {{- $courselist := . -}}
 <div>
   {{ block "header" . }}
-  {{ partialCached "header" . }}
+  {{ partial "header" . }}
   {{ end }}
   <div class="container standard-width mx-auto mt-5">
     {{ partial "course_list" . }}
   </div>
-  {{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+  {{ block "footer" . }} {{ partial "footer" . }} {{end}}
   {{- $staticApiBaseUrl := partial "static_api_base_url.html" -}}
   {{- $courseListData := (slice) -}}
   {{ with $courselist.Params.courses }}

--- a/www/layouts/educator/section.html
+++ b/www/layouts/educator/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{ block "header" . }} {{ partialCached "header" . }} {{end}}
+{{ block "header" . }} {{ partial "header" . }} {{end}}
 <div id="educator-main-section" class="page-single">
   <nav class="navbar navbar-expand-lg navbar-light bg-white sticky-top on-page-sub-nav">
     <div class="navbar-brand">
@@ -449,5 +449,5 @@
     </div>
   </div>
 </div>
-{{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+{{ block "footer" . }} {{ partial "footer" . }} {{end}}
 {{ end }}

--- a/www/layouts/home.html
+++ b/www/layouts/home.html
@@ -11,7 +11,7 @@
 <div id="home-header">
   {{ block "header" . }}
   {{ $renderSearchIcon := index .Params "renderSearchIcon" | default true }}
-  {{ partialCached "header" . $renderSearchIcon }}
+  {{ partial "header" . $renderSearchIcon }}
   {{ end }}
 </div>
 <div class="d-flex flex-column align-items-center home-banner" style="background-image: url(/images/homepage_hero.jpg);">
@@ -165,5 +165,5 @@
     </div>
   </div>
 </div>
-{{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+{{ block "footer" . }} {{ partial "footer" . }} {{end}}
 {{ end }}

--- a/www/layouts/newsletter/section.html
+++ b/www/layouts/newsletter/section.html
@@ -1,4 +1,4 @@
-{{ define "main" }} {{ block "header" . }} {{ partialCached "header" . }}
+{{ define "main" }} {{ block "header" . }} {{ partial "header" . }}
 {{end}}
 <div id="newsletter-main-section" class="page-single">
   <div class="px-lg-5 px-3 mt-6">
@@ -447,5 +447,5 @@
   </script>
   <!--End mc_embed_signup-->
 </div>
-{{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+{{ block "footer" . }} {{ partial "footer" . }} {{end}}
 {{ end }}

--- a/www/layouts/pages/single.html
+++ b/www/layouts/pages/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="h-100v">
   {{ block "header" . }}
-  {{ partialCached "header" . }}
+  {{ partial "header" . }}
   <div class="d-flex flex-column justify-content-between h-100">
     <div>
       <div class="row mt-6 px-6">
@@ -14,7 +14,7 @@
         {{ .Content }}
       </div>
     </div>
-    {{ block "footer" . }} {{ partialCached "footer" . }} {{ end }}
+    {{ block "footer" . }} {{ partial "footer" . }} {{ end }}
 </div>
 </div>
 {{ end }}

--- a/www/layouts/resource_collections/single.html
+++ b/www/layouts/resource_collections/single.html
@@ -2,7 +2,7 @@
 {{- $collection := . -}}
 <div>
   {{ block "header" . }}
-  {{ partialCached "header" . }}
+  {{ partial "header" . }}
   {{ end }}
   <div class="container standard-width mx-auto mt-5">
     <h1>
@@ -13,7 +13,7 @@
     </div>
     <div id="resource-collection-container"></div>
   </div>
-  {{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+  {{ block "footer" . }} {{ partial "footer" . }} {{end}}
     {{- $staticApiBaseUrl := partial "static_api_base_url.html" -}}
     {{- $contentMap := dict -}}
     {{- $courseJSONMap := dict -}}

--- a/www/layouts/resources/single.html
+++ b/www/layouts/resources/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 {{ block "header" . }}
-  {{ partialCached "header" . }}
+  {{ partial "header" . }}
 {{ end }}
 <div class="container mt-5">
   <div class="rounded mb-2">

--- a/www/layouts/search/section.html
+++ b/www/layouts/search/section.html
@@ -2,7 +2,7 @@
 <div class="search-wrapper">
   {{ block "header" . }}
   {{ $renderSearchIcon := index .Params "renderSearchIcon" | default true }}
-  {{ partialCached "header" . $renderSearchIcon }}
+  {{ partial "header" . $renderSearchIcon }}
   {{ end }}
   <div class="container-fluid">
     <main>

--- a/www/layouts/stories/list.html
+++ b/www/layouts/stories/list.html
@@ -3,7 +3,7 @@
 {{- $stories := where $pages "Type" "==" "stories" -}}
 <div>
   {{ block "header" . }}
-  {{ partialCached "header" . }}
+  {{ partial "header" . }}
   {{end}}
   <div class="testimonial-section container standard-width mx-auto mt-5 mb-5">
     <h1>OCW Stories</h1>
@@ -34,6 +34,6 @@
       {{ end }}
     </div>
   </div>
-  {{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+  {{ block "footer" . }} {{ partial "footer" . }} {{end}}
 </div>
 {{ end }}

--- a/www/layouts/stories/single.html
+++ b/www/layouts/stories/single.html
@@ -2,7 +2,7 @@
 {{- $story := . -}}
 <div>
   {{ block "header" . }}
-  {{ partialCached "header" . }}
+  {{ partial "header" . }}
   {{ end }}
   <div class="testimonial-single container standard-width mx-auto mt-5 mb-5">
     <h1>OCW Stories</h1>
@@ -26,6 +26,6 @@
       {{ .Content }}
     </div>
   </div>
-  {{ block "footer" . }} {{ partialCached "footer" . }} {{end}}
+  {{ block "footer" . }} {{ partial "footer" . }} {{end}}
 </div>
 {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1043

#### What's this PR do?
This PR removes the use of `partialCached` where we call partials and replaces that with simply `partial`. `partialCached` was originally introduced back in `hugo-course-publisher` (https://github.com/mitodl/hugo-course-publisher/pull/393) when we were attempting to build all OCW courses as one Hugo site. The performance gains you get from this are very minimal, when the Hugo build is already a small percentage of the time it takes a course build to run. The performance issues we were having at the time were more related to trying to build way too big of a Hugo site. With course builds isolated to individual Hugo builds, the recursive nav is not nearly as big of a problem. The build time is indeed reduced when using `partialCached`, but we're talking on the level of milliseconds. In my testing, courses that saw a ~600ms build time with `partialCached` took around 1200ms to build, so about double the time but the build time was already really low.

The reason behind removing the usage of `partialCached` has to do with the efforts in https://github.com/mitodl/ocw-hugo-themes/issues/1013 to consolidate the differences between the online and offline themes when it comes to URL rendering. We want to turn on relative URLs for all builds to make the HTML more portable. With `partialCached` being used with relative URLs, you end up with incorrect URLs in partials like the left nav. Another option here would be increasing the specificity of the cache key, but ultimately the partial would have to be re-rendered anyway when the URLs end up being different, which they will at each level of subdirectory beyond the root with `relativeUrls` turned on. The already marginal gains will be even more marginal. I think at least at first when turning on relative URLs, we should completely remove `partialCached` and maybe reintroduce it again at a later point if we can find a spot where it will give us significant gains without causing issues with incorrect URLs.

#### How should this be manually tested?
 - Clone the `cg/unified-build` branch of `ocw-hugo-projects` and point to it in your `.env`
 - Start up any course with a multi tiered nav with `yarn start course` (I used `OCW_TEST_COURSE=8.701-fall-2020`)
 - Browse to the site at http://localhost:3000 and click around the items on the nav. You will notice that the nav highlighting doesn't work currently with `relativeUrls` turned on , but clicking the nav items should at least bring you to the correct page.
 - Switch back to the `main` branch in `ocw-hugo-projects`
 - Go back to the site and all the links should still function, and nav highlighting should work again

#### Any background context you want to provide?
I noticed this issue while prototyping the move to relative URLs in https://github.com/mitodl/ocw-hugo-themes/pull/1041/. I started rendering relative URLs and on sub pages the wrong amount of `../` would be used to step back to the root on subpages, almost like the nav was being cached on another page and re-used when it shouldn't be because the URLs were different. Initially, removing the usage of `partialCached` solved this problem. Upon further testing, I was unable to reproduce this issue by pointing `ocw-hugo-themes` to `main` with `relativeUrls: true` still turned on. I'm keeping this PR open in case we need it, but I need to do further testing to ensure that we aren't ditching `partialCached` for no reason. It's important to be extra sure that this issue will not show itself because if it does there will be incorrect URLs everywhere which would be very bad.
