### PR TITLE
add ocw-course-v3 and course-offline-v2

### DIFF
--- a/course-offline-v2/course_home_page_url.html
+++ b/course-offline-v2/course_home_page_url.html
@@ -1,0 +1,2 @@
+{{ $pathToRoot := partial "path_to_root.html" . }}
+{{ return (printf "%s/index.html" (strings.TrimSuffix "/" $pathToRoot)) }}

--- a/course-offline-v2/get_destination.html
+++ b/course-offline-v2/get_destination.html
@@ -1,0 +1,11 @@
+{{ $destination := .Destination }}
+{{ $isInternalLink := not (strings.HasPrefix $destination "http") }}
+{{ $isExternalCourseLink := strings.HasPrefix $destination "/courses" }}
+{{ if $isInternalLink }}
+  {{ if $isExternalCourseLink }}
+    {{ $destination = partial "site_root_url.html" $destination }}
+  {{ else }}
+    {{ $destination = printf "%s/index.html" (strings.TrimSuffix "/" $destination) }}
+  {{ end }}
+{{ end }}
+{{ return $destination }}

--- a/course-offline-v2/get_search_url.html
+++ b/course-offline-v2/get_search_url.html
@@ -1,0 +1,2 @@
+{{ $baseUrl := partial "static_api_base_url.html" }}
+{{ return print (strings.TrimSuffix "/" $baseUrl) "/search?" (querify (index site.Data.search_query_keys .key) .value) }}

--- a/course-offline-v2/nav_url.html
+++ b/course-offline-v2/nav_url.html
@@ -1,0 +1,7 @@
+{{ $url := .menuItem.URL }}
+{{ $noHttpPrefix := not (strings.HasPrefix $url "http") }}
+{{ $noHtmlSuffix := not (strings.HasSuffix $url ".html") }}
+{{ if and $noHttpPrefix $noHtmlSuffix }}
+  {{ $url = printf "%s/index.html" (strings.TrimSuffix "/" $url) }}
+{{ end }}
+{{ return $url }}

--- a/course-offline-v2/page_url.html
+++ b/course-offline-v2/page_url.html
@@ -1,0 +1,2 @@
+{{ $pathToRoot := partial "path_to_root.html" .context }}
+{{ return printf "%s/%s/index.html" (strings.TrimSuffix "/" $pathToRoot) (strings.TrimSuffix "/" (strings.TrimPrefix "/" .url)) }}

--- a/course-offline-v2/path_to_root.html
+++ b/course-offline-v2/path_to_root.html
@@ -1,0 +1,11 @@
+{{- $parsedUrl := urls.Parse .RelPermalink -}}
+{{- $slashCount := strings.Count "/" .RelPermalink -}}
+{{- $pathToRoot := "" -}}
+{{- if gt $slashCount 1 -}}
+  {{- range seq (sub $slashCount 1) -}}
+    {{- $pathToRoot = $pathToRoot | print "../" -}}
+  {{- end -}}
+{{- else -}}
+  {{- $pathToRoot = "./" -}}
+{{- end -}}
+{{ return $pathToRoot }}

--- a/course-offline-v2/resource_url.html
+++ b/course-offline-v2/resource_url.html
@@ -1,0 +1,4 @@
+{{ $pathToRoot := partial "path_to_root.html" .context }}
+{{ $resourcePath := (urls.Parse .url).Path }}
+{{ $resourceFileName := path.Base $resourcePath }}
+{{ return (printf "%s/static_resources/%s" (strings.TrimSuffix "/" $pathToRoot) $resourceFileName) }}

--- a/course-offline-v2/site_root_url.html
+++ b/course-offline-v2/site_root_url.html
@@ -1,0 +1,2 @@
+{{ $baseUrl := partial "static_api_base_url.html" }}
+{{ return print (strings.TrimSuffix "/" $baseUrl) . }}

--- a/course-offline-v2/video_captions_file_url.html
+++ b/course-offline-v2/video_captions_file_url.html
@@ -1,0 +1,1 @@
+{{ return partial "site_root_url.html" .url }}

--- a/course-offline-v2/webpack_url.html
+++ b/course-offline-v2/webpack_url.html
@@ -1,0 +1,2 @@
+{{ $pathToRoot := partial "path_to_root.html" .context }}
+{{return (printf "%s/%s" (strings.TrimSuffix "/" $pathToRoot) (strings.TrimPrefix "/" .url)) -}}

--- a/course-v3/assets/course-v2.ts
+++ b/course-v3/assets/course-v2.ts
@@ -1,0 +1,38 @@
+import "../../node_modules/nanogallery2/src/css/nanogallery2.css"
+
+import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
+import "nanogallery2/src/jquery.nanogallery2.core.js"
+
+import "./css/course-v2.scss"
+
+import { initDivToggle } from "./js/div_toggle"
+import {
+  initCourseInfoExpander,
+  initCourseDescriptionExpander
+} from "./js/course_expander"
+import { initVideoTranscriptTrack } from "./js/video_transcript_track"
+import { initPlayBackSpeedButton } from "./js/video_playback_speed"
+import { initVideoFullscreenToggle } from "./js/video_fullscreen_toggle"
+import { initDownloadButton } from "./js/video-download-button"
+import { initCourseDrawersClosingViaSwiping } from "./js/mobile_course_drawers"
+import {
+  clearSolution,
+  checkAnswer,
+  showSolution
+} from "./js/quiz_multiple_choice"
+import "video.js/dist/video-js.css"
+import "videojs-youtube"
+
+$(function() {
+  initCourseDescriptionExpander(document)
+  initCourseInfoExpander(document)
+  initDownloadButton()
+  initPlayBackSpeedButton()
+  initVideoTranscriptTrack()
+  initDivToggle()
+  clearSolution()
+  checkAnswer()
+  showSolution()
+  initVideoFullscreenToggle()
+  initCourseDrawersClosingViaSwiping()
+})

--- a/course-v3/assets/css/course-content.scss
+++ b/course-v3/assets/css/course-content.scss
@@ -1,0 +1,39 @@
+#course-title.collapse:not(.show) {
+  display: block;
+  height: 5.5em;
+  overflow: hidden;
+}
+
+#course-title.collapsing {
+  height: 5.5em;
+}
+
+.course-content-title {
+  font-size: $font-xl;
+
+  @include media-breakpoint-down(xs) {
+    font-size: $font-lg !important;
+  }
+}
+
+.course-content-parent-title {
+  font-size: $font-lg;
+  @include media-breakpoint-down(xs) {
+    font-size: $font-md !important;
+  }
+}
+
+th,
+td {
+  > p:empty {
+    display: none;
+  }
+}
+
+td {
+  h3 {
+    font-weight: normal !important;
+    font-style: italic !important;
+    font-family: arial, helvetica, sans-serif !important;
+  }
+}

--- a/course-v3/assets/css/course-home.scss
+++ b/course-v3/assets/css/course-home.scss
@@ -1,0 +1,63 @@
+.course-home-page {
+  background-color: $light-gray;
+
+  #course-main-content {
+    max-width: $max-content-width;
+    margin: 0 auto;
+    padding: 1.5rem 2.5rem 4rem 2.5rem !important;
+  }
+
+  .course-home-grid {
+    padding-left: 10px !important;
+    padding-right: 10px !important;
+  }
+
+  @include media-breakpoint-down(sm) {
+    .course-cards {
+      flex-flow: column-reverse;
+    }
+
+    .course-home-grid {
+      padding-left: 5px !important;
+      padding-right: 5px !important;
+    }
+  }
+
+  .card {
+    border-radius: 0px;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.16);
+    border: 0px;
+    height: 100%;
+  }
+
+  .container-fluid {
+    max-width: $max-content-width;
+  }
+
+  .course-home-section {
+    padding: 20px 40px 0px 40px;
+
+    @include media-breakpoint-down(md) {
+      padding: 30px;
+    }
+
+    &.in-panel {
+      padding: 0;
+    }
+
+    a {
+      text-decoration: none;
+    }
+
+    .other-version-list {
+      a {
+        text-decoration: underline;
+        color: $blue;
+      }
+
+      li {
+        padding-bottom: 4px;
+      }
+    }
+  }
+}

--- a/course-v3/assets/css/course-image-section.scss
+++ b/course-v3/assets/css/course-image-section.scss
@@ -1,0 +1,17 @@
+.course-image-section-container {
+  .course-image-container {
+    overflow: hidden;
+
+    .course-image {
+      object-fit: contain;
+      border: 1px solid $medium-gray;
+      width: 100%;
+    }
+
+    .course-image-caption {
+      font-size: $font-sm;
+      margin-top: 10px;
+      line-height: 1.2;
+    }
+  }
+}

--- a/course-v3/assets/css/course-info.scss
+++ b/course-v3/assets/css/course-info.scss
@@ -1,0 +1,58 @@
+$panel-course-info-text-color: #464646;
+
+.course-info {
+  .course-info-content {
+    margin-top: 5px;
+  }
+}
+
+.panel-course-info-title {
+  font-size: $font-sm;
+  text-transform: uppercase;
+  font-weight: bold;
+  color: $panel-course-info-text-color !important;
+}
+
+.panel-course-info-text {
+  font-size: $font-sm;
+  color: $panel-course-info-text-color !important;
+  a {
+    color: $panel-course-info-text-color !important;
+  }
+}
+
+.close-course-info {
+  margin-left: auto;
+  background-color: $course-info-btn-color !important;
+  border-radius: 0px !important;
+}
+
+.close-course-info:hover {
+  background-color: $course-info-btn-hover-color !important;
+}
+
+.show-course-info {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: $course-info-btn-color !important;
+  border-radius: 0px !important;
+}
+
+.show-course-info:hover {
+  background-color: $course-info-btn-hover-color !important;
+}
+
+.close-mobile-course-info {
+  position: absolute;
+  right: 0;
+}
+
+.download-course-link-button {
+  border-color: $blue !important;
+  color: $blue !important;
+}
+
+.download-course-link-button:hover {
+  color: $white !important;
+}

--- a/course-v3/assets/css/course-nav.scss
+++ b/course-v3/assets/css/course-nav.scss
@@ -1,0 +1,52 @@
+nav {
+  display: block !important;
+}
+
+.course-nav {
+  a {
+    text-decoration: none;
+
+    &.active {
+      font-weight: 600;
+      color: $highlight-red !important;
+    }
+  }
+}
+
+.desktop-nav {
+  @include media-breakpoint-up(xl) {
+    max-width: $desktop-nav-max-width;
+  }
+}
+
+.mobile-course-nav-toggle-btn {
+  border: 1px solid $mobile-menu-btn-color;
+  color: $mobile-menu-btn-color;
+  border-radius: 15px;
+  padding: 3px 15px 3px 10px;
+  background: none;
+}
+
+.mobile-course-info-toggle-btn {
+  color: $mobile-menu-btn-color;
+}
+
+.course-nav-text-wrapper {
+  width: 100%;
+}
+
+.course-nav-section-toggle > i:after {
+  content: "keyboard_arrow_down";
+}
+
+.course-nav-section-toggle[aria-expanded="true"] > i:after {
+  content: "keyboard_arrow_up" !important;
+}
+
+.course-nav-child-nav {
+  list-style: none;
+}
+
+.course-nav-child-nav > li {
+  padding-right: 0 !important;
+}

--- a/course-v3/assets/css/course-resources.scss
+++ b/course-v3/assets/css/course-resources.scss
@@ -1,0 +1,83 @@
+h4 {
+  color: $highlight-red !important;
+}
+
+.download-course-container {
+  border-radius: 3px;
+
+  .download-course-button {
+    display: inline-flex;
+    height: fit-content;
+    padding: 10px 22px;
+    border-radius: 4px;
+    background-color: $blue;
+    color: white;
+    text-decoration: none;
+  }
+}
+
+.resource-list-toggle {
+  .collapsed {
+    border-bottom: 1px solid $border-gray;
+  }
+
+  a {
+    display: block;
+  }
+
+  a,
+  a:hover {
+    text-decoration: none;
+  }
+
+  a.collapsed i:before {
+    content: "keyboard_arrow_right";
+  }
+
+  a:not(.collapsed) i:before {
+    content: "keyboard_arrow_down";
+  }
+
+  i {
+    font-size: 2rem;
+    vertical-align: middle;
+  }
+
+  h4 {
+    display: inline;
+  }
+}
+
+.resource-list-item {
+  .resource-thumbnail {
+    height: 38px;
+    width: 32px;
+  }
+
+  .see-all-resources-icon {
+    display: inline-flex;
+    vertical-align: top;
+    margin-left: 5px;
+  }
+
+  .resource-download {
+    padding: 3px;
+    border: solid 0.5px $medium-gray;
+    border-radius: 20px;
+    margin-left: -12px;
+    margin-top: 13px;
+    background-color: $white;
+  }
+
+  .resource-download:hover {
+    background-color: $light-gray;
+  }
+
+  .resource-list-title {
+    text-decoration: none;
+  }
+
+  .resource-list-title:hover {
+    text-decoration: underline;
+  }
+}

--- a/course-v3/assets/css/course-v2.scss
+++ b/course-v3/assets/css/course-v2.scss
@@ -1,0 +1,151 @@
+@import "../../../base-theme/assets/css/imports/reset";
+@import "../../../base-theme/assets/css/bootstrap-overrides";
+@import "../../../base-theme/assets/css/breakpoints";
+@import "../../../base-theme/assets/css/variables";
+@import "~bootstrap/scss/bootstrap";
+@import "~offcanvas-bootstrap/src/sass/bootstrap.offcanvas";
+
+@import "course-nav";
+@import "course-info";
+@import "course-home";
+@import "drawer";
+@import "tables";
+@import "video";
+@import "videojs_player";
+@import "resource-page";
+@import "video-transcript";
+@import "course-content";
+@import "course-resources";
+@import "partial-collapse-list";
+@import "topic";
+@import "learning-resource-types";
+@import "course-image-section";
+
+html {
+  font-size: $course-font-root !important;
+}
+
+// TODO: This conditional rendering of logos should be removed when we completely move to the new course theme.
+#ocw-logo-white {
+  display: none;
+}
+
+#ocw-logo-white-v2 {
+  display: block !important;
+}
+
+#course-banner {
+  color: $white;
+  background-color: $blue;
+
+  .course-banner-content {
+    max-width: $max-content-width;
+    padding: 1.5rem 3rem !important;
+  }
+
+  .course-number-term-detail {
+    font-size: $font-sm;
+    color: $light-blue;
+  }
+
+  a {
+    text-decoration: none;
+    font-size: $font-xxxl;
+    font-weight: 400;
+  }
+}
+
+.font-black {
+  color: black !important;
+}
+
+#course-main-content article.content {
+  a:link {
+    color: $course-content-link-unclicked;
+  }
+
+  a:visited,
+  a:hover,
+  a:active {
+    color: $course-content-link-hover-clicked;
+  }
+}
+
+div[class^="toggle"]:not(.toggle-visible),
+span[class^="toggle"]:not(.toggle-visible) {
+  display: none;
+}
+
+div[class^="reveal"],
+.multiple-choice-check-button,
+.multiple-choice-show-button {
+  color: #115f83;
+  cursor: pointer;
+}
+
+.correctness-icon-correct {
+  color: green;
+}
+
+.correctness-icon-wrong {
+  color: red;
+}
+
+.correctness-icon {
+  position: relative;
+  top: 6px;
+}
+
+.multiple-choice-radio {
+  margin-top: 11px;
+  margin-bottom: 11px;
+}
+
+.multiple_choice_buttons {
+  margin: 10px;
+}
+
+pre {
+  padding: 10px;
+  border: 1px solid $medium-gray;
+}
+
+.collapse-btn-section {
+  a.collapsed span:after {
+    content: "keyboard_arrow_down";
+  }
+
+  a:not(.collapsed) span:after {
+    content: "keyboard_arrow_up";
+  }
+}
+
+.course-detail-section {
+  margin-bottom: 40px;
+}
+
+.course-detail-title {
+  font-weight: bold;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+// TODO: overriding some css of header and footer in this new theme
+// when we roll out this theme completely then we can move this css to thier respective files in base-theme
+
+#desktop-header {
+  height: $desktop-header-height-v2 !important;
+  .contents {
+    padding: 0 2rem !important;
+  }
+}
+
+#footer-container {
+  padding: 2rem 2rem !important;
+
+  .row {
+    max-width: $max-content-width !important;
+    width: 100% !important;
+    margin: 0 auto !important;
+  }
+}

