### PR TITLE
feat: lazyloading for nanogallery2 using dynamic import

### DIFF
--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -17,7 +17,7 @@ const entryNames = {
   instructorInsights: "instructor_insights",
   courseV2:           "course_v2",
   www:                "www",
-  fields:             "fields",
+  fields:             "fields"
 }
 
 const config: webpack.Configuration = {
@@ -40,7 +40,7 @@ const config: webpack.Configuration = {
     [entryNames.fields]: [
       fromRoot("./fields/assets/fields.js"),
       fromRoot("./base-theme/assets/index.ts")
-    ],
+    ]
   },
 
   output: {

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -18,8 +18,6 @@ const entryNames = {
   courseV2:           "course_v2",
   www:                "www",
   fields:             "fields",
-  videojs:            "videojs",
-  nanogallery2:       "nanogallery2"
 }
 
 const config: webpack.Configuration = {
@@ -43,10 +41,6 @@ const config: webpack.Configuration = {
       fromRoot("./fields/assets/fields.js"),
       fromRoot("./base-theme/assets/index.ts")
     ],
-    [entryNames.videojs]:      [fromRoot("./course-v2/assets/videojs-imports.js")],
-    [entryNames.nanogallery2]: [
-      fromRoot("./course-v2/assets/nanogallery2-imports.js")
-    ]
   },
 
   output: {

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -18,7 +18,8 @@ const entryNames = {
   courseV2:           "course_v2",
   www:                "www",
   fields:             "fields",
-  videojs:            "videojs"
+  videojs:            "videojs",
+  nanogallery2:       "nanogallery2"
 }
 
 const config: webpack.Configuration = {
@@ -42,7 +43,10 @@ const config: webpack.Configuration = {
       fromRoot("./fields/assets/fields.js"),
       fromRoot("./base-theme/assets/index.ts")
     ],
-    [entryNames.videojs]: [fromRoot("./course-v2/assets/videojs-imports.js")]
+    [entryNames.videojs]:      [fromRoot("./course-v2/assets/videojs-imports.js")],
+    [entryNames.nanogallery2]: [
+      fromRoot("./course-v2/assets/nanogallery2-imports.js")
+    ]
   },
 
   output: {

--- a/base-theme/layouts/shortcodes/image-gallery.html
+++ b/base-theme/layouts/shortcodes/image-gallery.html
@@ -1,3 +1,10 @@
 <div id="{{ .Get "id" }}" class="image-gallery" data-nanogallery2='{ "itemsBaseURL": "{{ .Get "baseUrl" }}" }'>
 {{ .Inner }}
 </div>
+
+<script>
+    window.onload = function() {
+      if (window.initNanogallery2)
+        window.initNanogallery2()
+    }
+</script>

--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -1,9 +1,9 @@
-import "../../node_modules/nanogallery2/src/css/nanogallery2.css"
 import "video.js/dist/video-js.css"
 
 import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
-import "nanogallery2/src/jquery.nanogallery2.core.js"
 import "promise-polyfill/src/polyfill.js"
+import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
+
 import "./css/course-v2.scss"
 import { initDivToggle } from "./js/div_toggle"
 import {
@@ -32,3 +32,6 @@ window.initVideoJS = () =>
   import("./videojs-imports").then(module => {
     module.initVideoJS()
   })
+
+// @ts-expect-error for window.initNanogallery2()
+window.initNanogallery2 = () => import("./nanogallery2-imports")

--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -1,6 +1,7 @@
 import "video.js/dist/video-js.css"
 
 import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
+import "promise-polyfill/src/polyfill.js"
 import "./css/course-v2.scss"
 import { initDivToggle } from "./js/div_toggle"
 import {

--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -3,7 +3,6 @@ import "video.js/dist/video-js.css"
 import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
 import "promise-polyfill/src/polyfill.js"
 import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
-
 import "./css/course-v2.scss"
 import { initDivToggle } from "./js/div_toggle"
 import {

--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -1,7 +1,6 @@
 import "video.js/dist/video-js.css"
 
 import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
-import "promise-polyfill/src/polyfill.js"
 import "./css/course-v2.scss"
 import { initDivToggle } from "./js/div_toggle"
 import {

--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -2,7 +2,6 @@ import "video.js/dist/video-js.css"
 
 import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
 import "promise-polyfill/src/polyfill.js"
-import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
 import "./css/course-v2.scss"
 import { initDivToggle } from "./js/div_toggle"
 import {

--- a/course-v2/assets/nanogallery2-imports.js
+++ b/course-v2/assets/nanogallery2-imports.js
@@ -1,0 +1,2 @@
+import "nanogallery2/src/jquery.nanogallery2.core.js"
+import "../../node_modules/nanogallery2/src/css/nanogallery2.css"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
#648 

#### What's this PR do?
This PR implements lazy loading for nanogallery2 using dynamic import. It also uses promise-polyfill for IE11 support.

#### How should this be manually tested?
This PR requires testing both i) videoJS ii) nanogallery2
Since the issue number is same for videoJS (and the nature of work too), therefore I just made the changes here instead of opening a new PR.
The testing for videoJS:
1. Checkout this branch.
2. Clear your cache
3. Get this course: [9.40-spring-2018](https://github.mit.edu/ocw-content-rc/9.40-spring-2018)
4. In your .env file, `OCW_TEST_COURSE=9.40-spring-2018`
5. `yarn start course`
6. Go to "[Lecture Videos](http://localhost:3000/video_galleries/lecture-videos/)"
7. Play any video. Make sure it plays.

**To test for Internet Explorer 11:**

1. Login to browserstack live.
2. Select Internet Explorer 11
3. Use [this netflify link](https://ocw-hugo-themes-course-v2-pr-1108--ocw-next.netlify.app/video_galleries/lecture-videos/) and play any video. Make sure it plays.

to test nanogallery2, we will have to use a course that uses image gallery.
1. Checkout this branch.
8. Clear your cache
9. Get this course: [2.672-spring-2009](https://github.mit.edu/ocw-content-rc/2.672-spring-2009)
10. In your .env file, `OCW_TEST_COURSE=2.672-spring-2009`
11. `yarn start course`
12. Go to [labs](http://localhost:3000/pages/labs/) and from there open any image gallery.
13. Right now you will not be able to open any image (they will appear black/blank because of URL misconfiguration which is not a part of this PR) but make sure nanogallery2 is working (press left/right to swipe between blank images)

nanogallery2 has also to be tested on Internet Explorer 11 to check for its compatibility. However, right now it is not possible to test using Browserstack on [Netlify link](https://ocw-hugo-themes-course-v2-pr-1108--ocw-next.netlify.app/) because we do not have the Image Gallery on the default course there. However, since we checked videoJS on IE11 and it worked, it is expected that nanogallery2 should work too because their overall code nature is same. We'll test the IE11 compatibility via Browserstack once this is on RC. 
