### PR TITLE
fix offline video gallery item url

### DIFF
--- a/course-v2/layouts/partials/video-gallery-item.html
+++ b/course-v2/layouts/partials/video-gallery-item.html
@@ -3,7 +3,7 @@
     <div class="inner-container">
       <div class="left-col">
         {{- if isset .Params.video_files "video_thumbnail_file" -}}
-        <img class="thumbnail" src ="{{ .Params.video_files.video_thumbnail_file }}" alt="" />
+        <img class="thumbnail" src="{{ .Params.video_files.video_thumbnail_file }}" alt="" />
         {{- else -}}
         <img class="youtube-logo-overlay" src="/static_shared/images/youtube.svg" alt="YouTube" />
         {{- end -}}

--- a/course-v2/layouts/partials/video-gallery-item.html
+++ b/course-v2/layouts/partials/video-gallery-item.html
@@ -1,5 +1,5 @@
 <div class="mb-2 border-gray rounded video-gallery-card">
-  <a class="video-link" href="{{- .RelPermalink -}}">
+  <a class="video-link" href="{{ partial "page_url.html" (dict "context" . "url" .RelPermalink) }}">
     <div class="inner-container">
       <div class="left-col">
         {{- if isset .Params.video_files "video_thumbnail_file" -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1063

#### What's this PR do?
This PR sets the `video-gallery-item.html` partial to use the `page_url.html` partial when generating a link to the video page for the video gallery item in question. This was missed in the original work pertaining to the offline theme. Calling the URL through this partial allows the proper URL to be rendered both when building the site using the normal online config as well as the offline config.

#### How should this be manually tested?
 - Download the course content repo at https://github.mit.edu/mitocwcontent/9.40-spring-2018
 - In `ocw-hugo-themes`, on this branch, run `yarn build /path/to/mitocwcontent/9.40-spring-2018 /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`, replacing the paths with your own
 - In the course content repo folder, browse to the `dist` folder and double click on `index.html`
 - Browse to the Lecture Videos section and click on any of the videos
 - Verify that you are brought to the proper video page