--- a/course-v3/assets/css/drawer.scss
+++ b/course-v3/assets/css/drawer.scss
@@ -1,0 +1,8 @@
+.drawer {
+  background: white;
+  max-width: 50% !important;
+
+  @include media-breakpoint-down(xs) {
+    max-width: 75% !important;
+  }
+}

--- a/course-v3/assets/css/instructor-insights.scss
+++ b/course-v3/assets/css/instructor-insights.scss
@@ -1,0 +1,55 @@
+@import "../../../base-theme/assets/css/variables.scss";
+#course-content-section {
+  p {
+    margin-bottom: 1.25rem;
+  }
+
+  .quotewrapper {
+    margin: 0;
+    line-height: 1.75em;
+  }
+
+  .quotewrapper blockquote,
+  figcaption {
+    font-family: "Helvetica-Oblique", "Helvetica", sans-serif;
+    font-style: italic;
+    margin: 0;
+  }
+
+  .quotewrapper blockquote.quote {
+    font-size: 1.5em;
+    font-weight: bold;
+    color: $medium-gray;
+  }
+
+  .quotewrapper .sigwrapper {
+    display: flex;
+  }
+
+  .quotewrapper figcaption.sig {
+    margin-left: auto;
+    text-transform: uppercase;
+    order: 2;
+    font-size: 1.25em;
+  }
+
+  .approx-students {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: $highlight-red;
+    border-radius: 50%;
+    h1 {
+      margin-top: 0.75rem;
+      margin-bottom: 0;
+    }
+
+    h1,
+    h2 {
+      color: $white !important;
+      text-transform: none !important;
+      user-select: none;
+    }
+  }
+}

--- a/course-v3/assets/css/learning-resource-types.scss
+++ b/course-v3/assets/css/learning-resource-types.scss
@@ -1,0 +1,15 @@
+.learning-resource-type-item {
+  border: 1px solid #bcbcbc;
+  border-radius: 15px;
+  box-sizing: border-box;
+  font-size: $font-sm;
+  padding: 3px 8px 3px 8px;
+
+  .material-icons {
+    font-size: 20px;
+  }
+}
+
+.learning-resource-type-item:hover {
+  border: 1px solid $dark-gray;
+}

--- a/course-v3/assets/css/partial-collapse-list.scss
+++ b/course-v3/assets/css/partial-collapse-list.scss
@@ -1,0 +1,70 @@
+.partial-collapse-overlay {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  z-index: 1;
+  background-size: cover;
+  @include media-breakpoint-up(lg) {
+    background: linear-gradient(transparent, transparent, $white) no-repeat
+      center;
+  }
+  @include media-breakpoint-down(md) {
+    background: linear-gradient(transparent, transparent, $light-gray) no-repeat
+      center;
+  }
+}
+
+.partial-collapse.collapse.show ~ .partial-collapse-overlay,
+.partial-collapse.collapsing ~ .partial-collapse-overlay {
+  display: none;
+}
+
+.partial-collapse-toggle-link {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  pointer-events: all;
+  z-index: 2;
+}
+
+.partial-collapse-icon-container {
+  position: absolute;
+  height: $partial-collapse-height;
+  width: 100%;
+  pointer-events: none;
+}
+
+.partial-collapse-icon {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 0;
+  pointer-events: all;
+}
+
+.partial-collapse-icon > i:after {
+  content: "expand_more";
+}
+
+.partial-collapse-toggle-link[aria-expanded="true"]
+  > .partial-collapse-icon-container
+  > .partial-collapse-icon
+  > i:after {
+  content: "expand_less" !important;
+}
+
+.partial-collapse.collapse:not(.show) {
+  display: block;
+  height: $partial-collapse-height;
+  overflow: hidden;
+}
+
+.partial-collapse.collapsing {
+  height: $partial-collapse-height;
+}
+
+.partial-collapse.collapse.show > ul > li > a.partial-collapse-link {
+  position: relative;
+  z-index: 3;
+}

--- a/course-v3/assets/css/resource-page.scss
+++ b/course-v3/assets/css/resource-page.scss
@@ -1,0 +1,9 @@
+.resource-page {
+  .row {
+    min-height: 60px;
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+}

--- a/course-v3/assets/css/tables.scss
+++ b/course-v3/assets/css/tables.scss
@@ -1,0 +1,63 @@
+/* 
+  responsive table css based on:
+  https://css-tricks.com/responsive-data-tables/
+  https://elvery.net/demo/responsive-tables/#no-more-tables
+*/
+@mixin mobile-table {
+  // Force table to not be like tables anymore
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr {
+    display: block;
+  }
+
+  // Hide table headers (but not display: none;, for accessibility)
+  thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+
+  tr {
+    border: 1px solid #ccc;
+  }
+
+  td {
+    border: none;
+    border-bottom: 1px solid #eee;
+  }
+
+  td:before {
+    /* 
+      The data-title attribute is written in using the table's headings
+      See responsive_tables.js for more info
+    */
+    content: attr(data-title);
+    font-weight: bold;
+  }
+}
+
+#course-main-content {
+  thead th,
+  td {
+    vertical-align: middle !important;
+  }
+
+  tr {
+    td:empty {
+      display: none;
+    }
+  }
+
+  @media only screen and (max-width: 760px),
+    (min-device-width: 768px) and (max-device-width: 1024px) {
+    @include mobile-table;
+  }
+}
+
+.mobile-table {
+  @include mobile-table;
+}

--- a/course-v3/assets/css/topic.scss
+++ b/course-v3/assets/css/topic.scss
@@ -1,0 +1,16 @@
+.topic-toggle {
+  position: absolute;
+  height: 26px;
+  top: 50%;
+  transform: translateY(-50%);
+  left: 0;
+  pointer-events: all;
+}
+
+.topic-toggle > i:after {
+  content: "chevron_right";
+}
+
+.topic-toggle[aria-expanded="true"] > i:after {
+  content: "expand_more" !important;
+}

--- a/course-v3/assets/css/video-transcript.scss
+++ b/course-v3/assets/css/video-transcript.scss
@@ -1,0 +1,42 @@
+.transcript {
+  width: 100%;
+  margin: auto;
+  font-family: Arial, sans-serif;
+}
+
+.transcript-body {
+  width: 100%;
+  height: 200px;
+  overflow-y: scroll;
+}
+
+.transcript-line {
+  position: relative;
+  padding: 5px 0px 5px 0px;
+  cursor: pointer;
+  line-height: 1.3;
+}
+
+.transcript-timestamp {
+  display: inline-block;
+  position: absolute;
+}
+
+.transcript-text {
+  display: block;
+  margin-left: 50px;
+  margin-right: 10px;
+}
+
+.transcript-text:empty {
+  height: 20px;
+}
+
+.transcript-line:hover {
+  background-color: $medium-gray;
+}
+
+.transcript-line.is-active {
+  font-weight: bold;
+  color: $orange;
+}

--- a/course-v3/assets/css/video.scss
+++ b/course-v3/assets/css/video.scss
@@ -1,0 +1,144 @@
+.video-gallery-card {
+  a {
+    user-select: none;
+    text-decoration: none;
+
+    .inner-container {
+      display: flex;
+      justify-content: space-between;
+      background-color: white;
+      color: black;
+      padding: 10px;
+      margin: 0;
+      text-align: left;
+      width: 100%;
+      cursor: pointer;
+
+      .left-col {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        position: relative;
+        margin-right: 10px;
+
+        img.thumbnail {
+          border-radius: 5px;
+
+          @include media-breakpoint-down(md) {
+            border-radius: 0px;
+          }
+        }
+
+        img.youtube-logo-overlay {
+          position: absolute;
+          opacity: 0.3;
+          left: 0;
+          top: 0;
+          transform: scale(0.62);
+          width: 100%;
+          height: 100%;
+        }
+      }
+
+      .right-col {
+        position: relative;
+        margin-left: 10px;
+        width: 100%;
+
+        .video-title {
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+        }
+      }
+    }
+  }
+}
+
+.video-embed {
+  max-width: $video-section-max-width;
+}
+
+.embedded-video-container {
+  // this padding will be applied when video is embedded
+  padding-bottom: 44px;
+  background-color: $light-gray;
+}
+
+.video-page {
+  max-width: $video-section-max-width;
+
+  .video-container {
+    height: 0;
+    padding-bottom: 56% !important;
+    margin-bottom: 44px;
+    position: relative;
+    max-width: 100%;
+  }
+
+  .video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.video-buttons-container {
+  background-color: $light-gray;
+  overflow: hidden;
+  margin-bottom: 35px;
+}
+
+.video-download-container {
+  float: right;
+  padding-top: 25px;
+  padding-bottom: 25px;
+  padding-right: 25px;
+}
+
+.video-download-button {
+  float: right;
+  font-size: $font-sm;
+  color: white;
+}
+
+a.video-download-button:visited {
+  color: white;
+}
+
+.video-page-link-section {
+  padding: 5px 15px 5px;
+  display: inline-flex;
+}
+
+.video-page-link {
+  text-decoration: none;
+  color: $black !important;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.video-page-link:hover {
+  text-decoration: none !important;
+}
+
+#course-main-content a.download-file.video-download-button:link {
+  color: white;
+}
+
+#course-main-content a.download-file.video-download-button:visited {
+  color: white;
+}
+
+@include media-breakpoint-down(md) {
+  .video-download-container {
+    padding-top: 15px;
+    padding-bottom: 15px;
+    padding-right: 15px;
+  }
+  .video-download-container:first-child {
+    padding-bottom: 0px;
+  }
+}

--- a/course-v3/assets/css/videojs_player.scss
+++ b/course-v3/assets/css/videojs_player.scss
@@ -1,0 +1,166 @@
+// color variables
+$control-item-color: $dark-gray;
+$control-item-bg-color: $light-gray;
+$slider-color: $pink;
+
+.vjs-ocw.video-js {
+  .ytp-chrome-top-buttons {
+    display: none;
+  }
+  .vjs-big-play-button {
+    font-size: 4em;
+  }
+
+  button {
+    font-size: 1.5em;
+  }
+
+  .vjs-control-bar {
+    height: 4.4em;
+    background-color: $control-item-bg-color;
+    color: $control-item-color;
+    transition: visibility 2s, opacity 0.1s;
+    bottom: auto;
+    display: flex;
+  }
+
+  .vjs-menu-content {
+    background-color: $control-item-bg-color !important;
+  }
+
+  .vjs-volume-bar {
+    margin: 2.1em 0.45em;
+  }
+
+  .vjs-control {
+    min-width: 3.5em;
+  }
+
+  .vjs-volume-panel {
+    min-width: 50px;
+  }
+
+  .vjs-volume-level {
+    background-color: $control-item-color;
+  }
+
+  .vjs-progress-control {
+    position: absolute;
+    bottom: 37px;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 10px;
+
+    .vjs-progress-holder {
+      color: $slider-color;
+      font-size: 1.5em;
+      margin: 0 !important;
+    }
+
+    .vjs-play-progress,
+    .vjs-slider-bar {
+      background-color: $slider-color;
+    }
+
+    .vjs-progress-holder,
+    .vjs-play-progress,
+    .vjs-load-progress,
+    .vjs-load-progress div {
+      border-radius: 6px;
+    }
+
+    .vjs-play-progress:before {
+      right: -0.9em !important;
+    }
+  }
+
+  .vjs-time-control {
+    font-size: 1.4em;
+    padding-left: 0.3em;
+    padding-right: 0.3em;
+
+    @include media-breakpoint-down(xs) {
+      display: none !important;
+    }
+  }
+
+  .vjs-duration,
+  .vjs-time-divider,
+  .vjs-current-time {
+    display: block;
+  }
+
+  .vjs-time-divider {
+    min-width: 1em;
+  }
+
+  .vjs-remaining-time,
+  .vjs-picture-in-picture-control {
+    display: none;
+  }
+
+  .vjs-fullscreen-control {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+  }
+
+  .vjs-subs-caps-button {
+    position: absolute;
+    right: 25px;
+    bottom: 0;
+  }
+
+  .vjs-quality-selector {
+    position: absolute;
+    right: 100px;
+
+    .vjs-icon-placeholder::before {
+      font-family: "Material Icons";
+      content: "\e8b8";
+    }
+  }
+
+  .vjs-download-button {
+    .vjs-icon-placeholder::before {
+      font-family: "Material Icons";
+      content: "\e258";
+    }
+    .vjs-icon-placeholder::after {
+      font-family: "Material Icons";
+      content: "\e5c5";
+      margin-left: 15px;
+    }
+  }
+
+  .vjs-menu-button-popup {
+    .vjs-menu {
+      width: 15em;
+    }
+  }
+  .playback-button-position {
+    position: absolute;
+    right: -1rem;
+
+    .vjs-menu-content {
+      right: 100px;
+      margin: 10px;
+      box-shadow: 5px 5px 10px;
+    }
+  }
+
+  .download-button-position {
+    position: absolute;
+    right: 9rem;
+
+    .vjs-menu-content {
+      box-shadow: 5px 5px 10px;
+      margin: 10px;
+
+      li {
+        text-transform: capitalize;
+      }
+    }
+  }
+}

