### PR TITLE
Fix: Image Gallery Controls Not Rendering

### DIFF
--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -82,7 +82,7 @@ const config: webpack.Configuration = {
             ]
           },
           {
-            use:  [
+            use: [
               {
                 loader:  "file-loader",
                 options: {
@@ -90,8 +90,8 @@ const config: webpack.Configuration = {
                 }
               }
             ]
-          },
-        ],
+          }
+        ]
       },
       {
         test:    /\.(t|j)sx?$/,

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -51,7 +51,7 @@ const config: webpack.Configuration = {
   module: {
     rules: [
       {
-        test: /nanogallery2/,
+        test: /nanogallery2(?!.*\.(woff|woff2)$)/,
         use:  "imports-loader?module.exports=>undefined&exports=>undefined"
       },
       {
@@ -65,17 +65,33 @@ const config: webpack.Configuration = {
           }
         ]
       },
-
       {
         test: /\.(woff|ttf|woff2|eot)$/,
-        use:  [
+        oneOf: [
           {
-            loader:  "file-loader",
-            options: {
-              name: "fonts/[fullhash].[ext]"
-            }
-          }
-        ]
+            test: /nanogallery2/,
+            use:  [
+              {
+                loader:  "file-loader",
+                options: {
+                  publicPath: "./",
+                  outputPath: "css",
+                  name: "fonts/[contenthash].[ext]"
+                }
+              }
+            ]
+          },
+          {
+            use:  [
+              {
+                loader:  "file-loader",
+                options: {
+                  name: "fonts/[contenthash].[ext]"
+                }
+              }
+            ]
+          },
+        ],
       },
       {
         test:    /\.(t|j)sx?$/,

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -66,7 +66,7 @@ const config: webpack.Configuration = {
         ]
       },
       {
-        test: /\.(woff|ttf|woff2|eot)$/,
+        test:  /\.(woff|ttf|woff2|eot)$/,
         oneOf: [
           {
             test: /nanogallery2/,
@@ -76,7 +76,7 @@ const config: webpack.Configuration = {
                 options: {
                   publicPath: "./",
                   outputPath: "css",
-                  name: "fonts/[contenthash].[ext]"
+                  name:       "fonts/[contenthash].[ext]"
                 }
               }
             ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

Closes https://github.com/mitodl/ocw-hugo-themes/issues/1057

#### What's this PR do?

This PR changes two webpack rules.

1. Excludes nanogallery fonts from being "unexported".
2. Updates fonts file-loader rule to place nanogallery fonts under `static_shared/css/fonts`. 

#### How should this be manually tested?

1. Clear your browser's cache and disable AdBlock (if any).
2. Open your local clone of [cw-hugo-themes](https://github.com/mitodl/ocw-hugo-themes)
3. Checkout `hussaintaj/1057-gallery-controls`
4. Copy [2.672-spring-2009](https://github.mit.edu/ocw-content-rc/2.672-spring-2009) into your content folder.
5. Set `OCW_TEST_COURSE=2.672-spring-2009` in your .env file. (This should be your course content directory name)
6. Run `yarn start course`
7. Visit `http://localhost:3000/pages/labs/#nanogallery/fd614745-fc1f-6cb1-a422-ffc6befbbdd1_nanogallery2/0/1`
**Expected Result**: At this point, you should see the gallery widget with the controls being rendered properly. Please refer to the images attached below.
8. Open Developer Tools in your browser. Navigate to the Network tab. And browse the site.
**Expected Result**: You see no 404s for font resources.
9. Run `yarn start www` and repeat step 8.

#### Any background context you want to provide?

(Optional to read) relevant issue https://github.com/mitodl/ocw-hugo-themes/issues/1033

#### Screenshots (if appropriate)
Desktop

<img alt="Desktop Screenshot" width="400" src="https://user-images.githubusercontent.com/71316217/219633597-5b6c534c-5c40-47a5-b4d6-77382fcf77dd.jpg" />

Mobile

<img alt="Mobile Screenshot" height="400" src="https://user-images.githubusercontent.com/71316217/219633622-f1fee526-d32c-4e1e-8ddd-7cbdb7ef6fa6.jpg" />
