### PR TITLE
run image gallery base urls through resource_url.html

### DIFF
--- a/base-theme/layouts/shortcodes/image-gallery.html
+++ b/base-theme/layouts/shortcodes/image-gallery.html
@@ -1,4 +1,5 @@
-<div id="{{ .Get "id" }}" class="image-gallery" data-nanogallery2='{ "itemsBaseURL": "{{ .Get "baseUrl" }}" }'>
+{{ $baseUrl := .Get "baseUrl" }}
+<div id="{{ .Get "id" }}" class="image-gallery" data-nanogallery2='{ "itemsBaseURL": "{{ partial "resource_url.html" (dict "context" . "url" $baseUrl) }}" }'>
 {{ .Inner }}
 </div>
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1109

#### What's this PR do?
This PR takes the `baseUrl` property of image gallery shortcodes and passes it through `resource_url.html` before sending it along to nanogallery. This has the effect of prefixing images with `RESOURCE_BASE_URL` if it is set, and allows image galleries to function when testing sites locally by requesting images that don't exist locally from the live OCW site instead.

#### How should this be manually tested?
 - Get this course: [2.672-spring-2009](https://github.mit.edu/ocw-content-rc/2.672-spring-2009)
 - In your .env file, set:
```
OCW_TEST_COURSE=2.672-spring-2009
RESOURCE_BASE_URL=https://ocw.mit.edu/
```
 - Run `yarn start course`
 - Go to [labs](http://localhost:3000/pages/labs/) and from there open any image gallery.

#### Where should the reviewer start?
`base-theme/layouts/shortcodes/image-gallery.html`