--- a/course-v3/assets/js/course_expander.test.ts
+++ b/course-v3/assets/js/course_expander.test.ts
@@ -1,0 +1,81 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { JSDOM } from "jsdom"
+
+import { initCourseInfoExpander } from "./course_expander"
+
+describe("initCourseInfoExpander", () => {
+  let html
+
+  beforeEach(() => {
+    html = `<body>
+    <div class="course-description expand-container collapsed">
+      <div class="course-info expand-container collapsed">
+        <a class="expand-link course-info-link" aria-expanded="false">
+          <h4>Course Info</h4>
+          <span class="expander-arrow material-icons">keyboard_arrow_right</span>
+        </a>
+      </div>
+      <button class="expand-link read-more" aria-expanded="false">
+        <span class="read-more-text">Read More</span>
+      </button>
+    </div>
+    </body>`
+  })
+
+  const assertExpanded = (button, expanded) => {
+    const container = button.closest(".expand-container")
+    expect(button.getAttribute("aria-expanded")).toBe(String(expanded))
+    expect(button.classList.contains("expanded")).toBe(expanded)
+    expect(container.classList.contains("collapsed")).toBe(!expanded)
+    const readmore = button.querySelector(".read-more-text")
+    if (readmore) {
+      expect(readmore.textContent).toBe(expanded ? "Show Less" : "Read More")
+    }
+    const arrow = button.querySelector(".expander-arrow")
+    if (arrow) {
+      expect(arrow.textContent).toBe(
+        expanded ? "keyboard_arrow_down" : "keyboard_arrow_right"
+      )
+    }
+  }
+
+  const toggleButton = (button, isMouseClick, window) => {
+    if (isMouseClick) {
+      button.click()
+    } else {
+      const event = new window.KeyboardEvent("keypress", {
+        key:     "Enter",
+        bubbles: true
+      })
+      button.dispatchEvent(event)
+    }
+  }
+
+  //
+  ;[true, false].forEach(isReadMore => {
+    [true, false].forEach(isMouseClick => {
+      it(`toggles the ${isReadMore ? "read more" : "course info"} link by ${
+        isMouseClick ? "click" : "enter"
+      }`, () => {
+        const { window } = new JSDOM(html)
+        const document = window.document
+        initCourseInfoExpander(document)
+        const buttonSelectors = [".read-more", ".course-info-link"]
+        const selector = isReadMore ? ".read-more" : ".course-info-link"
+        const button = document.querySelector(selector)
+        const otherButton = document.querySelector(
+          buttonSelectors.find(_selector => _selector !== selector)
+        )
+        assertExpanded(button, false)
+        assertExpanded(otherButton, false)
+        toggleButton(button, isMouseClick, window)
+        assertExpanded(button, true)
+        assertExpanded(otherButton, false)
+        toggleButton(button, isMouseClick, window)
+        assertExpanded(button, false)
+        assertExpanded(otherButton, false)
+      })
+    })
+  })
+})

--- a/course-v3/assets/js/course_expander.ts
+++ b/course-v3/assets/js/course_expander.ts
@@ -1,0 +1,72 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+const toggleExpand = (button, container) => {
+  const expanded = button.classList.contains("expanded")
+  const readmoreText = button.querySelector(".read-more-text")
+  const arrow = button.querySelector(".expander-arrow")
+  if (expanded) {
+    button.classList.remove("expanded")
+    button.setAttribute("aria-expanded", "false")
+    container.classList.add("collapsed")
+    if (arrow) {
+      arrow.textContent = "keyboard_arrow_right"
+    }
+  } else {
+    button.classList.add("expanded")
+    button.setAttribute("aria-expanded", "true")
+    container.classList.remove("collapsed")
+    if (arrow) {
+      arrow.textContent = "keyboard_arrow_down"
+    }
+  }
+
+  if (readmoreText) {
+    readmoreText.textContent = expanded ? "Read More" : "Show Less"
+  }
+}
+
+const initCourseInfoExpander = document => {
+  for (const expanderButton of document.querySelectorAll(".expand-link")) {
+    const container = expanderButton.closest(".expand-container")
+    expanderButton.addEventListener("click", event => {
+      event.preventDefault()
+      toggleExpand(expanderButton, container)
+    })
+    expanderButton.addEventListener("keypress", event => {
+      if (event.key === "Enter") {
+        event.preventDefault()
+        toggleExpand(expanderButton, container)
+      }
+    })
+  }
+}
+
+const initCourseDescriptionExpander = document => {
+  const courseDescription = document.getElementById("course-description")
+  if (courseDescription) {
+    const collapsedDescription = courseDescription.querySelector(
+      "#collapsed-description"
+    )
+    const expandedDescription = courseDescription?.querySelector(
+      "#expanded-description"
+    )
+    if (collapsedDescription && expandedDescription) {
+      const expandLink = collapsedDescription.querySelector(
+        "#expand-description"
+      )
+      const collapseLink = expandedDescription.querySelector(
+        "#collapse-description"
+      )
+      expandLink.addEventListener("click", () => {
+        collapsedDescription.classList.add("d-none")
+        expandedDescription.classList.remove("d-none")
+      })
+      collapseLink.addEventListener("click", () => {
+        collapsedDescription.classList.remove("d-none")
+        expandedDescription.classList.add("d-none")
+      })
+    }
+  }
+}
+
+export { initCourseInfoExpander, initCourseDescriptionExpander }

--- a/course-v3/assets/js/div_toggle.js
+++ b/course-v3/assets/js/div_toggle.js
@@ -1,0 +1,17 @@
+export const initDivToggle = () => {
+  const revealElements = document.querySelectorAll("[class*=reveal]")
+  for (const reveal of Array.from(revealElements)) {
+    for (const elementClass of Array.from(reveal.classList)) {
+      if (elementClass.match(/^reveal/)) {
+        reveal.addEventListener("click", () => {
+          const revealId = elementClass.replace("reveal", "")
+
+          const hideables = document.getElementsByClassName(`toggle${revealId}`)
+          for (const hidable of Array.from(hideables)) {
+            hidable.classList.toggle("toggle-visible")
+          }
+        })
+      }
+    }
+  }
+}

--- a/course-v3/assets/js/mobile_course_drawers.ts
+++ b/course-v3/assets/js/mobile_course_drawers.ts
@@ -1,0 +1,55 @@
+enum SwipeDirection {
+  Left = "L",
+  Right = "R"
+}
+
+export const initCourseDrawersClosingViaSwiping = () => {
+  enableSwiping(
+    "mobile-course-nav",
+    "mobile-course-nav-toggle",
+    SwipeDirection.Left
+  )
+  enableSwiping(
+    "course-info-drawer",
+    "mobile-course-info-toggle",
+    SwipeDirection.Right
+  )
+}
+
+/**
+ * It adds touch event listener to the element and clicks the button when swiped in the mentioned direction.
+ *
+ * @param {string} elementId element on which touch eventlistenter is added.
+ * @param {string} buttonId This button will be clicked on swiping
+ * @param {string} swipeDirection L= Swipe left, R= Swipe Right
+ */
+const enableSwiping = (
+  elementId: string,
+  buttonId: string,
+  swipeDirection: SwipeDirection
+) => {
+  const element = document.getElementById(elementId)
+  if (!element) throw Error(`Element having ID: ${elementId} does not exist`)
+
+  let touchstartX = 0
+  let touchendX = 0
+
+  element.addEventListener("touchstart", e => {
+    touchstartX = e.changedTouches[0].screenX
+  })
+
+  element.addEventListener("touchend", e => {
+    touchendX = e.changedTouches[0].screenX
+    if (
+      (swipeDirection === SwipeDirection.Right && touchendX > touchstartX) ||
+      (swipeDirection === SwipeDirection.Left && touchendX < touchstartX)
+    ) {
+      const buttonElement = document.getElementById(buttonId)
+      if (!buttonElement) {
+        throw Error(`Button element having ID: ${buttonId} does not exist`)
+      }
+
+      buttonElement.click()
+    }
+  })
+}

--- a/course-v3/assets/js/navigation.js
+++ b/course-v3/assets/js/navigation.js
@@ -1,0 +1,52 @@
+// @ts-expect-error TODO
+function expandNav(navItemEl, collapseEl) {
+  collapseEl.classList.add("show")
+  navItemEl
+    .querySelector(".course-nav-section-toggle, video-tab-toggle-section")
+    .setAttribute("aria-expanded", "true")
+}
+
+function courseNav() {
+  document
+    .querySelectorAll(".course-nav, .transcript-header")
+    .forEach(navEl => {
+      // set .active on the currently active link
+      navEl.querySelectorAll(".nav-link").forEach(navLinkEl => {
+        const navLink = navLinkEl.getAttribute("href") ?
+          navLinkEl.getAttribute("href") :
+          ""
+        if (
+          // @ts-expect-error TODO
+          navLink.replace(/\/$/, "") ===
+          window.location.pathname.replace(/\/$/, "")
+        ) {
+          navLinkEl.classList.add("active")
+          // @ts-expect-error TODO
+          const uuid = navLinkEl.dataset.uuid
+          const navItemEl = navLinkEl.closest(".course-nav-list-item")
+          const collapseEl = navItemEl?.querySelector(".collapse")
+          const sectionToggles = Array.prototype.filter.call(
+            document.querySelectorAll(".course-nav-section-toggle"),
+            node => {
+              return node.dataset.uuid === uuid
+            }
+          )
+          // if this is a parent item, expand its children
+          if (navItemEl && collapseEl && sectionToggles.length > 0) {
+            expandNav(navItemEl, collapseEl)
+          }
+        }
+      })
+
+      const activeEl = navEl.querySelector("a.nav-link.active")
+
+      // iterate through nav items, find any that are parents of the active link, expanded if needed
+      navEl.querySelectorAll(".course-nav-list-item").forEach(navItemEl => {
+        const collapseEl = navItemEl.querySelector(".collapse")
+        if (collapseEl && collapseEl.contains(activeEl)) {
+          expandNav(navItemEl, collapseEl)
+        }
+      })
+    })
+}
+courseNav()

--- a/course-v3/assets/js/quiz_multiple_choice.js
+++ b/course-v3/assets/js/quiz_multiple_choice.js
@@ -1,0 +1,60 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+export const clearSolution = () => {
+  const radioElements = document.getElementsByClassName("multiple-choice-radio")
+  for (const radio of radioElements) {
+    radio.addEventListener("click", () => {
+      Array.from(
+        radio.closest("fieldset").getElementsByClassName("correctness-icon")
+      ).forEach(solution => {
+        solution.classList.remove("toggle-visible")
+      })
+    })
+  }
+}
+
+export const checkAnswer = () => {
+  Array.from(
+    document.getElementsByClassName("multiple-choice-check-button")
+  ).forEach(button => {
+    button.addEventListener("click", () => {
+      Array.from(
+        button
+          .closest(".multiple-choice-question")
+          .getElementsByClassName("multiple-choice-radio")
+      ).forEach(input => {
+        if (input.checked) {
+          input
+            .closest("div")
+            .getElementsByClassName("correctness-icon")[0]
+            .classList.add("toggle-visible")
+        }
+      })
+    })
+  })
+}
+
+export const showSolution = () => {
+  Array.from(
+    document.getElementsByClassName("multiple-choice-show-button")
+  ).forEach(button => {
+    button.addEventListener("click", () => {
+      const solutionShown = button
+        .closest(".multiple-choice-question")
+        .getElementsByClassName("multiple-choice-solution")[0]
+        .classList.toggle("toggle-visible")
+
+      if (solutionShown) {
+        button
+          .closest(".multiple-choice-question")
+          .getElementsByClassName("correctness-icon-correct")[0]
+          .classList.add("toggle-visible")
+      } else {
+        button
+          .closest(".multiple-choice-question")
+          .getElementsByClassName("correctness-icon-correct")[0]
+          .classList.remove("toggle-visible")
+      }
+    })
+  })
+}

--- a/course-v3/assets/js/responsive_tables.ts
+++ b/course-v3/assets/js/responsive_tables.ts
@@ -1,0 +1,47 @@
+const getTables = () =>
+  document.querySelectorAll<HTMLElement>("#course-content-section table")
+const getCourseContent = () => document.getElementById("course-content-section")
+
+function initResponsiveTables2() {
+  const tables = getTables()
+  const mainContent = getCourseContent()
+  if (!mainContent) return
+  if (!window.ResizeObserver) return
+
+  const observer = new ResizeObserver(() => calculateOverlap2())
+  observer.observe(mainContent)
+  tables.forEach(table => {
+    const headings = table.getElementsByTagName("th")
+    const rows = table.querySelectorAll("table tr")
+    // set data-title attribute on table cells
+    rows.forEach(row => {
+      const cells = row.querySelectorAll("td")
+      cells.forEach((cell, i) => {
+        if (headings.length >= i + 1) {
+          cells[i].dataset["title"] = headings[i].innerText.trim().concat(": ")
+        }
+      })
+    })
+  })
+}
+
+function calculateOverlap2() {
+  const tables = getTables()
+  const mainContent = getCourseContent()
+  if (!mainContent) return
+
+  tables.forEach(table => {
+    const mainRect = mainContent.getBoundingClientRect()
+    const tableMinWidth = +(table.dataset.minWidth ?? 0)
+    if (mainRect.width > tableMinWidth) {
+      table.classList.remove("mobile-table")
+    }
+    const tableRect = table.getBoundingClientRect()
+    if (tableRect.right > mainRect.right) {
+      table.dataset.minWidth = `${tableRect.width}`
+      table.classList.add("mobile-table")
+    }
+  })
+}
+
+initResponsiveTables2()

--- a/course-v3/assets/js/video-download-button.js
+++ b/course-v3/assets/js/video-download-button.js
@@ -1,0 +1,83 @@
+//@ts-nocheck
+import videojs from "video.js"
+
+function _createDownloadMenuItems() {
+  const MenuItems = videojs.getComponent("MenuItem")
+  const DownloadMenuItems = videojs.extend(MenuItems, {
+    constructor: function(player, options) {
+      options.selectable = false
+      MenuItems.call(this, player, options)
+    },
+    handleClick: function() {
+      window.open(this.options_.link, "_black").focus()
+    }
+  })
+  MenuItems.registerComponent("DownloadMenuItems", DownloadMenuItems)
+}
+
+function _createDownloadbutton() {
+  const MenuButton = videojs.getComponent("MenuButton")
+  const DownloadMenuButton = videojs.extend(MenuButton, {
+    constructor: function(player, options) {
+      this.label = document.createElement("span")
+      this.values = options.values
+      options.label = "download options"
+
+      MenuButton.call(this, player, options)
+      this.$("button").classList.add("vjs-download-button")
+      this.el().setAttribute("aria-label", "download button")
+      this.el().classList.add("download-button-position")
+      this.controlText("download button")
+    },
+    createItems: function() {
+      const menuItems = []
+      const DownloadMenuItems = videojs.getComponent("DownloadMenuItems")
+      this.values
+        .filter(item => item[1])
+        .map(item => {
+          menuItems.push(
+            new DownloadMenuItems(this.player_, {
+              label: item[0],
+              link:  item[1]
+            })
+          )
+        })
+      return menuItems
+    }
+  })
+  MenuButton.registerComponent("DownloadMenuButton", DownloadMenuButton)
+}
+
+export function initDownloadButton() {
+  _createDownloadMenuItems()
+  _createDownloadbutton()
+
+  const DownloadMenuButton = videojs.getComponent("DownloadMenuButton")
+
+  if (document.querySelector(".video-container")) {
+    const videoPlayers = document.querySelectorAll(".vjs-ocw")
+    for (const videoPlayer of Array.from(videoPlayers)) {
+      const player = videojs(videoPlayer.id)
+      const videoDownloadLink =
+        videoPlayer.getAttribute("data-downloadlink") ?? false
+      const transcriptDownloadLink =
+        videoPlayer.getAttribute("data-transcriptLink") ?? false
+      const options = [
+        ["Download video", videoDownloadLink],
+        ["Download transcript", transcriptDownloadLink]
+      ]
+      player.ready(() => {
+        const downloadButton = new DownloadMenuButton(player, {
+          values: options
+        })
+        player.controlBar.downloadButton = player.controlBar.el_.insertBefore(
+          downloadButton.el_,
+          player.controlBar.getChild("fullscreenToggle").el_
+        )
+        player.controlBar.downloadButton.dispose = function() {
+          this.parentNode.removeChild(this)
+        }
+      })
+    }
+  }
+}

