### PR TITLE
Fix: Search page has double thumbnail/compact buttons on mobile

### DIFF
--- a/www/assets/css/search.scss
+++ b/www/assets/css/search.scss
@@ -227,7 +227,10 @@
     }
 
     .layout-buttons-mobile {
-      display: inline-block;
+      @include breakpoint(mobile) {
+        display: inline-block;
+      }
+      display: none;
       float: right;
       padding-right: 20px button {
         height: 32px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1093

#### What's this PR do?
This PR updates the CSS rules to hide the mobile buttons by default and shows them on mobile view.

#### How should this be manually tested?
1. Navigate to your directory where [ocw-hugo-themes](https://github.com/mitodl/ocw-hugo-themes) is set up.
2. Run `yarn start www`
3. Open `http://localhost:3000/search`
4. Open brower's Developer Tools and open device toolbar. Change the website's size gradually and observe the change. See the video attached below for reference. You should always see only one set of layout buttons.


#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/71316217/222415712-be7b1d3a-645d-41dd-9190-4cf0ebb0f5a4.mov


