### PR TITLE
remove download button from offline site

### DIFF
--- a/course-offline/layouts/partials/download_course_link_button.html
+++ b/course-offline/layouts/partials/download_course_link_button.html
@@ -1,0 +1,12 @@
+{{ $noResourcesFound := partial "show_no_resources_found.html" (dict "context" .context "taxonomy" "learning_resource_types") }}
+{{ $downloadPageUrl := partial "page_url.html" (dict "context" .context "url" "/download") }}
+{{ if not $noResourcesFound }}
+<hr>
+<div class="pb-3">
+  <a class="download-course-link-button btn btn-outline-primary btn-link link-button text-decoration-none px-4 py-2"
+    role="button"
+    href="{{- $downloadPageUrl -}}">
+    <div class="text-center w-100">Browse Resources</div>
+  </a>
+</div>
+{{ end }}

--- a/course-offline/layouts/partials/resources_header.html
+++ b/course-offline/layouts/partials/resources_header.html
@@ -1,0 +1,1 @@
+{{/* This file is intentionally left blank so a download button is not generated in the offline theme */}}

--- a/course-v2/layouts/partials/course_image_section.html
+++ b/course-v2/layouts/partials/course_image_section.html
@@ -16,7 +16,7 @@
         </div>
       </div>
       <div>
-        {{ partialCached "download_course_link_button.html" (dict "context" . "inPanel" true) }}
+        {{ partial "download_course_link_button.html" (dict "context" . "inPanel" true) }}
       </div>
     </div>
   </div>

--- a/course-v2/layouts/partials/desktop_course_info.html
+++ b/course-v2/layouts/partials/desktop_course_info.html
@@ -4,7 +4,7 @@
     <div class="px-3">
       {{ partial "topics.html" (dict "context" . "inPanel" true) }}
       {{ partial "learning_resource_types.html" (dict "context" . "inPanel" true) }}
-      {{ partialCached "download_course_link_button.html" (dict "context" . "inPanel" true) }}
+      {{ partial "download_course_link_button.html" (dict "context" . "inPanel" true) }}
     </div>
   </div>
 </div>

--- a/course-v2/layouts/partials/mobile_course_info.html
+++ b/course-v2/layouts/partials/mobile_course_info.html
@@ -20,5 +20,5 @@
   {{ partial "course_info.html" (dict "context" . "inPanel" true) }}
   {{ partial "topics.html" (dict "context" . "inPanel" true) }}
   {{ partial "learning_resource_types.html" (dict "context" . "inPanel" true) }}
-  {{ partialCached "download_course_link_button.html" (dict "context" . "inPanel" true) }}
+  {{ partial "download_course_link_button.html" (dict "context" . "inPanel" true) }}
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1083

#### What's this PR do?
This PR changes how the "Download Course" button is rendered in the `course-offline` theme. It doesn't make any sense to render a button that says "Download Course" in an offline course that you have already downloaded. However, the `/download` page is still useful if a course has been tagged with `learning_resource_type` taxonomy tags, as a helpful list of categorized resources will be there. If a course has these tags, a link will still be generated in the course info drawer but it will now say "Browse Resources."

The "Download Course" button and banner that shows up at the top of online courses has been overridden and removed in `course-offline`, because it obviously doesn't make any sense to download a full zipped version of the offline course inside an offline course you have already downloaded.

#### How should this be manually tested?
 - Download the course content repo at https://github.mit.edu/mitocwcontent/9.40-spring-2018
 - In `ocw-hugo-themes`, on this branch, run `yarn build /path/to/mitocwcontent/9.40-spring-2018 /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`, replacing the paths with your own
 - In the course content repo folder, browse to the `dist` folder and double click on `index.html`
 - Click the "Browse Resources" button to be brought to the `/download` page and verify that there is no "Download Course" banner and button at the top of the page
 - With `OCW_TEST_COURSE=9.40-spring-2018` in your `.env`, run `yarn start course`
 - Visit http://localhost:3000 and verify that the button in the course info drawer says "Download Course" again
 - Click the link and verify that the "Download Course" banner and button are at the top of the download page (the link will not work when running through the Hugo dev server)


#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/218879721-c1f92b21-20d9-431d-bfbe-db7a0d48ff45.png)
![image](https://user-images.githubusercontent.com/12089658/218879856-be082b3a-56e1-4a0f-9406-5dd92c2d3259.png)
![image](https://user-images.githubusercontent.com/12089658/218879947-b7286272-7fad-4f5e-b118-209fe663d952.png)
![image](https://user-images.githubusercontent.com/12089658/218880010-9b8741b6-001d-469f-ba4a-b91231623531.png)