--- a/course-v3/assets/js/video_fullscreen_toggle.js
+++ b/course-v3/assets/js/video_fullscreen_toggle.js
@@ -1,0 +1,23 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+export const initVideoFullscreenToggle = () => {
+  // this fixes the issue of control bar going to the top on fullscreen
+  $(document).on(
+    "mozfullscreenchange webkitfullscreenchange fullscreenchange",
+    function() {
+      const fullscreenElement =
+        document.fullscreenElement ||
+        document.mozFullScreenElement ||
+        document.webkitFullscreenElement ||
+        document.msFullscreenElement
+      if (fullscreenElement) {
+        // entering full screen
+        $(".vjs-control-bar").css("bottom", 0)
+      } else {
+        // exiting full screen
+        $(".vjs-control-bar").css("bottom", "auto")
+      }
+    }
+  )
+}

--- a/course-v3/assets/js/video_playback_speed.js
+++ b/course-v3/assets/js/video_playback_speed.js
@@ -1,0 +1,85 @@
+//@ts-nocheck
+import videojs from "video.js"
+
+function _initMenuItems() {
+  const MenuItems = videojs.getComponent("MenuItem")
+  const SettingMenuItems = videojs.extend(MenuItems, {
+    constructor: function(player, options) {
+      options.selectable = true
+      MenuItems.call(this, player, options)
+      player.on("onPlaybackRateChange", videojs.bind(this, this.update))
+    },
+    handleClick: function() {
+      this.player_.tech_.ytPlayer.setPlaybackRate(this.options_.label)
+      this.player_.currentPlaybackRate = this.options_.label
+      this.player_.trigger("onPlaybackRateChange")
+    },
+    update: function() {
+      const selection = this.player_.currentPlaybackRate
+      this.selected(this.options_.label === selection)
+    }
+  })
+  MenuItems.registerComponent("SettingMenuItems", SettingMenuItems)
+}
+
+function _initMenuButton() {
+  const MenuButton = videojs.getComponent("MenuButton")
+  const SettingMenuButton = videojs.extend(MenuButton, {
+    constructor: function(player, options) {
+      this.label = document.createElement("span")
+      this.playbackSpeeds = options.playbackSpeeds
+      options.label = "playback speed"
+
+      MenuButton.call(this, player, options)
+      this.$("button").classList.add("vjs-quality-selector")
+      this.el().setAttribute("aria-label", "playback speed")
+      this.el().classList.add("playback-button-position")
+      this.controlText("playback speed")
+    },
+    createItems: function() {
+      const menuItems = []
+      const SettingMenuItems = videojs.getComponent("SettingMenuItems")
+      this.playbackSpeeds.map(item => {
+        menuItems.push(
+          new SettingMenuItems(this.player_, {
+            label:    item,
+            selected: item === this.player_.playbackRate()
+          })
+        )
+      })
+      return menuItems
+    }
+  })
+
+  // ready function
+  MenuButton.registerComponent("SettingMenuButton", SettingMenuButton)
+}
+
+export const initPlayBackSpeedButton = () => {
+  _initMenuItems()
+  _initMenuButton()
+
+  const SettingMenuButton = videojs.getComponent("SettingMenuButton")
+
+  if (document.querySelector(".video-container")) {
+    const videoPlayers = document.querySelectorAll(".vjs-ocw")
+    for (const videoPlayer of Array.from(videoPlayers)) {
+      const player = videojs(videoPlayer.id)
+      player.ready(function() {
+        const playbackRates = [0.25, 0.5, 0.75, 1, 1.25, 1.5]
+        const menuButton = new SettingMenuButton(player, {
+          playbackSpeeds: playbackRates,
+          title:          "Playback speed"
+        })
+        player.controlBar.resolutionSwitcher =
+          player.controlBar.el_.insertBefore(
+            menuButton.el_,
+            player.controlBar.el().lastChild.nextSibling
+          )
+        player.controlBar.resolutionSwitcher.dispose = function() {
+          this.parentNode.removeChild(this)
+        }
+      })
+    }
+  }
+}

--- a/course-v3/assets/js/video_transcript_track.js
+++ b/course-v3/assets/js/video_transcript_track.js
@@ -1,0 +1,35 @@
+import videojs from "video.js"
+
+export const initVideoTranscriptTrack = () => {
+  if (document.querySelector(".video-container")) {
+    const videoPlayers = document.querySelectorAll(".vjs-ocw")
+
+    for (const videoPlayer of Array.from(videoPlayers)) {
+      videojs(videoPlayer.id).ready(function() {
+        // @ts-expect-error TODO
+        window.videojs = videojs
+        require("videojs-transcript-ac")
+
+        const options = {
+          showTitle:         false,
+          showTrackSelector: false
+        }
+
+        // @ts-expect-error TODO
+        const transcript = this.transcript(options)
+
+        if (videoPlayer.closest(".video-page")) {
+          // @ts-expect-error TODO
+          const transcriptContainer = videoPlayer
+            .closest(".video-page")
+            .querySelector(".transcript")
+            ?.querySelector(".video-tab-content-section")
+
+          if (transcriptContainer) {
+            transcriptContainer.appendChild(transcript.el())
+          }
+        }
+      })
+    }
+  }
+}

--- a/course-v3/content/learning_resource_types/_index.md
+++ b/course-v3/content/learning_resource_types/_index.md
@@ -1,0 +1,5 @@
+---
+title: Resources
+url: /download/
+kind: taxonomy
+---

--- a/course-v3/content/resources/_index.md
+++ b/course-v3/content/resources/_index.md
@@ -1,0 +1,5 @@
+---
+_build:
+  list: never
+  render: never
+---

--- a/course-v3/go.mod
+++ b/course-v3/go.mod
@@ -1,0 +1,3 @@
+module github.com/mitodl/ocw-hugo-themes/course
+
+go 1.16

--- a/course-v3/layouts/_default/baseof.coursedata.json
+++ b/course-v3/layouts/_default/baseof.coursedata.json
@@ -1,0 +1,1 @@
+{{ block "main" . }}{{ end }}

--- a/course-v3/layouts/_default/baseof.html
+++ b/course-v3/layouts/_default/baseof.html
@@ -1,0 +1,192 @@
+{{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
+<!doctype html>
+<html lang="{{ $.Site.Language.Lang }}">
+{{ partial "head.html" . }}
+<body class="course-home-page">
+  {{ if $gtmId }}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtmId }}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  {{ end }}
+  <div class="overflow-auto">
+    {{ partialCached "mobile_course_nav.html" . }}
+    {{ partialCached "mobile_course_info.html" . }}
+    {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
+    {{ $isCourseHomePage := (eq .Params.layout "course_home") }}
+    {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
+
+    <div id="course-main-content">
+      <div class="row">
+        <div class="col-12 course-home-grid">
+          <div class="medium-and-below-only">
+            <div class="d-flex align-items-center mb-3">
+              <div class="col-6 px-0">
+                {{ partial "mobile_nav_toggle.html" . }}
+              </div>
+              <div class="col-6 px-0">
+                {{ partial "course_info_toggle.html" (dict "isCourseHomePage" $isCourseHomePage) }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row course-cards">
+        <div class="col-2 course-home-grid large-and-above-only">  
+          {{ partialCached "desktop_nav.html" . }}
+        </div>
+        <div class="col-sm-12 col-lg-10 course-home-grid">
+          <div class="">
+            <div class="card">
+              <div class="d-flex">
+                <div class="col-12 p-0" id="main-course-section">
+                  <div class="card-body">
+                    {{ if not $isCourseHomePage }}
+                      <button 
+                        type="button" 
+                        class="btn show-course-info large-and-above-only"
+                        id="show-desktop-course-drawer"
+                        aria-label="Show Course Info"
+                        >
+                        <img src="/static_shared/images/left_arrow.svg" alt=""/>
+                      </button>
+                    {{ end }} 
+                    {{ block "main" . }}{{ end }}
+                  </div>
+                </div>
+                {{/*  adding d-none class here as this section (with id="desktop-course-drawer") is being controlled (shown/hidden) 
+                via script written below hence hidden at the start to avoid a quick glitch  */}}
+                <div class="p-0 large-and-above-only d-none" id="desktop-course-drawer">
+                  {{ if not $isCourseHomePage }}
+                    {{ partialCached "desktop_course_info.html" . }}
+                  {{ end }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {{ block "footer" . }}{{ partial "footer-v2" . }}{{end}}
+  </div>
+  {{ partialCached "hide_offline_links.html" . }}
+  <script>
+    // Script for maintaining and toggling course drawer state
+    // note: This script is placed here instead of being in the bundle so it runs as soon as the HTML is rendered 
+    // this way, a glitch/layout thrashing in the course drawer is avoided.
+    // code for toggling the course drawer has also been placed here to avoid code duplication.
+    
+    // constants
+    'use strict';
+    const COURSE_DRAWER_LOCAL_STORAGE_KEY = "desktopCourseDrawerState"
+    const COURSE_DRAWER_OPENED = "opened"
+    const COURSE_DRAWER_CLOSED = "closed"
+    // IDs of elements
+    const DESKTOP_COURSE_DRAWER_ID = "desktop-course-drawer"
+    const SHOW_COURSE_DRAWER_BTN_ID = "show-desktop-course-drawer"
+    const HIDE_COURSE_DRAWER_BTN_ID = "hide-desktop-course-drawer"
+    const MAIN_COURSE_SECTION_ID = "main-course-section"
+
+    try{
+
+      /*
+      * Checks if user has already selected any option/state for drawer then it sets that else keep it open by default
+      */
+      function maintainDesktopCourseDrawerState() {
+        const isCourseDrawerOpen = getLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY)
+        if (isCourseDrawerOpen === null) {
+          // No preference found so setting to "opened" as default and opening the drawer
+          setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_OPENED)
+          showOrHideDesktopCourseDrawer(COURSE_DRAWER_OPENED)
+        } else {
+          showOrHideDesktopCourseDrawer(isCourseDrawerOpen)
+        }
+      }
+
+      /*
+      * Adds and defines "click" event listeners for show-drawer and hide-drawer buttons, making this function act as a drawer toggler.
+      */
+      function toggleDesktopCourseDrawer() {
+        const showCourseDrawerBtn = document.getElementById(SHOW_COURSE_DRAWER_BTN_ID)
+        const hideCourseDrawerBtn = document.getElementById(HIDE_COURSE_DRAWER_BTN_ID)
+        showCourseDrawerBtn.addEventListener("click", () => {
+          setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_OPENED)
+          showOrHideDesktopCourseDrawer(COURSE_DRAWER_OPENED)
+        })
+        hideCourseDrawerBtn.addEventListener("click", () => {
+          setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_CLOSED)
+          showOrHideDesktopCourseDrawer(COURSE_DRAWER_CLOSED)
+        })
+      }
+
+      // helper functions
+
+      function showOrHideDesktopCourseDrawer(state) {
+        const desktopCourseDrawer = document.getElementById(DESKTOP_COURSE_DRAWER_ID)
+        const showCourseDrawerBtn = document.getElementById(SHOW_COURSE_DRAWER_BTN_ID)
+        const mainCourseSection = document.getElementById(MAIN_COURSE_SECTION_ID)
+        if (state === COURSE_DRAWER_OPENED) {
+          desktopCourseDrawer.classList.add("col-3")
+          desktopCourseDrawer.classList.remove("d-none")
+          showCourseDrawerBtn.classList.add("d-none")
+          mainCourseSection.classList.add("col-lg-9")
+          mainCourseSection.classList.remove("col-md-12")
+        } else {
+          desktopCourseDrawer.classList.remove("col-3")
+          desktopCourseDrawer.classList.add("d-none")
+          showCourseDrawerBtn.classList.remove("d-none")
+          mainCourseSection.classList.remove("col-lg-9")
+          mainCourseSection.classList.add("col-md-12")
+        }
+      }
+
+      function setOrGetLocalStorageItem(action,key,value) {
+        try {
+          // checking browser support for localStorage
+          if (typeof Storage !== "undefined") {
+            if (action === "set") {
+              localStorage.setItem(key, value)
+              return true
+            } else {
+              return localStorage.getItem(key)
+            }
+          }
+          console.error("This browser has no web storage support.")
+          return null
+        } catch (e) {
+          console.error("An exception occurred while storing/fetching data in/from localstorage: ", e)
+          return null
+        }
+      }
+
+      function setLocalStorageItem(key, value) {
+        return setOrGetLocalStorageItem("set", key, value)
+      }
+      
+      function getLocalStorageItem(key){
+        return setOrGetLocalStorageItem("get", key)
+      }
+
+      maintainDesktopCourseDrawerState()
+      toggleDesktopCourseDrawer()
+    }
+    catch(e){
+      console.error("Something went wrong in maintaining/toggling course drawer state", e)
+    }
+  </script>
+
+  {{ partialCached "navigation_js.html" . }}
+  {{ partialCached "responsive_tables_js.html" . }}
+  {{- $webpack := .Site.Data.webpack -}}
+  {{- $js_urls := slice $webpack.common.js $webpack.course_v2.js -}}
+  {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
+  <!-- Appzi: Capture Insightful Feedback -->
+  {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
+
+  <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
+
+  <!-- End Appzi -->
+</body>
+
+</html>

--- a/course-v3/layouts/_default/section.coursedata.json
+++ b/course-v3/layouts/_default/section.coursedata.json
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "course_content.json" . }}
+{{ end }}

