### PR TITLE
Changed course number detail colour to white for better contarst

### DIFF
--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -45,7 +45,7 @@ html {
 
   .course-number-term-detail {
     font-size: $font-sm;
-    color: $light-blue;
+    color: $white;
   }
 
   a {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1035 

#### What's this PR do?
updates colour of course number and term to white for better contrast.

#### How should this be manually tested?
- Run lighthouse on course theme.
- Verify it does not report contrast issue

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2023-01-26 at 7 00 46 PM" src="https://user-images.githubusercontent.com/87968618/214855422-dd181fdd-d4c5-41fb-9445-a93a19a165f4.png">
