### PR TITLE
Fix: TypeError on missing transcripts

### DIFF
--- a/course-v2/assets/js/video_transcript_track.js
+++ b/course-v2/assets/js/video_transcript_track.js
@@ -10,13 +10,18 @@ export const initVideoTranscriptTrack = () => {
         window.videojs = videojs
         require("videojs-transcript-ac")
 
-        const options = {
-          showTitle:         false,
-          showTrackSelector: false
-        }
+        let transcript = null
+        const hasTextTracks = this.textTracks().length !== 0
 
-        // @ts-expect-error TODO
-        const transcript = this.transcript(options)
+        if (hasTextTracks) {
+          const options = {
+            showTitle:         false,
+            showTrackSelector: false
+          }
+
+          // @ts-expect-error TODO
+          transcript = this.transcript(options)
+        }
 
         if (videoPlayer.closest(".video-page")) {
           // @ts-expect-error TODO
@@ -25,7 +30,7 @@ export const initVideoTranscriptTrack = () => {
             .querySelector(".transcript")
             ?.querySelector(".video-tab-content-section")
 
-          if (transcriptContainer) {
+          if (transcript && transcriptContainer) {
             transcriptContainer.appendChild(transcript.el())
           }
         }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/948

#### What's this PR do?
This PR updates the video transcript initialization code. The script will now check for text tracks (captions) before it creates the transcript. In case there are no captions, no transcript is created.

#### How should this be manually tested?

To test this change locally, follow these steps.

1. Clone and setup [3.091-fall-2018](https://github.mit.edu/ocw-content-rc/3.091-fall-2018) course.
2. On your local ocw-hugo-themes repo, checkout `hussaintaj/948-type-error`.
3. At https://github.com/mitodl/ocw-hugo-themes/blob/bfdf78acff2583e13585f98bb8e08399ad3a3b73/base-theme/layouts/partials/youtube_player.html#L22
  temporarily change `"type": "video/youtube"` to `"type": "video"`.
  **Rationale**: Locally, video.js throws an origin error. The exact cause is unknown to me. This error prevents the script from moving forward and logging the error mentioned in the related issue. Setting the type to something random breaks the video, however, it allows the script to proceed and log the error we see on production.
4. Run `yarn start course 3.091-fall-2018`
5. Visit [http://localhost:3000/resources/lecture-1/](http://localhost:3000/resources/lecture-1/)
6. In the developer console, you should **not** see the TypeError described in https://github.com/mitodl/ocw-hugo-themes/issues/948
  PS: The video might be broken. It is not a cause for concern. It was caused by our temporary change in step 3. Revert that step and it will start to work. 