--- a/course-v3/layouts/home.html
+++ b/course-v3/layouts/home.html
@@ -1,0 +1,57 @@
+{{- $gtmId := getenv "GTM_ACCOUNT_ID" -}}
+{{- $courseData := .Site.Data.course -}}
+<!doctype html>
+<html lang="{{ $.Site.Language.Lang }}">
+{{ partial "head.html" . }}
+<body class="course-home-page">
+  {{ if $gtmId }}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtmId }}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  {{ end }}
+  
+  <div class="overflow-auto">
+    {{ partialCached "mobile_course_nav.html" . }}
+    {{ partialCached "mobile_course_info.html" . }}
+    {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
+    {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
+
+  <div id="course-main-content">
+    <div class="row">
+      <div class="col-12 course-home-grid">
+        <div class="medium-and-below-only mb-3">
+          {{ partial "mobile_nav_toggle.html" . }}
+        </div>
+      </div>
+    </div>
+    <div class="row course-cards">
+      <div class="col-2 course-home-grid large-and-above-only">  
+        {{ partialCached "desktop_nav.html" . }}
+      </div>
+      <div class="col-12 col-md-8 col-lg-7 course-home-grid">
+        {{ partialCached "course_detail.html" . }}
+      </div>
+      <div class="col-12 col-md-4 col-lg-3 mb-3 mb-md-0 course-home-grid">
+        {{ partialCached "course_image_section.html" . }}
+      </div>
+    </div>
+  </div>
+  
+  {{ block "footer" . }}{{ partial "footer-v2" . }}{{end}}
+  {{ partialCached "hide_offline_links.html" . }}
+  </div>
+  {{ partialCached "navigation_js.html" . }}
+  {{ partialCached "responsive_tables_js.html" . }}
+
+  {{- $webpack := .Site.Data.webpack -}}
+  {{- $js_urls := slice $webpack.common.js $webpack.course_v2.js -}}
+  {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
+  <!-- Appzi: Capture Insightful Feedback -->
+  {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
+  <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
+
+  <!-- End Appzi -->
+</body>
+
+</html>

--- a/course-v3/layouts/index.contentmap.json
+++ b/course-v3/layouts/index.contentmap.json
@@ -1,0 +1,5 @@
+{{- $contentMap := dict -}}
+{{- range where $.Site.Pages "Params.uid" "!=" nil -}}
+  {{- $contentMap = merge $contentMap (dict .Params.uid .RelPermalink) -}}
+{{- end -}}
+{{- $contentMap | jsonify -}}

--- a/course-v3/layouts/index.coursedata.json
+++ b/course-v3/layouts/index.coursedata.json
@@ -1,0 +1,39 @@
+{{- $courseData := .Site.Data.course -}}
+{{- $courseImageUrl := index (partial "course-image-url.html" .) 0 -}}
+{{- $courseImageMetadata := index (partial "course-image-url.html" .) 1 -}}
+
+{
+  "course_title": {{- $courseData.course_title | jsonify -}},
+  "course_description": {{- $courseData.course_description | jsonify -}},
+  "site_uid": {{- $courseData.site_uid | jsonify -}},
+  "legacy_uid": {{- $courseData.legacy_uid | jsonify -}},
+  {{- with $courseData.instructors.content -}}
+  {{- $instructors := partial "get_instructors.html" .  -}}
+  "instructors": [
+  {{- range $index, $instructor := $instructors -}}
+  {{- if $index -}}
+    ,  
+  {{- end -}}
+  {
+    "first_name":  {{- $instructor.first_name | jsonify -}},
+    "last_name":  {{- $instructor.last_name | jsonify -}},
+    "middle_initial":  {{- $instructor.middle_initial | jsonify -}},
+    "salutation":  {{- $instructor.salutation | jsonify -}},
+    "title":  {{- $instructor.title | jsonify -}}
+  }
+  {{- end }}],
+  {{- else -}}
+  "instructors": [],
+  {{- end -}}
+  "department_numbers": {{- $courseData.department_numbers | jsonify -}},
+  "learning_resource_types": {{- $courseData.learning_resource_types | jsonify -}},
+  "topics": {{- $courseData.topics | jsonify -}},
+  "primary_course_number": {{- $courseData.primary_course_number | jsonify -}},
+  "extra_course_numbers":  {{- $courseData.extra_course_numbers | jsonify -}},
+  "term":  {{- $courseData.term | jsonify -}},
+  "year":  {{- $courseData.year | jsonify -}},
+  "level":  {{- $courseData.level | jsonify -}},
+  "image_src": {{- $courseImageUrl | jsonify -}},
+  "course_image_metadata": {{- $courseImageMetadata.Params | jsonify -}}
+}
+

--- a/course-v3/layouts/learning_resource_types/taxonomy.html
+++ b/course-v3/layouts/learning_resource_types/taxonomy.html
@@ -1,0 +1,22 @@
+{{ define "main" }}
+{{ partial "resources_header.html" . }}
+{{ $numberOfResourcesLimit := 10 }}
+{{ $taxonomy := "learning_resource_types" }}
+
+<div class="mb-5">
+  {{ with ($.Site.GetPage (printf "/%s" $taxonomy)) }}
+    {{ with .Pages }}
+      {{ range . }}
+        {{ if in .Title "Video" }}
+          {{ partial "resource_list_collapsible.html" (dict "context" . "expand" true) }}
+        {{ end }}
+      {{ end }}
+      {{ range . }}
+        {{ if not (in .Title "Video") }}
+          {{ partial "resource_list_collapsible.html" (dict "context" . "expand" false) }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+</div>
+{{ end }}

--- a/course-v3/layouts/learning_resource_types/term.html
+++ b/course-v3/layouts/learning_resource_types/term.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+{{ partial "course_content.html" . }}
+
+<div class="mb-5">
+  {{ $resources := where .Pages "Params.content_type" "resource" }}
+  {{ partial "resource_list.html" (dict "resources" $resources) }}
+</div>
+{{ end }}

--- a/course-v3/layouts/lists/single.html
+++ b/course-v3/layouts/lists/single.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+
+  {{- $bundle := . -}}
+  {{- $uids := .Params.resources.content -}}
+  {{- $resources := slice -}}
+
+  {{ partial "course_content.html" . }}
+  <div class="mb-5">
+    <div class="mb-3 collection-description">
+      {{ $bundle.Description | .RenderString }}
+    </div>
+      {{ range $id := $uids }}
+        {{ $page := where $.Site.Pages "Params.uid" $id }}
+        {{ $resources = $resources |  append (index $page 0) }}
+      {{ end }}
+      {{- partial "resource_list.html" (dict "resources" $resources "sort" false) -}}
+  </div>
+{{ end }}

--- a/course-v3/layouts/pages/_markup/render-heading.html
+++ b/course-v3/layouts/pages/_markup/render-heading.html
@@ -1,0 +1,5 @@
+{{ if and (eq .Level 2) (.Anchor) }}
+    <h{{ add .Level 1}} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }}</h{{ add .Level 1 }}>
+{{ else }}
+    <h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }}</h{{ .Level }}>
+{{ end }}

--- a/course-v3/layouts/pages/instructor_insights.html
+++ b/course-v3/layouts/pages/instructor_insights.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "course_content.html" . }}
+{{ end }}

--- a/course-v3/layouts/pages/section.html
+++ b/course-v3/layouts/pages/section.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "course_content.html" . }}
+{{ end }}

--- a/course-v3/layouts/pages/single.coursedata.json
+++ b/course-v3/layouts/pages/single.coursedata.json
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "course_content.json" . }}
+{{ end }}

--- a/course-v3/layouts/pages/single.html
+++ b/course-v3/layouts/pages/single.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "course_content.html" . }}
+{{ end }}

--- a/course-v3/layouts/partials/archived_versions.html
+++ b/course-v3/layouts/partials/archived_versions.html
@@ -1,0 +1,14 @@
+{{ $courseData := .Site.Data.course }}
+{{ $archivedVersions := $courseData.archived_versions }}
+{{ if gt (len $archivedVersions) 0}}
+<div class="course-home-section w-100">
+  <div class="container px-0 mx-0">
+    <h4 class="course-info-title font-weight-bold">ARCHIVED OCW VERSIONS</h4>
+    <ul class="other-version-list list-unstyled">
+    {{ range $archivedVersions }}
+    <li>{{ . | markdownify }}</li>
+    {{ end }}
+    </ul>
+  </div>
+</div>
+{{ end }}

--- a/course-v3/layouts/partials/contains_videos.html
+++ b/course-v3/layouts/partials/contains_videos.html
@@ -1,0 +1,11 @@
+{{- $containsVideos := false -}}
+{{- with (.context.GetPage (printf "/%s" .taxonomy)) -}}
+    {{- with .Pages -}}
+      {{- range . -}}
+        {{- if in .Title "Video" -}}
+          {{- $containsVideos = true -}}
+        {{- end -}}
+      {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- return $containsVideos -}}

--- a/course-v3/layouts/partials/course_banner.html
+++ b/course-v3/layouts/partials/course_banner.html
@@ -1,0 +1,13 @@
+{{ $bannerClass := "text-capitalize display-4 m-0 text-white" }}
+{{ $currentPage := . }}
+<div id="course-banner" class="p-0">
+  <div class="max-content-width course-banner-content m-auto py-3">
+    {{ $courseData := .Site.Data.course }}
+    <span class="course-number-term-detail">{{ $courseData.primary_course_number }} | {{ $courseData.term }} {{ $courseData.year }} | {{ delimit $courseData.level ", " }}</span>
+    <br>
+    <a
+      class="{{ $bannerClass }}"
+      href="{{ partial "course_home_page_url.html" . }}"
+    >{{ $courseData.course_title }}</a>
+  </div>
+</div>

--- a/course-v3/layouts/partials/course_content.html
+++ b/course-v3/layouts/partials/course_content.html
@@ -1,0 +1,6 @@
+<div class="mb-2">
+  {{ partial "content_header_v2.html" . }}
+  <article class="content pt-3 mt-1">
+    <main id="course-content-section">{{- .Content -}}</main>
+  </article>
+</div>

--- a/course-v3/layouts/partials/course_content.json
+++ b/course-v3/layouts/partials/course_content.json
@@ -1,0 +1,4 @@
+{
+  "title": {{- .Title | jsonify -}},
+  "content": {{- .Plain | jsonify  -}}
+}

--- a/course-v3/layouts/partials/course_description.html
+++ b/course-v3/layouts/partials/course_description.html
@@ -1,0 +1,24 @@
+{{ $courseData := .context.Site.Data.course }}
+{{ $shouldCollapseDescription := false }}
+{{ with $courseData.course_description }}
+  {{ $shouldCollapseDescription = gt (len .) 320 }}
+{{ end }}
+<div id="course-description">
+  <div class="course-detail-title">
+    Course Description
+  </div>
+  {{ if $shouldCollapseDescription }}
+  <div id="collapsed-description" class="description">
+    {{- .context.RenderString (truncate 320 $courseData.course_description) -}}
+    {{- partial "link_button.html" (dict "text" "Show more" "id" "expand-description")  -}}
+  </div>
+  <div id="expanded-description" class="description d-none">
+    {{- .context.RenderString $courseData.course_description -}}
+    {{- partial "link_button.html" (dict "text" "Show less" "id" "collapse-description")  -}}
+  </div>
+  {{ else }}
+  <div id="full-description" class="description">
+    {{- .context.RenderString $courseData.course_description -}}
+  </div>
+  {{ end }}
+</div>

--- a/course-v3/layouts/partials/course_detail.html
+++ b/course-v3/layouts/partials/course_detail.html
@@ -1,0 +1,15 @@
+<div class="card">
+  <div class="card-body">
+    <section class="course-detail-section">
+      {{ partial "course_description.html" (dict "context" .) }}
+    </section>
+
+    <section class="course-detail-section">
+      {{ partial "course_info.html" (dict "context" . "inPanel" false) }}
+    </section>
+
+    <section class="course-detail-section">
+      {{ partial "learning_resource_types.html" (dict "context" . "inPanel" false) }}
+    </section>
+  </div>
+</div>

