### PR TITLE
Deduplicate webpack assets

### DIFF
--- a/base-theme/assets/index.ts
+++ b/base-theme/assets/index.ts
@@ -1,5 +1,4 @@
 import "./css/main.scss"
-import "video.js/dist/video-js.css"
 
 import "bootstrap"
 import Popper from "popper.js"

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -139,19 +139,15 @@ const config: webpack.Configuration = {
   ),
   optimization: {
     splitChunks:  {
-      name:        "common",
       minChunks:   2,
       cacheGroups: {
-        shared: {
-          test: /[\\/]node_modules[\\/]/,
-          name(module, chunks, cacheGroupKey) {
-            const chunkNames = chunks.map(item => item.name)
-            if (chunkNames.includes(entryNames.www)) {
-              return `${cacheGroupKey}_www`
-            }
-            return cacheGroupKey
-          },
-          chunks: 'all',
+        common: {
+          test:   /[\\/]node_modules[\\/]/,
+          name:   "common",
+          chunks: chunk => {
+            const splitChunks = [entryNames.www, entryNames.courseV2]
+            return splitChunks.includes(chunk.name)
+          }
         }
       }
     },

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -13,16 +13,31 @@ import packageJson from "../../../package.json"
 const fromRoot = (pathFromRoot: string) =>
   path.resolve(__dirname, "../../../", pathFromRoot)
 
+const entryNames = {
+  courseV1: "course_v1",
+  courseV2: "course_v2",
+  www:       "www",
+  fields:    "fields"
+}
+
 const config: webpack.Configuration = {
   resolve: {
     // Add `.ts` and `.tsx` as a resolvable extension.
     extensions: [".ts", ".tsx", ".js"]
   },
   entry: {
-    main:                fromRoot("./base-theme/assets/index.ts"),
-    course_v2:           fromRoot("./course-v2/assets/course-v2.ts"),
-    www:                 fromRoot("./www/assets/www.tsx"),
-    fields:              fromRoot("./fields/assets/fields.js")
+    [entryNames.courseV2]: [
+      fromRoot("./course-v2/assets/course-v2.ts"),
+      fromRoot("./base-theme/assets/index.ts"),
+    ],
+    [entryNames.www]: [
+      fromRoot("./www/assets/www.tsx"),
+      fromRoot("./base-theme/assets/index.ts"),
+    ],
+    [entryNames.fields]: [
+      fromRoot("./fields/assets/fields.js"),
+      fromRoot("./base-theme/assets/index.ts"),
+    ]
   },
 
   output: {
@@ -121,7 +136,26 @@ const config: webpack.Configuration = {
         openAnalyzer: true
       }) :
       []
-  )
+  ),
+  optimization: {
+    splitChunks:  {
+      name:        "common",
+      minChunks:   2,
+      cacheGroups: {
+        shared: {
+          test: /[\\/]node_modules[\\/]/,
+          name(module, chunks, cacheGroupKey) {
+            const chunkNames = chunks.map(item => item.name)
+            if (chunkNames.includes(entryNames.www)) {
+              return `${cacheGroupKey}_www`
+            }
+            return cacheGroupKey
+          },
+          chunks: 'all',
+        }
+      }
+    },
+  }
 }
 
 export default config

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -21,7 +21,6 @@ const config: webpack.Configuration = {
   entry: {
     main:                fromRoot("./base-theme/assets/index.ts"),
     course_v2:           fromRoot("./course-v2/assets/course-v2.ts"),
-    instructor_insights: fromRoot("./course-v2/assets/instructor-insights.js"),
     www:                 fromRoot("./www/assets/www.tsx"),
     fields:              fromRoot("./fields/assets/fields.js")
   },

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -14,9 +14,10 @@ const fromRoot = (pathFromRoot: string) =>
   path.resolve(__dirname, "../../../", pathFromRoot)
 
 const entryNames = {
-  courseV2: "course_v2",
-  www:      "www",
-  fields:   "fields"
+  instructorInsights: "instructor_insights",
+  courseV2:           "course_v2",
+  www:                "www",
+  fields:             "fields"
 }
 
 const config: webpack.Configuration = {
@@ -28,6 +29,9 @@ const config: webpack.Configuration = {
     [entryNames.courseV2]: [
       fromRoot("./course-v2/assets/course-v2.ts"),
       fromRoot("./base-theme/assets/index.ts")
+    ],
+    [entryNames.instructorInsights]: [
+      fromRoot("./course-v2/assets/css/instructor-insights.scss")
     ],
     [entryNames.www]: [
       fromRoot("./www/assets/www.tsx"),

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -14,7 +14,6 @@ const fromRoot = (pathFromRoot: string) =>
   path.resolve(__dirname, "../../../", pathFromRoot)
 
 const entryNames = {
-  courseV1: "course_v1",
   courseV2: "course_v2",
   www:      "www",
   fields:   "fields"

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -16,8 +16,8 @@ const fromRoot = (pathFromRoot: string) =>
 const entryNames = {
   courseV1: "course_v1",
   courseV2: "course_v2",
-  www:       "www",
-  fields:    "fields"
+  www:      "www",
+  fields:   "fields"
 }
 
 const config: webpack.Configuration = {
@@ -28,15 +28,15 @@ const config: webpack.Configuration = {
   entry: {
     [entryNames.courseV2]: [
       fromRoot("./course-v2/assets/course-v2.ts"),
-      fromRoot("./base-theme/assets/index.ts"),
+      fromRoot("./base-theme/assets/index.ts")
     ],
     [entryNames.www]: [
       fromRoot("./www/assets/www.tsx"),
-      fromRoot("./base-theme/assets/index.ts"),
+      fromRoot("./base-theme/assets/index.ts")
     ],
     [entryNames.fields]: [
       fromRoot("./fields/assets/fields.js"),
-      fromRoot("./base-theme/assets/index.ts"),
+      fromRoot("./base-theme/assets/index.ts")
     ]
   },
 
@@ -138,7 +138,7 @@ const config: webpack.Configuration = {
       []
   ),
   optimization: {
-    splitChunks:  {
+    splitChunks: {
       minChunks:   2,
       cacheGroups: {
         common: {
@@ -150,7 +150,7 @@ const config: webpack.Configuration = {
           }
         }
       }
-    },
+    }
   }
 }
 

--- a/base-theme/layouts/partials/head.html
+++ b/base-theme/layouts/partials/head.html
@@ -15,8 +15,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   {{ block "seo" . }}{{ end }}
   <title>{{ block "title" . }}{{ end }}</title>
-  {{ $theme := .Site.Data.webpack.main }}
-  {{ partial "include_css.html" (dict "context" . "url" $theme.css) }}
+  {{ $css_urls := slice .Site.Data.webpack.common.css }}
+  {{ partial "include_css.html" (dict "context" . "urls" $css_urls) }}
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">
   <style>
   @font-face {

--- a/base-theme/layouts/partials/include_css.html
+++ b/base-theme/layouts/partials/include_css.html
@@ -1,5 +1,7 @@
 {{ $context := .context }}
 {{ $urls := .urls }}
 {{ range $url := $urls }}
-    <link href="{{ partial "webpack_url.html" (dict "context" $context "url" $url) }}" rel="stylesheet">
+    {{ with $url }}
+    <link href="{{ partial "webpack_url.html" (dict "context" $context "url" . ) }}" rel="stylesheet">
+    {{ end }}
 {{ end }}

--- a/base-theme/layouts/partials/include_css.html
+++ b/base-theme/layouts/partials/include_css.html
@@ -1,11 +1,3 @@
 {{ $context := .context }}
 {{ $url := .url }}
-{{ $type := (printf "%T" $url) }}
-{{ if eq $type "[]interface {}" }}
-{{ with index $url 0 }}
-<link href="{{ partial "webpack_url.html" (dict "context" $context "url" .) }}" rel="stylesheet">
-{{ end }}
-{{ end }}
-{{ if eq $type "string" }}
 <link href="{{ partial "webpack_url.html" (dict "context" $context "url" $url) }}" rel="stylesheet">
-{{ end }}

--- a/base-theme/layouts/partials/include_css.html
+++ b/base-theme/layouts/partials/include_css.html
@@ -1,3 +1,5 @@
 {{ $context := .context }}
-{{ $url := .url }}
-<link href="{{ partial "webpack_url.html" (dict "context" $context "url" $url) }}" rel="stylesheet">
+{{ $urls := .urls }}
+{{ range $url := $urls }}
+    <link href="{{ partial "webpack_url.html" (dict "context" $context "url" $url) }}" rel="stylesheet">
+{{ end }}

--- a/base-theme/layouts/partials/include_js.html
+++ b/base-theme/layouts/partials/include_js.html
@@ -1,5 +1,7 @@
 {{ $context := .context }}
 {{ $urls := .urls }}
 {{ range $url := $urls }}
-    <script src="{{ partial "webpack_url.html" (dict "context" $context "url" $url) }}"></script>
+    {{ with $url }}
+    <script src="{{ partial "webpack_url.html" (dict "context" $context "url" . ) }}"></script>
+    {{ end }}
 {{ end }}

--- a/base-theme/layouts/partials/include_js.html
+++ b/base-theme/layouts/partials/include_js.html
@@ -1,3 +1,5 @@
 {{ $context := .context }}
-{{ $url := .url }}
-<script src="{{ partial "webpack_url.html" (dict "context" $context "url" $url) }}"></script>
+{{ $urls := .urls }}
+{{ range $url := $urls }}
+    <script src="{{ partial "webpack_url.html" (dict "context" $context "url" $url) }}"></script>
+{{ end }}

--- a/base-theme/layouts/partials/include_js.html
+++ b/base-theme/layouts/partials/include_js.html
@@ -1,11 +1,3 @@
 {{ $context := .context }}
 {{ $url := .url }}
-{{ $type := (printf "%T" $url) }}
-{{ if eq $type "[]interface {}" }}
-{{ with index $url 0 }}
-<script src="{{ partial "webpack_url.html" (dict "context" $context "url" .) }}"></script>
-{{ end }}
-{{ end }}
-{{ if eq $type "string" }}
 <script src="{{ partial "webpack_url.html" (dict "context" $context "url" $url) }}"></script>
-{{ end }}

--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -20,6 +20,7 @@ import {
   checkAnswer,
   showSolution
 } from "./js/quiz_multiple_choice"
+import "video.js/dist/video-js.css"
 import "videojs-youtube"
 
 $(function() {

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -20,7 +20,6 @@
 @import "topic";
 @import "learning-resource-types";
 @import "course-image-section";
-@import "instructor-insights";
 
 html {
   font-size: $course-font-root !important;

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -20,6 +20,7 @@
 @import "topic";
 @import "learning-resource-types";
 @import "course-image-section";
+@import "instructor-insights";
 
 html {
   font-size: $course-font-root !important;

--- a/course-v2/assets/instructor-insights.js
+++ b/course-v2/assets/instructor-insights.js
@@ -1,1 +1,0 @@
-import "./css/instructor-insights.scss"

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -178,13 +178,12 @@
 
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
-  {{- $theme := .Site.Data.webpack.main -}}
-  {{- $courseTheme := .Site.Data.webpack.course_v2 -}}
-  {{ partial "include_js.html" (dict "context" . "url" $theme.js) }}
-  {{ partial "include_js.html" (dict "context" . "url" $courseTheme.js) }}
+  {{- $webpack := .Site.Data.webpack -}}
+  {{- $js_urls := slice $webpack.common.js $webpack.course_v2.js -}}
+  {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
   <!-- Appzi: Capture Insightful Feedback -->
   {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
-
+  
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
 
   <!-- End Appzi -->

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -183,7 +183,7 @@
   {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
   <!-- Appzi: Capture Insightful Feedback -->
   {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
-  
+
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
 
   <!-- End Appzi -->

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -43,13 +43,11 @@
   </div>
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
-  {{- $theme := .Site.Data.webpack.main -}}
-  {{- $courseTheme := .Site.Data.webpack.course_v2 -}}
 
-  {{ partial "include_js.html" (dict "context" . "url" $theme.js) }}
-  {{ partial "include_js.html" (dict "context" . "url" $courseTheme.js) }}
+  {{- $webpack := .Site.Data.webpack -}}
+  {{- $js_urls := slice $webpack.common.js $webpack.course_v2.js -}}
+  {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
   <!-- Appzi: Capture Insightful Feedback -->
-
   {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
 

--- a/course-v2/layouts/partials/extrahead.html
+++ b/course-v2/layouts/partials/extrahead.html
@@ -1,10 +1,6 @@
 {{- define "title" -}}{{ partial "title.html" . }}{{- end -}}
 {{- define "extrahead" -}}
 {{- $layout := .Params.layout -}}
-{{- $instructorInsights := .Site.Data.webpack.instructor_insights -}}
 {{- $courseTheme := .Site.Data.webpack.course_v2 -}}
-{{- if eq $layout "instructor_insights" -}}
-{{ partial "include_css.html" (dict "context" . "url" $instructorInsights.css) }}
-{{- end -}}
 {{ partial "include_css.html" (dict "context" . "url" $courseTheme.css) }}
 {{- end -}}

--- a/course-v2/layouts/partials/extrahead.html
+++ b/course-v2/layouts/partials/extrahead.html
@@ -1,6 +1,6 @@
 {{- define "title" -}}{{ partial "title.html" . }}{{- end -}}
 {{- define "extrahead" -}}
 {{- $layout := .Params.layout -}}
-{{- $courseTheme := .Site.Data.webpack.course_v2 -}}
-{{ partial "include_css.html" (dict "context" . "url" $courseTheme.css) }}
+{{- $css_urls := slice .Site.Data.webpack.course_v2.css }}
+{{ partial "include_css.html" (dict "context" . "urls" $css_urls) }}
 {{- end -}}

--- a/course-v2/layouts/partials/extrahead.html
+++ b/course-v2/layouts/partials/extrahead.html
@@ -1,6 +1,9 @@
 {{- define "title" -}}{{ partial "title.html" . }}{{- end -}}
 {{- define "extrahead" -}}
-{{- $layout := .Params.layout -}}
 {{- $css_urls := slice .Site.Data.webpack.course_v2.css }}
+{{- $layout := .Params.layout -}}
+{{- if eq $layout "instructor_insights" -}}
+    {{- $css_urls = $css_urls | append .Site.Data.webpack.instructor_insights.css -}}
+{{- end -}}
 {{ partial "include_css.html" (dict "context" . "urls" $css_urls) }}
 {{- end -}}

--- a/fields/layouts/_default/baseof.html
+++ b/fields/layouts/_default/baseof.html
@@ -13,9 +13,10 @@
       {{ block "notification" . }}{{ partial "notification" . }}{{ end }}
       {{ block "main" . }}{{ end }}
     </div>
-    {{ $main := .Site.Data.webpack.main }}
+    {{- $webpack := .Site.Data.webpack -}}
+    {{- $js_urls := slice $webpack.common.js -}}
     {{ block "extrajs" . }}{{ end }}
-    {{ partial "include_js.html" (dict "context" . "url" $main.js) }}
+    {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
     <!-- Appzi: Capture Insightful Feedback -->
 
     <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>

--- a/fields/layouts/partials/extrahead.html
+++ b/fields/layouts/partials/extrahead.html
@@ -1,9 +1,8 @@
 {{ define "title" }}{{ partial "title.html" . }}{{ end }}
 {{ define "extrahead" }}
-{{ $wwwTheme := .Site.Data.webpack.www }}
-{{ $fieldsTheme := .Site.Data.webpack.fields }}
-{{ partial "include_css.html" (dict "context" . "url" $wwwTheme.css) }}
-{{ partial "include_css.html" (dict "context" . "url" $fieldsTheme.css) }}
+{{ $webpack := .Site.Data.webpack }}
+{{ $css_urls := slice $webpack.www.css $webpack.fields.css }}
+{{ partial "include_css.html" (dict "context" . "urls" $css_urls) }}
 <link
 href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css"
 rel="stylesheet"

--- a/fields/layouts/partials/extrajs.html
+++ b/fields/layouts/partials/extrajs.html
@@ -1,6 +1,5 @@
 {{- define "extrajs" -}}
-{{- $www := .Site.Data.webpack.www -}}
-{{- $fields := .Site.Data.webpack.fields -}}
-{{ partial "include_js.html" (dict "context" . "url" $www.js) }}
-{{ partial "include_js.html" (dict "context" . "url" $fields.js) }}
+{{- $webpack := .Site.Data.webpack -}}
+{{- $js_urls := slice $webpack.fields.js $webpack.www.js -}}
+{{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
 {{- end -}}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,9 @@ const config: PlaywrightTestConfig = {
   ],
   webServer: {
     command:             "yarn start:webpack",
-    url:                 `http://0.0.0.0:${env.WEBPACK_PORT}/static_shared/css/main.css`,
+    // This just needs to be some address that returns 200 when webpack has finished compiling.
+    // It finishes all the files concurrently, so any file will work fine.
+    url:                 `http://0.0.0.0:${env.WEBPACK_PORT}/static_shared/js/www.js`,
     reuseExistingServer: !process.env.CI
   },
   globalSetup: path.resolve(__dirname, "./tests-e2e/global-setup.ts")

--- a/www/layouts/_default/baseof.html
+++ b/www/layouts/_default/baseof.html
@@ -13,9 +13,10 @@
       {{ block "notification" . }}{{ partial "notification" . }}{{ end }}
       {{ block "main" . }}{{ end }}
     </div>
-    {{ $main := .Site.Data.webpack.main }}
+    {{- $webpack := .Site.Data.webpack -}}
+    {{- $js_urls := slice $webpack.common.js -}}
     {{ block "extrajs" . }}{{ end }}
-    {{ partial "include_js.html" (dict "context" . "url" $main.js) }}
+    {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
     <!-- Appzi: Capture Insightful Feedback -->
     {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
     <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>

--- a/www/layouts/partials/extrahead.html
+++ b/www/layouts/partials/extrahead.html
@@ -1,7 +1,7 @@
 {{ define "title" }}{{ partial "title.html" . }}{{ end }}
 {{ define "extrahead" }}
-{{ $wwwTheme := .Site.Data.webpack.www }}
-{{ partial "include_css.html" (dict "context" . "url" $wwwTheme.css) }}
+{{ $css_urls := slice .Site.Data.webpack.www.css }}
+{{ partial "include_css.html" (dict "context" . "urls" $css_urls ) }}
 <link
 href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css"
 rel="stylesheet"

--- a/www/layouts/partials/extrajs.html
+++ b/www/layouts/partials/extrajs.html
@@ -1,4 +1,5 @@
 {{- define "extrajs" -}}
-{{- $www := .Site.Data.webpack.www -}}
-{{ partial "include_js.html" (dict "context" . "url" $www.js) }}
+{{- $webpack := .Site.Data.webpack -}}
+{{- $js_urls := slice $webpack.www.js -}}
+{{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
 {{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/1033

#### What's this PR do?
This PR changes how we share common resources between different pages on OCW. The overall approach is to make it less manual and have webpack do more code splitting automatically. See file comments for more, and comments in https://github.com/mitodl/ocw-hugo-themes/issues/1033 for some background.

#### How should this be manually tested?
There should be no noticeable change in behavior, other than smaller bundles. Some things you might do:
- run `yarn start www` and make sure things look ok
- run `yarn start course` and make sure things look ok
    - check that videos work!
- run `rm -rf base-theme/dist && WEBPACK_ANALYZE=true  NODE_ENV=production yarn build:webpack` and check out the production bundles

#### More Details

The files that were loaded before/after on sites are (before gzip):
```
# BEFORE.... v1.82, commit cc68e3e
course pages:
    course_v2.css   198 kb     ⌉___ first bundle
    course_v2.js    866 kb     ⌋
    main.css        220 kb     ⌉____ second bundle
    main.js         323 kb     ⌋

www pages:
    www.css        580 kb     ⌉___ first bundle
    www.js         228 kb     ⌋
    main.css       220 kb     ⌉____ second bundle
    main.js        323 kb     ⌋

# NOW:
course pages:
    course_v2.css  260 kb        ⌉
    course_v2.js   778 kb        |--- single bundle
    common.js      250 kb        ⌋

www pages:
    www.css        229 kb       ⌉
    www.js         391 kb       |--- single bundle
    common.js      250 kb       ⌋
```
A roughly 35% decrease in www js/css asset size, and 20% in course. Neat.
