### PR TITLE
fix: tsconfig.json errors for Overwriting Input File

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "outDir": "dist"
   },
   "include": [
     "./base-theme/assets/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,7 @@
   ],
   "exclude": [
     "./base-theme/assets/webpack",
-    "./dist/**/*"
+    "./dist/**/*.js"
   ],
   "ts-node": {
     "files": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "./dist"
   },
   "include": [
     "./base-theme/assets/**/*.ts",
@@ -35,7 +35,8 @@
     "./www/assets/**/*.js",
   ],
   "exclude": [
-    "./base-theme/assets/webpack"
+    "./base-theme/assets/webpack",
+    "./dist/**/*"
   ],
   "ts-node": {
     "files": true,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1114

#### What's this PR do?
This PR sets an output directory (`outDir`) in `compilerOptions` with exclude path so that the compiled Javascript files will not attempt to overwrite the input files which were previously placed right next to the input files with the same names.

#### How should this be manually tested?
1. Checkout to this branch
2. Run `npx tsc --build`
3. Observe that there are no errors reported.