--- a/course-v3/layouts/partials/course_image_section.html
+++ b/course-v3/layouts/partials/course_image_section.html
@@ -1,0 +1,23 @@
+{{- $imageData := partial "course-image-url.html" . -}}
+{{- $courseImageUrl := index $imageData 0 -}}
+{{- $courseImageMetadata := index $imageData 1 -}}
+
+<div class="card">
+  <div class="card-body">
+    <div class="course-image-section-container">
+      <div class="course-image-container">
+        <div class="d-flex flex-column">
+          <img class="course-image" src="{{ $courseImageUrl }}"
+            alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
+          />
+        </div>
+        <div class="course-image-caption">
+          <span>{{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}</span>
+        </div>
+      </div>
+      <div>
+        {{ partialCached "download_course_link_button.html" (dict "context" . "inPanel" true) }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/course-v3/layouts/partials/course_info.html
+++ b/course-v3/layouts/partials/course_info.html
@@ -1,0 +1,99 @@
+{{ $courseData := .context.Site.Data.course }} {{ $inPanel := .inPanel }} {{
+$isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
+
+<div class="course-info">
+  <div class="course-detail-title {{ if $inPanel }}bg-light-gray{{ end }}">
+    <div class="d-flex">
+      <div class="font-black {{ if $inPanel }}py-2 pl-3 m-0{{ end }}">
+        Course Info
+      </div>
+      {{ if $inPanel }}
+      <button
+        type="button"
+        class="btn close-course-info large-and-above-only"
+        id="{{ if $isDesktopCourseDrawer }}hide-desktop-course-drawer{{ end }}"
+        aria-label="Close Course Info"
+        >
+        <img
+          class="toggle navbar-toggle offcanvas-toggle"
+          src="/static_shared/images/close_small.svg"
+          alt=""
+          width="12px"
+        />
+      </button>
+      {{ end }}
+    </div>
+  </div>
+  <div
+    id="course-info"
+    class="position-relative {{ if $inPanel }}px-3 mt-4{{ end }}">
+    <div class="row">
+      <div class="col-12 {{ if not $inPanel }}col-sm-6{{ end }}">
+        {{ with $courseData.instructors.content }}
+        <div class="">
+          {{ $instructors := partial "get_instructors.html" . }}
+          <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+            {{ if eq (len $instructors) 1 }}Instructor{{ else }}Instructors{{
+            end }}
+          </div>
+          <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
+            {{ partial "partial_collapse_list.html" (dict "list" $instructors
+            "id" "instructors" "key" "title" "klass" "course-info-instructor"
+            "showCollapse" $inPanel) }}
+          </div>
+        </div>
+        {{ end }} {{ with $courseData.department_numbers }}
+        <div class="mt-4">
+          {{ $departments := partial "get_departments.html" . }}
+          <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+            Departments
+          </div>
+          <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
+            {{ partial "partial_collapse_list.html" (dict "list" $departments
+            "id" "departments" "key" "title" "klass" "course-info-department"
+            "useLinks" true) }}
+          </div>
+        </div>
+        {{ end }} 
+        {{ if $inPanel }}
+        <div class="mt-4">
+          <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+            As Taught In
+          </div>
+          <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
+            {{ $courseData.term }}
+            {{ if isset $courseData "year" }}
+              {{ $courseData.year }}
+            {{ end }}
+          </div>
+        </div>
+
+        <div class="mt-4">
+          <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+            Level
+          </div>
+          <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
+            {{ if eq (printf "%T" $courseData.level) "string" }} {{
+            $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
+            {{- partial "link.html" (dict "href" $levelSearchUrl "text" $courseData.level "stripLinkOffline" true) -}}
+            {{ else }}
+              {{ range $courseData.level }}
+                {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) }}
+                {{- partial "link.html" (dict "href" $levelSearchUrl "text" . "stripLinkOffline" true) -}}<br />
+              {{ end }}
+            {{ end }}
+          </div>
+        </div>
+        {{ end }}
+      </div>
+
+      {{ if not $inPanel }}
+      <div class="col-12 col-sm-6">
+        <div class="mt-4 mt-sm-0">
+          {{ partial "topics.html" (merge . (dict "renderMarginTop" false)) }}
+        </div>
+      </div>
+      {{ end }}
+    </div>
+  </div>
+</div>

--- a/course-v3/layouts/partials/course_info_toggle.html
+++ b/course-v3/layouts/partials/course_info_toggle.html
@@ -1,0 +1,11 @@
+{{ $isCourseHomePage := .isCourseHomePage | default "" }}
+
+{{ if not $isCourseHomePage }}
+  <button 
+    class="btn btn-link float-right mobile-course-info-toggle-btn toggle navbar-toggle offcanvas-toggle"
+    id="mobile-course-info-toggle"
+    data-toggle="offcanvas" 
+    data-target="#course-info-drawer">
+    More Info
+  </button>
+{{ end }}

--- a/course-v3/layouts/partials/course_other_version.html
+++ b/course-v3/layouts/partials/course_other_version.html
@@ -1,0 +1,20 @@
+<!-- New Partial -->
+{{/*  I did not know that other_versions.html already exists, so this partial is a duplicate 
+and will get rid of one of them after figuring out things/data for other versions  */}}
+
+{{- $courseData := .context.Site.Data.course -}}
+{{- $extraCourseNumbers := split $courseData.extra_course_numbers ","  -}}
+
+{{ if gt (len $extraCourseNumbers) 0 }}
+  <div class="other-version">
+    <div class="course-detail-title">
+      Other Version of {{ $courseData.primary_course_number }}
+    </div>
+    <div>
+      OCW has multiple versions of this course, as taught in different terms by different faculty, with distinct materials and pedagogy.
+    </div>
+    {{ range $extraCourseNumbers }}
+    <div class="my-2">{{ . }}</div>
+    {{ end }}
+  </div>
+{{ end }}

--- a/course-v3/layouts/partials/desktop_course_info.html
+++ b/course-v3/layouts/partials/desktop_course_info.html
@@ -1,0 +1,10 @@
+<div class="border-left">
+  <div>
+    {{ partial "course_info.html" (dict "context" . "inPanel" true "isDesktopCourseDrawer" true) }}
+    <div class="px-3">
+      {{ partial "topics.html" (dict "context" . "inPanel" true) }}
+      {{ partial "learning_resource_types.html" (dict "context" . "inPanel" true) }}
+      {{ partialCached "download_course_link_button.html" (dict "context" . "inPanel" true) }}
+    </div>
+  </div>
+</div>

--- a/course-v3/layouts/partials/desktop_nav.html
+++ b/course-v3/layouts/partials/desktop_nav.html
@@ -1,0 +1,5 @@
+<div class="card">
+  <div class="card-body pr-2">
+    {{ partial "nav.html" . }}
+  </div>
+</div>

--- a/course-v3/layouts/partials/download_course_link_button.html
+++ b/course-v3/layouts/partials/download_course_link_button.html
@@ -1,0 +1,16 @@
+{{- $trimmedBaseUrl := strings.TrimSuffix "/" site.BaseURL -}}
+{{- $downloadPageUrl := print $trimmedBaseUrl "/download" -}}
+{{- $downloadPageUrl = partial "page_url.html" (dict "context" .context "url" $downloadPageUrl) -}}
+{{- $downloadCourseUrl := partial "get_course_download_url.html" .context -}}
+{{- $zipExists := partial "file_exists_at_url.html" (dict "context" .context "url" $downloadCourseUrl ) -}}
+{{- $noResourcesFound := partial "show_no_resources_found.html" (dict "context" .context "taxonomy" "learning_resource_types") -}}
+{{- if or $zipExists (not $noResourcesFound) -}}
+<hr>
+<div class="pb-3">
+  <a class="download-course-link-button btn btn-outline-primary btn-link link-button text-decoration-none px-4 py-2"
+    role="button"
+    href="{{- $downloadPageUrl -}}">
+    <div class="text-center w-100">Download Course</div>
+  </a>
+</div>
+{{- end -}}

--- a/course-v3/layouts/partials/extrahead.html
+++ b/course-v3/layouts/partials/extrahead.html
@@ -1,0 +1,9 @@
+{{- define "title" -}}{{ partial "title.html" . }}{{- end -}}
+{{- define "extrahead" -}}
+{{- $css_urls := slice .Site.Data.webpack.course_v2.css }}
+{{- $layout := .Params.layout -}}
+{{- if eq $layout "instructor_insights" -}}
+    {{- $css_urls = $css_urls | append .Site.Data.webpack.instructor_insights.css -}}
+{{- end -}}
+{{ partial "include_css.html" (dict "context" . "urls" $css_urls) }}
+{{- end -}}

--- a/course-v3/layouts/partials/get_course_download_url.html
+++ b/course-v3/layouts/partials/get_course_download_url.html
@@ -1,0 +1,4 @@
+{{- $domain := strings.TrimSuffix "/" (getenv "STATIC_API_BASE_URL") -}}
+{{- $trimmedBaseUrl := strings.TrimPrefix "/" (strings.TrimSuffix "/" site.BaseURL) -}}
+{{- $shortId := site.Data.course.site_short_id -}}
+{{- return printf "%v/%v/%v.zip" $domain $trimmedBaseUrl $shortId -}}

--- a/course-v3/layouts/partials/get_departments.html
+++ b/course-v3/layouts/partials/get_departments.html
@@ -1,0 +1,7 @@
+{{ $departments := slice }}
+{{ range . }}
+{{ $department := index site.Data.departments . }}
+{{ $department := merge $department (dict "url" (partial "get_search_url.html" (dict "key" "department_numbers" "value" $department.title))) }}
+{{ $departments = $departments | append $department }}
+{{ end }}
+{{ return $departments }}

--- a/course-v3/layouts/partials/get_instructors.html
+++ b/course-v3/layouts/partials/get_instructors.html
@@ -1,0 +1,18 @@
+{{ $instructors := slice }}
+{{ range . }}
+  {{ $staticApiBaseUrl := getenv "STATIC_API_BASE_URL" }}
+  {{ $url := (print (strings.TrimSuffix "/" $staticApiBaseUrl) "/instructors/" . "/index.json") }}
+  {{ with resources.GetRemote $url }}
+    {{ with .Err }}
+      {{ errorf "Failed to fetch instructors from %v with error %v" $url . }}
+    {{ else }}
+      {{ $data := (. | unmarshal).data }}
+      {{ $searchUrl := partial "get_search_url.html" (dict "key" "instructors" "value" (title $data.title)) }}
+      {{ $instructor := merge $data (dict "url" $searchUrl) }}
+      {{ $instructors = $instructors | append $instructor }}
+    {{ end }}
+  {{ else }}
+    {{ errorf "Failed to fetch instructors from %v" $url }}
+  {{ end }}
+{{ end }}
+{{ return $instructors }}

--- a/course-v3/layouts/partials/get_resource_download_link.html
+++ b/course-v3/layouts/partials/get_resource_download_link.html
@@ -1,0 +1,10 @@
+{{- $resourceParams := . -}}
+{{- $downloadLink := $resourceParams.file | default nil -}}
+
+{{ if and (eq $downloadLink nil) (eq $resourceParams.resourceType "Video") }}
+  {{ $downloadLink = $resourceParams.video_files.archive_url }}
+{{ else if $downloadLink }}
+  {{ $downloadLink = partial "resource_url.html" (dict "context" . "url" $downloadLink)  }}
+{{ end }}
+
+{{ return $downloadLink }}

--- a/course-v3/layouts/partials/get_resource_thumbnail_src.html
+++ b/course-v3/layouts/partials/get_resource_thumbnail_src.html
@@ -1,0 +1,14 @@
+{{- $resourceType := .resourceType -}}
+{{- $resourceThumbnailSrc := "/static_shared/images/file_thumbnail.png" -}}
+
+{{ if eq $resourceType "Document" }}
+  {{- $resourceThumbnailSrc = "/static_shared/images/pdf_thumbnail.png" -}}
+{{ else if eq $resourceType "Image" }}
+  {{- $resourceThumbnailSrc = "/static_shared/images/file_thumbnail.png" -}}
+{{ else if eq $resourceType "Video" }}
+{{- $resourceThumbnailSrc = "/static_shared/images/mobile_video_thumbnail.png" -}}
+{{ else if eq $resourceType "Other" }}
+  {{- $resourceThumbnailSrc = "/static_shared/images/file_thumbnail.png" -}}
+{{ end }}
+
+{{ return $resourceThumbnailSrc }}

--- a/course-v3/layouts/partials/hierarchical_select_as_map.html
+++ b/course-v3/layouts/partials/hierarchical_select_as_map.html
@@ -1,0 +1,14 @@
+{{- $scratch := newScratch -}}
+{{ $scratch.Set "combined" dict }}
+
+{{ range $topicGroup := . }}
+  {{ $scratch.Set "inner" nil }}
+
+  {{ range $index := seq (len $topicGroup) }}
+    {{ $scratch.Set "inner" (dict (index $topicGroup (sub (len $topicGroup) $index)) ($scratch.Get "inner")) }}
+  {{ end }}
+
+  {{ $scratch.Set "combined" (merge ($scratch.Get "combined") ($scratch.Get "inner" | default dict)) }}
+{{ end }}
+
+{{- return $scratch.Get "combined" -}}

--- a/course-v3/layouts/partials/learning_resource_type.html
+++ b/course-v3/layouts/partials/learning_resource_type.html
@@ -1,0 +1,41 @@
+{{- $context := .context -}}
+{{ $inPanel := .inPanel }}
+
+<div class="{{ if not $inPanel }}learning-resource-type-item{{ end }}">
+  <div class="d-flex">
+    <i class="material-icons pr-1">
+      {{- if eq $context "Course Introduction" -}}
+      groups
+      {{- else if in $context "Audio" -}}
+      equalizer
+      {{- else if in $context "Video" -}}
+      theaters
+      {{- else if or (in $context "Problem Sets") (in $context "Assignment") -}}
+        {{- if or (in $context "with Examples") (in $context "with Solutions") -}}
+        assignment_turned_in
+        {{- else -}}
+        assignment
+        {{- end -}}
+      {{- else if in $context "Exams" -}}
+      grading
+      {{- else if eq $context "Image Gallery" -}}
+      collections
+      {{- else if eq $context "Lecture Notes" -}}
+      notes
+      {{- else if eq $context "Online Textbook" -}}
+      menu_book
+      {{- else if in $context "Projects" -}}
+      group_work
+      {{- else if in $context "Simulations" -}}
+      laptop_windows
+      {{- else if in $context "Instructor Insights" -}}
+      <span class="material-icons-round">
+        co_present
+      </span> 
+      {{- end -}}
+    </i>
+    <span>
+      {{- $context -}}
+    </span>
+  </div>
+</div>

--- a/course-v3/layouts/partials/learning_resource_types.html
+++ b/course-v3/layouts/partials/learning_resource_types.html
@@ -1,0 +1,19 @@
+{{ $courseData := .context.Site.Data.course }}
+{{ $inPanel := .inPanel }}
+
+{{ if gt (len ($courseData.learning_resource_types | default slice)) 0 }}
+<div class="">
+  <div class="course-detail-title {{ if $inPanel }}panel-course-info-title mt-3{{ end }}">
+    Learning Resource Types
+  </div>
+  <div>
+    <div class="row {{ if $inPanel }}d-inline m-0{{ end }}">
+      {{ range $courseData.learning_resource_types }}
+        <div class="{{ if $inPanel }}panel-course-info-text my-2{{ else }} m-2 {{ end }}">
+          {{ partial "learning_resource_type.html" (dict "context" . "inPanel" $inPanel) }}
+        </div>
+      {{ end }}
+    </div>
+  </div>
+</div>
+{{end}}

--- a/course-v3/layouts/partials/link_button.html
+++ b/course-v3/layouts/partials/link_button.html
@@ -1,0 +1,1 @@
+<button id="{{ .id }}" type="button" class="btn btn-link link-button p-0">{{ .text }}</button>

--- a/course-v3/layouts/partials/mobile_course_info.html
+++ b/course-v3/layouts/partials/mobile_course_info.html
@@ -1,0 +1,24 @@
+<div
+  id="course-info-drawer"
+  class="bg-faded pt-3 bg-light navbar-offcanvas navbar-offcanvas-right medium-and-below-only drawer"
+>
+  <div class="col-12">
+    <button
+      class="btn close-mobile-course-info"
+      type="button"
+      aria-label="Close Course Info"
+      onclick="$('#mobile-course-info-toggle').click();"
+      >
+      <img
+        class=""
+        src="/static_shared/images/close_small.svg"
+        alt=""
+        width="12px"
+      />
+    </button>
+  </div>
+  {{ partial "course_info.html" (dict "context" . "inPanel" true) }}
+  {{ partial "topics.html" (dict "context" . "inPanel" true) }}
+  {{ partial "learning_resource_types.html" (dict "context" . "inPanel" true) }}
+  {{ partialCached "download_course_link_button.html" (dict "context" . "inPanel" true) }}
+</div>

--- a/course-v3/layouts/partials/mobile_course_nav.html
+++ b/course-v3/layouts/partials/mobile_course_nav.html
@@ -1,0 +1,20 @@
+<div
+  id="mobile-course-nav"
+  class="navbar-offcanvas offcanvas-toggle offcanvas-toggle-close medium-and-below-only drawer">
+  <h3 class="my-4 d-flex align-items-center justify-content-between">
+    Browse Course Material
+    <button
+      class="btn"
+      type="button"
+      aria-label="Close Course Menu"
+      onclick="$('#mobile-course-nav-toggle').click();"
+      >
+      <img
+        src="/static_shared/images/close_small.svg"
+        alt=""
+        width="12px"
+      />
+    </button>
+  </h3>
+  {{ partial "nav.html" . }}
+</div>

--- a/course-v3/layouts/partials/mobile_nav_toggle.html
+++ b/course-v3/layouts/partials/mobile_nav_toggle.html
@@ -1,0 +1,11 @@
+<div>
+  <button
+    id="mobile-course-nav-toggle"
+    class="mobile-course-nav-toggle-btn d-inline-flex align-items-center offcanvas-toggle"
+    data-toggle="offcanvas"
+    data-target="#mobile-course-nav"
+  >
+    <img src="/static_shared/images/expand.svg" alt=""/>
+    <span class="pl-1">Menu</span>
+  </button>
+</div>

--- a/course-v3/layouts/partials/nav.html
+++ b/course-v3/layouts/partials/nav.html
@@ -1,0 +1,8 @@
+{{ $menu := index .Site.Menus "leftnav" }}
+<nav id="course-nav" class="course-nav">
+  <ul class="w-100 m-auto list-unstyled">
+    {{ range $menu }}
+      {{ partial "nav_item.html" (dict "menuItem" .) }}
+    {{ end }}
+  </ul>
+</nav>

--- a/course-v3/layouts/partials/nav_item.html
+++ b/course-v3/layouts/partials/nav_item.html
@@ -1,0 +1,37 @@
+{{ $id := .menuItem.Identifier }}
+{{ $hasParent := isset . "parentId" }}
+{{ $hasChildren := .menuItem.HasChildren }}
+{{ $url := partial "nav_url.html" . }}
+
+<li class="course-nav-list-item">
+  <div class="course-nav-parent d-flex flex-direction-row align-items-center justify-content-between">
+    <span class="course-nav-text-wrapper">
+      <a class="text-dark nav-link"
+        data-uuid="{{ .menuItem.Identifier }}"
+        href="{{ $url }}">
+        {{ .menuItem.Name }}
+      </a>
+    </span>
+    {{ if .menuItem.HasChildren }}
+    <a class="course-nav-section-toggle"
+      href="#nav-container_{{ .menuItem.Identifier }}"
+      data-toggle="collapse"
+      aria-controls="nav-container_{{ .menuItem.Identifier }}"
+      aria-expanded=""
+      data-uuid="{{ .menuItem.Identifier }}">
+      <i class="material-icons md-18"></i>
+    </a>
+    {{ end }}
+  </div>
+  {{ if or (not $hasParent) $hasChildren }}
+  <span class="medium-and-below-only"><hr/></span>
+  {{ end }}
+  <div class="collapse"
+    id="nav-container_{{ .menuItem.Identifier }}">
+    <ul class="course-nav-child-nav m-auto">
+      {{ range .menuItem.Children }}
+        {{ partial "nav_item.html" (dict "menuItem" . "parentId" $id ) }}
+      {{ end }}
+    </ul>
+  </div>
+</li>

--- a/course-v3/layouts/partials/nav_url.html
+++ b/course-v3/layouts/partials/nav_url.html
@@ -1,0 +1,1 @@
+{{ return .menuItem.URL }}

--- a/course-v3/layouts/partials/navigation_js.html
+++ b/course-v3/layouts/partials/navigation_js.html
@@ -1,0 +1,5 @@
+{{ $navjs := resources.Get "js/navigation.js" }}
+{{ $minified := $navjs | resources.Minify }}
+<script>
+{{ $minified.Content | safeJS }}
+</script>

--- a/course-v3/layouts/partials/no_resources_found.html
+++ b/course-v3/layouts/partials/no_resources_found.html
@@ -1,0 +1,3 @@
+<div>
+  <p>No Resources Found.</p>  
+</div>

--- a/course-v3/layouts/partials/open_learning_library_versions.html
+++ b/course-v3/layouts/partials/open_learning_library_versions.html
@@ -1,0 +1,15 @@
+{{ $courseData := .Site.Data.course }}
+{{ $openLearningLibraryVersions := $courseData.open_learning_library_versions }}
+{{ if gt (len $openLearningLibraryVersions) 0}}
+<div class="course-home-section w-100">
+  <div class="container px-0 mx-0">
+    <h4 class="course-info-title font-weight-bold">INTERACTIVE ASSESSMENTS WITH OPEN LEARNING LIBRARY</h4>
+    <p>Other versions of this course on MIT Open Learning Library have interactive assessments and progress tracking to better support independent learning.</p>
+    <ul class="other-version-list list-unstyled">
+    {{ range $openLearningLibraryVersions }}
+    <li>{{ . | markdownify }}</li>
+    {{ end }}
+    </ul>
+  </div>
+</div>
+{{ end }}

--- a/course-v3/layouts/partials/other_versions.html
+++ b/course-v3/layouts/partials/other_versions.html
@@ -1,0 +1,16 @@
+<!-- Old Partial -->
+{{ $courseData := .Site.Data.course }}
+{{ $otherVersions := $courseData.other_versions }}
+{{ if gt (len $otherVersions) 0}}
+<div class="course-home-section w-100">
+  <div class="container px-0 mx-0">
+    <h4 class="course-info-title font-weight-bold">OTHER {{ index $courseData.primary_course_number  }} OFFERINGS ON OPENCOURSEWARE</h4>
+    <p>OCW has multiple versions of this course as taught in different terms by different faculty, with distinct materials and pedagogy.</p>
+    <ul class="other-version-list list-unstyled">
+    {{ range $otherVersions }}
+    <li>{{ . | markdownify }}</li>
+    {{ end }}
+    </ul>
+  </div>
+</div>
+{{ end }}

--- a/course-v3/layouts/partials/partial_collapse_list.html
+++ b/course-v3/layouts/partials/partial_collapse_list.html
@@ -1,0 +1,54 @@
+{{ $params := . }}
+{{ $className := .klass | default "" }}
+{{ $useLinks := .useLinks | default true }}
+{{ $showCollapse := .showCollapse | default true }}
+{{ if and (gt (len .list) 4) $showCollapse }}
+<div class="position-relative pr-3">
+  <a class="partial-collapse-toggle-link" href="#partial-collapse-container_{{ .id }}" data-toggle="collapse"
+    aria-controls="partial-collapse-container_{{ .id }}" aria-expanded="false">
+    <div class="partial-collapse-icon-container">
+      <span class="partial-collapse-icon">
+        <i class="material-icons md-18"></i>
+      </span>
+    </div>
+  </a>
+  <div class="partial-collapse collapse" id="partial-collapse-container_{{ .id }}">
+    <ul class="list-unstyled m-0">
+      {{ range $item := .list }}
+      {{ $text := "" }}
+      {{ if isset $params "key" }}
+        {{ $text = index $item $params.key }}
+      {{ else }}
+        {{ $text = $item }}
+      {{ end }}
+      <li>
+        {{ if $useLinks }}
+        {{- partial "link.html" (dict "href" (index $item "url") "class" (printf "partial-collapse-link %s" $className) "text" $text "stripLinkOffline" true) -}}
+        {{ else }}
+        {{ $text }}
+        {{ end }}
+      </li>
+      {{ end }}
+    </ul>
+  </div>
+  <div class="partial-collapse-overlay"></div>
+</div>
+{{ else }}
+<ul class="list-unstyled m-0">
+  {{ range $item := .list }}
+  {{ $text := "" }}
+  {{ if isset $params "key" }}
+    {{ $text = index $item $params.key }}
+  {{ else }}
+    {{ $text = $item }}
+  {{ end }}
+  <li>
+    {{ if $useLinks }}
+    {{- partial "link.html" (dict "href" (index $item "url") "class" $className "text" $text "stripLinkOffline" true) -}}
+    {{ else }}
+    {{ $text }}
+    {{ end }}
+  </li>
+  {{ end }}
+</ul>
+{{ end }}

--- a/course-v3/layouts/partials/quiz_multiple_choice_choice.html
+++ b/course-v3/layouts/partials/quiz_multiple_choice_choice.html
@@ -1,0 +1,13 @@
+<div class="multiple-choice-div">
+	<input type='radio' name={{ .questionId }} class="multiple-choice-radio"}>
+	<span> {{.choiceText}} </span>
+	{{ if eq .correct "true" }}
+		<span class="toggle material-icons correctness-icon correctness-icon-correct">
+			check
+		</span>
+  {{ else }}
+  	<span class="toggle material-icons  correctness-icon correctness-icon-wrong">
+			close
+		</span>
+	{{end}}
+</div>

--- a/course-v3/layouts/partials/quiz_multiple_choice_solution.html
+++ b/course-v3/layouts/partials/quiz_multiple_choice_solution.html
@@ -1,0 +1,18 @@
+<div class="multiple_choice_buttons">
+	<span class="multiple-choice-check-button">
+		Check
+	</span>
+  {{if .solution }}
+  	&emsp;
+  	<span class='multiple-choice-show-button'>
+  		Show Solution
+  	</span>
+  {{end}}
+</div>
+{{if .solution }}
+  <div class="toggle multiple-choice-solution">
+    <p>
+      {{.solution}}
+    </p>
+  </div>
+{{end}}

--- a/course-v3/layouts/partials/resource_list.html
+++ b/course-v3/layouts/partials/resource_list.html
@@ -1,0 +1,24 @@
+{{- $hideThumbnail := .hideThumbnail | default false -}}
+{{- $hideDownloadIcon := .hideDownloadIcon | default false -}}
+{{- $defaultSort := .sort | default true -}}
+
+{{ $resources := .resources }}
+{{ $numberOfResources := len $resources }}
+
+{{ $limitResources := .limitResources | default $numberOfResources }}
+
+{{ if gt $numberOfResources 0 }}
+  {{ if $defaultSort }}
+    {{ range sort (first $limitResources $resources) .Params "title" }}
+      {{- partial "resource_list_item.html" (dict "params" .Params "permalink" .Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
+      <hr>
+    {{end}}
+  {{ else }}
+    {{ range (first $limitResources $resources)}}
+      {{- partial "resource_list_item.html" (dict "params" .Params "permalink" .Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
+      <hr>
+    {{ end }}
+  {{ end }}
+{{ else }}
+  {{ partial "no_resources_found.html" }}
+{{ end }}

--- a/course-v3/layouts/partials/resource_list_collapsible.html
+++ b/course-v3/layouts/partials/resource_list_collapsible.html
@@ -1,0 +1,39 @@
+{{ $expand := .expand }}
+{{ with .context}}
+{{ $numberOfResourcesLimit := 10 }}
+<div class="resource-list">
+{{ $resources := where .Pages "Params.content_type" "resource" }}
+{{ $numberOfResources := len $resources }}
+{{ if gt $numberOfResources 0 }}
+  {{ $limitedResourcesShown := false }}
+
+  {{ if gt $numberOfResources $numberOfResourcesLimit }}
+  {{ $numberOfResources = $numberOfResourcesLimit }}
+  {{ $limitedResourcesShown = true }}
+  {{ end }}
+  {{ $resourceSlug := urlize (lower .Title) }}
+  <div class="resource-list-toggle">
+  <a href="#resource-list-container-{{ $resourceSlug }}"
+  class="{{ if not $expand }}collapsed {{ end }}py-3"
+  data-toggle="collapse"
+  aria-controls="resource-list-container-{{ $resourceSlug }}"
+  aria-expanded="{{ if $expand }}true{{ end }}">
+    <i class="material-icons"></i>
+    <h4 class="my-4">{{ .Title }}</h4>  
+  </a>
+  </div>
+
+  <div id="resource-list-container-{{ $resourceSlug }}" class="collapse{{ if $expand }} show{{ end }} py-3">
+  {{ partial "resource_list.html" (dict "resources" $resources "limitResources" $numberOfResources) }}
+
+  {{ if eq $limitedResourcesShown true }}
+  <div>
+    <div class="float-right">
+    {{ partial "see_all.html" (dict "permalink" .Permalink) }}
+    </div>
+  </div>
+  {{ end }}
+  </div>
+{{ end }}
+</div>
+{{ end }}

--- a/course-v3/layouts/partials/resource_list_item.html
+++ b/course-v3/layouts/partials/resource_list_item.html
@@ -1,0 +1,32 @@
+<div class="resource-list-item container">
+  <div class="row">
+    <div class="d-inline-flex">
+      {{ if not .hideThumbnail }}
+        {{ $thumbnailSrc := partial "get_resource_thumbnail_src.html" (dict "resourceType" .params.resourcetype) }}
+        <img
+          class="resource-thumbnail"
+          src="{{- $thumbnailSrc -}}"
+        />
+      {{ end }}
+
+      {{ if not .hideDownloadIcon }}
+        {{ $downloadableLink := partial "get_resource_download_link.html" .params }}
+          <span class="pr-2">
+            {{ if $downloadableLink }}
+              <a href="{{- $downloadableLink -}}" target="_blank" download>
+                <img
+                  class="hide-offline resource-download"
+                  src="/static_shared/images/download.svg"
+                />
+              </a>
+            {{ end }}
+          </span>
+      {{ end }}
+      <div class="pt-2">
+        <a class="resource-list-title" href="{{ .permalink }}">
+          {{ .params.title }}
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/course-v3/layouts/partials/resources_header.html
+++ b/course-v3/layouts/partials/resources_header.html
@@ -1,0 +1,26 @@
+{{- $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-" -}}
+{{- $downloadCourseUrl := partial "get_course_download_url.html" . -}}
+{{- $zipExists := partial "file_exists_at_url.html" (dict "context" . "url" $downloadCourseUrl ) -}}
+{{- $noResourcesFound := partial "show_no_resources_found.html" (dict "context" . "taxonomy" "learning_resource_types") -}}
+{{- $containsVideos := partial "contains_videos.html" (dict "context" . "taxonomy" "learning_resource_types") -}}
+{{- if $zipExists -}}
+<div class="mb-2">
+  <h2>Download</h2>
+  <div class="hide-offline download-course-container background-color-light-grey p-3">
+    <div class="row">
+      <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
+        <a class="download-course-button p-2" href="{{ $downloadCourseUrl }}">
+          <span class="material-icons">file_download</span> Download course
+        </a>
+      </div>
+      <div class="col-12 col-md-9">
+        This package contains the same content as the online version of the course
+        {{- if $containsVideos }}, <em>except for the audio/video materials</em>. These can be downloaded below{{ end }}. 
+        For help downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
+      </div>
+    </div>
+  </div>
+</div>
+{{- else if $noResourcesFound -}}
+  {{ partial "no_resources_found.html" }}
+{{- end -}}

--- a/course-v3/layouts/partials/responsive_tables_js.html
+++ b/course-v3/layouts/partials/responsive_tables_js.html
@@ -1,0 +1,5 @@
+{{ $navjs := resources.Get "js/responsive_tables.ts" | js.Build }}
+{{ $minified := $navjs | resources.Minify }}
+<script>
+{{ $minified.Content | safeJS }}
+</script>

--- a/course-v3/layouts/partials/see_all.html
+++ b/course-v3/layouts/partials/see_all.html
@@ -1,0 +1,6 @@
+<div>
+  <a class="text-decoration-none font-weight-bold" href="{{ .permalink }}">
+    <span>See all</span>
+    <i class="material-icons see-all-resources-icon align-middle">arrow_forward</i>
+  </a>
+</div>

--- a/course-v3/layouts/partials/show_no_resources_found.html
+++ b/course-v3/layouts/partials/show_no_resources_found.html
@@ -1,0 +1,12 @@
+{{ $showNoResourcesFoundMessage := true }}
+{{ with (.context.GetPage (printf "/%s" .taxonomy)) }}
+    {{ with .Pages }}
+      {{ range . }}
+        {{ $resources := where .Pages "Params.content_type" "resource" }}
+        {{ if gt (len $resources) 0 }}
+            {{ $showNoResourcesFoundMessage = false }}
+        {{ end }}
+      {{ end }}
+  {{ end }}
+{{ end }}
+{{ return $showNoResourcesFoundMessage }}

--- a/course-v3/layouts/partials/title.html
+++ b/course-v3/layouts/partials/title.html
@@ -1,0 +1,17 @@
+{{ $courseData := .Site.Data.course }}
+{{- $titleArray := (slice) -}}
+{{- if .Params.Title -}}
+  {{- $titleArray = $titleArray | append .Params.Title -}}
+{{- end -}}
+{{- if $courseData.course_title -}}
+  {{- $titleArray = $titleArray | append $courseData.course_title -}}
+  {{- if $courseData.department_numbers -}}
+    {{ $departments := partial "get_departments.html" $courseData.department_numbers }}
+    {{- $titleArray = $titleArray | append (index $departments 0).title -}}
+  {{- end -}}
+{{- end -}}
+{{- $titleArray = $titleArray | append $.Site.Title -}}
+{{- if lt (len $titleArray) 3 -}}
+  {{- $titleArray = $titleArray | append "Free Online Course Materials" -}}
+{{- end -}}
+{{- delimit $titleArray " | " -}}

--- a/course-v3/layouts/partials/topic.html
+++ b/course-v3/layouts/partials/topic.html
@@ -1,0 +1,57 @@
+{{ $index := .index }}
+{{ $context := .context }}
+{{ $subtopics := slice }}
+{{ if not (eq .subtopics nil) }}
+{{ $subtopics = .subtopics }}
+{{ end }}
+{{ $scratch := newScratch }}
+<div class="position-relative pt-1 pb-1{{ if gt (len $subtopics) 0 }} pl-4 ml-n2 {{ end }}">
+  {{ if gt (len $subtopics) 0 }}
+  <a class="topic-toggle"
+    href="#subtopic-container_{{ $index }}"
+    data-toggle="collapse"
+    aria-controls="subtopic-container_{{ $index }}"
+    aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}">
+    <i class="material-icons"></i>
+  </a>
+  {{ end }}
+  <span class="topic-text-wrapper">
+    {{ $topicTitle := title .topic }}
+    {{ $topicUrl := partial "get_search_url.html" (dict "key" "topic" "value" $topicTitle) }}
+    {{- partial "link.html" (dict "href" $topicUrl "class" "text-black course-info-topic" "text" $topicTitle "stripLinkOffline" true) -}}
+  </span>
+</div>
+{{ if gt (len $subtopics) 0 }}
+<div class="pl-4 subtopic-container collapse{{if eq $index 0 }} show{{ end }}" id="subtopic-container_{{ $index }}">
+  {{ $scratch.Set "index" 0 }}
+  {{ range $subtopic, $specialities := $subtopics }}
+  {{ $subtopicIndex := $scratch.Get "index" }}
+  <div class="position-relative pt-1 pb-1 {{ if gt (len ($specialities | default slice)) 0 }} pl-4 {{ else }} pl-2 {{ end }}">
+    {{ if gt (len ($specialities | default slice)) 0 }}
+    <a class="topic-toggle"
+      href="#speciality-container_{{ $index }}_{{ $subtopicIndex }}"
+      data-toggle="collapse"
+      aria-controls="speciality-container_{{ $index }}_{{ $subtopicIndex }}"
+      aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}">
+      <i class="material-icons"></i>
+    </a>
+    {{ end }}
+    <span class="topic-text-wrapper">
+      {{ $subTopicTitle := title $subtopic }}
+      {{ $subTopicUrl := partial "get_search_url.html" (dict "key" "topic" "value" $subTopicTitle) }}
+      {{- partial "link.html" (dict "href" $subTopicUrl "class" "text-black course-info-topic" "text" $subTopicTitle "stripLinkOffline" true) -}}
+    </span>
+  </div>
+  {{ range $speciality, $ignore := $specialities }}
+  <div class="pt-1 pb-1 pl-5 collapse{{if eq $index 0 }} show{{ end }}" id="speciality-container_{{ $index }}_{{ $subtopicIndex }}">
+    <span class="topic-text-wrapper">
+      {{ $specialityTitle := title $speciality }}
+      {{ $specialityUrl := partial "get_search_url.html" (dict "key" "topic" "value" $specialityTitle) }}
+      {{- partial "link.html" (dict "href" $specialityUrl "class" "text-black course-info-topic" "text" $specialityTitle "stripLinkOffline" true) -}}
+    </span>
+  </div>
+  {{ end }}
+  {{ $scratch.Set "index" (add 1 ($scratch.Get "index")) }}
+  {{ end }}
+</div>
+{{ end }}

--- a/course-v3/layouts/partials/topics.html
+++ b/course-v3/layouts/partials/topics.html
@@ -1,0 +1,24 @@
+{{ $courseData := .context.Site.Data.course }}
+{{ $scratch := newScratch }}
+{{ $scratch.Set "index" 0 }}
+{{ $inPanel := .inPanel }}
+{{ $renderMarginTop := .renderMarginTop | default true}}
+<div class=" {{ if $renderMarginTop }}mt-4{{ end }}">
+  <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+    Topics
+  </div>
+  <ul class="list-unstyled pb-2 m-0 {{ if $inPanel }}panel-course-info-text{{ end }}">
+    {{- $topics := (slice (slice "Social Science" "Political Science" "American Politics") (slice "Social Science" "Public Administration" "Public Policy")) -}}
+
+    {{ with $courseData.topics }}
+      {{ $topics := partial "hierarchical_select_as_map.html" . }}
+
+      {{- range $topic, $subtopics := $topics -}}
+      <li>
+        {{- partial "topic.html" (dict "index" ($scratch.Get "index") "topic" $topic "subtopics" $subtopics) -}}
+      </li>
+      {{ $scratch.Set "index" (add 1 ($scratch.Get "index")) }}
+      {{- end -}}
+    {{ end }}
+  </ul>
+</div>

--- a/course-v3/layouts/partials/video-gallery-item.html
+++ b/course-v3/layouts/partials/video-gallery-item.html
@@ -1,0 +1,16 @@
+<div class="mb-2 border-gray rounded video-gallery-card">
+  <a class="video-link" href="{{- .RelPermalink -}}">
+    <div class="inner-container">
+      <div class="left-col">
+        {{- if isset .Params.video_files "video_thumbnail_file" -}}
+        <img class="thumbnail" src ="{{ .Params.video_files.video_thumbnail_file }}" alt="" />
+        {{- else -}}
+        <img class="youtube-logo-overlay" src="/static_shared/images/youtube.svg" alt="YouTube" />
+        {{- end -}}
+      </div>
+      <div class="right-col py-5">
+        <h5 class="video-title">{{ .Params.title }}</h5>
+      </div>
+    </div>
+  </a>
+</div>

--- a/course-v3/layouts/partials/video-gallery-page.html
+++ b/course-v3/layouts/partials/video-gallery-page.html
@@ -1,0 +1,13 @@
+{{- $ctx := . -}}
+{{- partial "course_content.html" . -}}
+{{/*
+  We check is_media_gallery here in case this is a legacy course. Legacy courses 
+  often render video galleries between the text and bottomtext, so ocw-to-hugo 
+  adds a video-gallery shortcode in the middle. So if it's a legacy course, we 
+  don't need to explicitly render the video gallery here.
+*/}}
+{{- if not (isset .Params "is_media_gallery") -}}
+  {{- if isset .Params "videos" -}}
+    {{- partial "video-gallery.html" . -}}
+  {{- end -}}
+{{- end -}}

--- a/course-v3/layouts/partials/video-gallery-page.json
+++ b/course-v3/layouts/partials/video-gallery-page.json
@@ -1,0 +1,25 @@
+{{- $ctx := . -}}
+{ 
+  "title": {{- .Title | jsonify -}},
+  "description": {{- .Description | jsonify -}}
+  {{- if not (isset .Params "is_media_gallery") -}}
+  {{- if isset .Params "videos" -}}
+  , 
+  "videos": [
+    {{- range $index, $uuid := .Params.videos.content -}}
+    {{- range $ctx.Site.Pages -}}
+      {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
+        {{- if $index -}}
+         ,  
+        {{- end -}}
+        {
+          "description": {{ .Params.description | jsonify }},
+          "file": {{ .Params.file | jsonify }}
+        }
+      {{- end -}}
+    {{- end -}}
+    {{- end -}}
+    ]
+  {{- end -}}
+  {{- end -}}
+}

--- a/course-v3/layouts/partials/video-gallery.html
+++ b/course-v3/layouts/partials/video-gallery.html
@@ -1,0 +1,9 @@
+{{- $ctx := . -}}
+{{- range .Params.videos.content -}}
+  {{- $uuid := . -}}
+  {{- range $ctx.Site.Pages -}}
+    {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
+      {{ partial "video-gallery-item.html" . }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/course-v3/layouts/resources/single.coursedata.json
+++ b/course-v3/layouts/resources/single.coursedata.json
@@ -1,0 +1,19 @@
+{
+  "title": {{- .Title | jsonify -}},
+  "description": {{ .Params.description | jsonify }},
+  "file": {{ .Params.file | jsonify }},
+  "learning_resource_types": {{ .Params.learning_resource_types| jsonify }},
+  "resource_type": {{ .Params.resourcetype | jsonify}},
+  "file_type": {{ .Params.file_type | jsonify}}
+  {{- if eq .Params.resourcetype "Image" -}}
+  ,
+  "image_metadata": {{ .Params.image_metadata | jsonify}}
+  {{- else if eq .Params.resourcetype "Video" -}}
+  ,
+  "youtube_key":  {{ .Params.video_metadata.youtube_id | jsonify}},
+  "captions_file": {{ .Params.video_files.video_captions_file | jsonify }},
+  "transcript_file": {{ .Params.video_files.video_transcript_file | jsonify }},
+  "thumbnail_file": {{ .Params.video_files.video_thumbnail_file | jsonify }},
+  "archive_url": {{ .Params.video_files.archive_url | jsonify }}
+  {{- end -}}
+}

--- a/course-v3/layouts/resources/single.html
+++ b/course-v3/layouts/resources/single.html
@@ -1,0 +1,4 @@
+{{ define "main" }}
+{{ partial "resource_title_v2.html" . }}
+{{ partial "resource_body_v2.html" . }}
+{{ end }}

--- a/course-v3/layouts/shortcodes/quiz_choice.html
+++ b/course-v3/layouts/shortcodes/quiz_choice.html
@@ -1,0 +1,5 @@
+{{ $correct := .Get "isCorrect" }}
+{{ $inner := .Inner }}
+{{ $questionId := .Parent.Parent.Get "questionId" }}
+
+{{ partial "quiz_multiple_choice_choice.html" (dict "correct" $correct "choiceText" $inner "questionId" $questionId) }}

--- a/course-v3/layouts/shortcodes/quiz_choices.html
+++ b/course-v3/layouts/shortcodes/quiz_choices.html
@@ -1,0 +1,2 @@
+{{ $questionId := .Parent.Get "questionId" }}
+<fieldset class={{$questionId}}>{{ .Inner }}</fieldset>

--- a/course-v3/layouts/shortcodes/quiz_multiple_choice.html
+++ b/course-v3/layouts/shortcodes/quiz_multiple_choice.html
@@ -1,0 +1,2 @@
+{{ $questionId := .Get "questionId" }}
+<div class="multiple-choice-question" id={{$questionId}}><p>{{ .Inner }}</p></div>

--- a/course-v3/layouts/shortcodes/quiz_solution.html
+++ b/course-v3/layouts/shortcodes/quiz_solution.html
@@ -1,0 +1,4 @@
+{{ $solution := .Inner }}
+{{ $questionId := .Parent.Get "questionId" }}
+
+{{ partial "quiz_multiple_choice_solution.html" (dict "solution" $solution "questionId" $questionId)}}

--- a/course-v3/layouts/shortcodes/resource_file.html
+++ b/course-v3/layouts/shortcodes/resource_file.html
@@ -1,0 +1,4 @@
+{{- $uuid := index .Params 0 -}}
+{{- range where $.Site.Pages "Params.uid" $uuid -}}
+{{- partial "resource_url.html" (dict "context" . "url" .Params.file) -}}
+{{- end -}}

--- a/course-v3/layouts/shortcodes/video-gallery.html
+++ b/course-v3/layouts/shortcodes/video-gallery.html
@@ -1,0 +1,1 @@
+{{ partial "video-gallery.html" .Page }}

--- a/course-v3/layouts/shortcodes/youtube.html
+++ b/course-v3/layouts/shortcodes/youtube.html
@@ -1,0 +1,4 @@
+{{ $youtubeId := index .Params 0 }}
+{{ $captionsLocation := index .Params 1}}
+{{ $transcriptPdfLocation := index .Params 2}}
+{{ partial "youtube_player.html" (dict "youtubeKey" $youtubeId "captionsLocation" $captionsLocation "transcriptPdfLocation" $transcriptPdfLocation) }}

--- a/course-v3/layouts/video_galleries/list.html
+++ b/course-v3/layouts/video_galleries/list.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "video-gallery-page.html" . }}
+{{ end }}

--- a/course-v3/layouts/video_galleries/single.coursedata.json
+++ b/course-v3/layouts/video_galleries/single.coursedata.json
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "video-gallery-page.json" . }}
+{{ end }}

--- a/course-v3/layouts/video_galleries/single.html
+++ b/course-v3/layouts/video_galleries/single.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "video-gallery-page.html" . }}
+{{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-themes/issues/1013

#### What's this PR do?
This PR adds the `course-v3` and `course-offline-v2` themes to the repo, which are duplicates of `course-v2` and `course-offline` respectively. This is being done to facilitate moving to rendering a course site using relative URLs and removing URL overrides in `course-offline` in a non-destructive manner.

#### How should this be manually tested?
 - Clone the `cg/course-relative` branch of `ocw-hugo-projects` (https://github.com/mitodl/ocw-hugo-projects/pull/244)
 - Point to the Hugo configs in the `ocw-course-v3` project in your env with `COURSE_HUGO_CONFIG_PATH=/path/to/ocw-hugo-projects/ocw-course-v3/config.yaml`
 - Run `yarn start course` to start a course of your choice
 - Inspect the various links in the nav, course title banner, etc. and make sure they are relative, clicking around the site to make sure they work
 - Switch your env back to `COURSE_HUGO_CONFIG_PATH=/path/to/ocw-hugo-projects/ocw-course-v2/config.yaml`
 - Restart the course site
 - If you inspect the links again, they should be back to being absolute URLs

#### Any background context you want to provide?
The following functionality is out of scope of this PR, and the reason we are creating a separate theme to get this work done is to be able to get the ball rolling without breaking these features in `course-v2`:

 - Links to other courses i.e. `/courses/course-1`
 - The sitemap

These features don't work on the local dev server anyway, but I figured it was worth noting here.