### PR TITLE
Fix: Bad links on offline Download page

### DIFF
--- a/course-offline/layouts/partials/resource_list_item_title.html
+++ b/course-offline/layouts/partials/resource_list_item_title.html
@@ -1,0 +1,3 @@
+<a class="resource-list-title" href="{{ .permalink }}index.html">
+    {{ .title }}
+</a>

--- a/course-v2/layouts/partials/resource_list_item.html
+++ b/course-v2/layouts/partials/resource_list_item.html
@@ -23,9 +23,7 @@
           </span>
       {{ end }}
       <div class="pt-2">
-        <a class="resource-list-title" href="{{ .permalink }}">
-          {{ .params.title }}
-        </a>
+        {{partial "resource_list_item_title.html" (dict "permalink" .permalink "title" .params.title)}}
       </div>
     </div>
   </div>

--- a/course-v2/layouts/partials/resource_list_item_title.html
+++ b/course-v2/layouts/partials/resource_list_item_title.html
@@ -1,0 +1,3 @@
+<a class="resource-list-title" href="{{ .permalink }}">
+    {{ .title }}
+</a>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1095 

#### What's this PR do?
This PR appends "index.html" to downloaded course resource files to open correctly

#### How should this be manually tested?
- Download the course content repo at https://github.mit.edu/mitocwcontent/18.06-spring-2010
- In ocw-hugo-themes, on this branch, run yarn build /path/to/mitocwcontent/18.06-spring-2010 /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml, replacing the paths with your own
- In the course content repo folder, browse to the dist/download folder and double click on index.html
- Try to click on any link and you should be redirected to the correct path ending in index.html

