### PR TITLE
feat: YouTube controller design layout for embed videos

### DIFF
--- a/base-theme/layouts/partials/video_embed.html
+++ b/base-theme/layouts/partials/video_embed.html
@@ -6,6 +6,8 @@
 {{ $startTime := $resource.Params.start_time | default "" }}
 {{ $endTime := $resource.Params.end_time | default "" }}
 {{ $downloadLink := $resource.Params.file }}
+{{ $transcriptPdfLocation := partial "resource_url.html" (dict "context" . "url" $resource.Params.video_files.video_transcript_file) }}
+
 {{ if (eq $downloadLink nil) }}
 {{ $downloadLink = $resource.Params.video_files.archive_url }}
 {{ else }}
@@ -16,11 +18,6 @@
   {{ partial "youtube_player.html" (dict "youtubeKey" $youtubeKey "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime "downloadLink" $downloadLink) }}
   {{ range where site.Pages "Params.uid" $uid }}
   {{ $resourceUrl := partial "page_url.html" (dict "context" $context "url" .Permalink) }}
-  <div class="video-buttons-container">
-      <div class='video-page-link-section' onclick="window.location='{{ $resourceUrl }}';">
-        <div class="video-page-link">View video page</div>
-        <i class="material-icons video-page-link">chevron_right</i>
-      </div>
-    </div>
+  {{ partial "video_expandable_tab.html" (dict "tabTitle" "View video page" "downloadLink" $downloadLink "transcriptLink" $transcriptPdfLocation "resourceUrl" $resourceUrl) }}
   {{ end }}
 </div>

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -7,12 +7,17 @@
   >
   <div class="video-tab-header">
     {{ if .tabTitle }}
-      <i class="material-icons toggle md-18"></i>
-      <span class="tab-title">
-        {{- .tabTitle -}}
+      {{/*  In case of embed videos, the tab bar should be a link  */}}
+      <span class="tab-title-section" {{ if and .resourceUrl (not .tabClass) }} onclick="window.location='{{ .resourceUrl }}';"{{ end }}>
+        <i class="material-icons toggle md-18"></i>
+        <span class="tab-title">
+          {{- .tabTitle -}}
+        </span>
       </span>
     {{ end }}
-    {{ if or (eq .tabTitle "Transcript") (eq .tabTitle "") }}
+    {{/*  If we have transcript or the video is embed video, show download button on those tabs.
+      Otherwise show download button in a standalone tab bar  */}}
+    {{ if or (eq .tabTitle "Transcript") (eq .tabTitle "View video page") (eq .tabTitle "") }}
       <div class="float-right">
         <div class="video-download-icons">
           <img class="video-download-icon" src="/static_shared/images/videojs_download.svg"/>

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -7,8 +7,13 @@
   >
   <div class="video-tab-header">
     {{ if .tabTitle }}
-      {{/*  In case of embed videos, the tab bar should be a link  */}}
-      <span class="tab-title-section" {{ if and .resourceUrl (not .tabClass) }} onclick="window.location='{{ .resourceUrl }}';"{{ end }}>
+      {{/*  In case of embed videos, the tab bar should have a clickable link  */}}
+      <span 
+        class="tab-title-section" 
+        {{ if and .resourceUrl (eq .tabTitle "View video page") }} 
+        onclick="window.location='{{ .resourceUrl }}';"
+        {{ end }}
+        >
         <i class="material-icons toggle md-18"></i>
         <span class="tab-title">
           {{- .tabTitle -}}

--- a/base-theme/layouts/partials/youtube_player.html
+++ b/base-theme/layouts/partials/youtube_player.html
@@ -1,13 +1,13 @@
 {{ $random := delimit (shuffle (split (md5 "seed") "" )) "" }}
-{{$youtubeParams:=""}}
+{{$youtubeParams:=`, "youtube": {`}}
 {{if and (ne .startTime "") (ne .endTime "")}}
-{{$youtubeParams =  delimit (slice `, "youtube": { "start": ` .startTime `, "end":`  .endTime  `}`) "" }}
+{{$youtubeParams = printf "%s" (delimit (slice `"start": ` .startTime `, "end":`  .endTime  `, `) "" ) | printf "%s%s" $youtubeParams}}
 {{else if ne .startTime ""}}
-{{$youtubeParams =  delimit (slice `, "youtube": { "start": ` .startTime `}`) "" }}
+{{$youtubeParams = printf "%s" (delimit (slice `"start": ` .startTime `, `) "") | printf "%s%s" $youtubeParams }}
 {{else if ne .endTime ""}}
-{{$youtubeParams =  delimit (slice `, "youtube": { "end": ` .endTime `}`) "" }}
+{{$youtubeParams = printf "%s" (delimit (slice `"end": ` .endTime `, `) "") |  printf "%s%s" $youtubeParams }}
 {{end}}
-
+{{$youtubeParams = printf "%s" `"ytControls":2}` | printf "%s%s" $youtubeParams |}}
 <div class="video-container embedded-video-container">
   <video
     id="video-player-{{ .youtubeKey }}-{{ $random }}"
@@ -17,7 +17,6 @@
     data-transcriptlink = "{{ .transcriptLink }}" 
     data-setup='{
     "fluid": true,
-    "youtube": { "ytControls": 2 },
     "techOrder": ["youtube"],
     "inactivityTimeout": 0,
     "sources": [{"type": "video/youtube", "src": "https://www.youtube.com/embed/{{ .youtubeKey }}"}]

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -57,16 +57,13 @@
 
 .video-embed {
   max-width: $video-section-max-width;
-}
+  margin-bottom: 15px;
 
-.embedded-video-container {
-  // this padding will be applied when video is embedded
-  padding-bottom: 44px;
-  background-color: $light-gray;
 }
 
 .video-page {
   max-width: $video-section-max-width;
+  margin-bottom: 15px;
 
   .video-container {
     height: 0;
@@ -85,12 +82,6 @@
   }
 }
 
-.video-buttons-container {
-  background-color: $light-gray;
-  overflow: hidden;
-  margin-bottom: 35px;
-}
-
 .video-download-container {
   float: right;
   padding-top: 25px;
@@ -106,22 +97,6 @@
 
 a.video-download-button:visited {
   color: white;
-}
-
-.video-page-link-section {
-  padding: 5px 15px 5px;
-  display: inline-flex;
-}
-
-.video-page-link {
-  text-decoration: none;
-  color: $black !important;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.video-page-link:hover {
-  text-decoration: none !important;
 }
 
 #course-main-content a.download-file.video-download-button:link {

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -58,7 +58,6 @@
 .video-embed {
   max-width: $video-section-max-width;
   margin-bottom: 15px;
-
 }
 
 .video-page {
@@ -140,7 +139,7 @@ a.video-download-button:visited {
   display: block;
   padding: 5px 40px 5px 5px;
   text-decoration: none;
-  color: $black;
+  color: $black !important;
 }
 
 .video-tab-download-popup a:hover {

--- a/course-v2/assets/css/videojs_player.scss
+++ b/course-v2/assets/css/videojs_player.scss
@@ -16,7 +16,7 @@ $slider-color: $pink;
   }
 
   .vjs-control-bar {
-    display: none;
+    display: none !important;
   }
 
   .vjs-control-bar-offline {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1103 and https://github.com/mitodl/hq/issues/1196

#### What's this PR do?
This PR updates design layout for embed videos. It also fixes the bug issued in https://github.com/mitodl/hq/issues/1196 by updating youtubeParams.

#### How should this be manually tested?

For any of these changes (start time, end time, or general layout related changes), sometimes they can take a little time even after clearing cache and using incognito window. If it still does not work, try clearing cache a couple of times, give it a minute or two, and then try again.

Firstly, follow the testing steps on [this PR](https://github.com/mitodl/ocw-hugo-themes/pull/1115). They will be repeated exactly as they are, but you will be checking out to this branch instead.

Next, we will have to test a sample course to test for embed videos. And we will also be testing that `start_time` and `end_time` of videos are functioning properly with the new changes. 

Clear cache, and use new incognito window.
Use this course: [18.02sc-fall-2010](https://github.mit.edu/ocw-content-rc/18.02sc-fall-2010)
1. Checkout to this branch
2. Make sure you update the above course in your .env
3. Run `yarn start course`
4. Go to this link: http://localhost:3000/pages/2.-partial-derivatives/part-a-functions-of-two-variables-tangent-approximation-and-optimization/session-27-approximation-formula/
Note: You can do the next step (5) in combination of step (7) to save time.
5. For the recitation video (embed video), Make sure the YouTube controls are working + "VIEW VIDEO PAGE" is in black tab bar (clickable) + Download icon is there with "Download video" and "Download transcript" links. The look should match the InVision designs in these links:
https://projects.invisionapp.com/d/main?origin=v7#/console/21537330/472347461/preview
https://projects.invisionapp.com/d/main?origin=v7#/console/21537330/472347462/preview
6. We will also make sure our single video YouTube controller is also working on embed video courses: Go to this link http://localhost:3000/resources/clip-approximation-formula/ and make sure the changes you tested in the above PR are also prevalent on this link. 
7. Now we will edit `start_time` and `end_time` for all their possible combinations for the recitation video in step 4. Values for all combinations can be: `{(ST: 5, ET: 9), (ST: 5, ET: ''), (ST: '', ET: 9), (ST: '', ET: '')} `
8. Go to this markdown file for the recitation video in your local ocw-content-rc directory: `18.02sc-fall-2010/content/resources/tangent-plane-approximation.md`
9. You will see that currently the `start_time` and `end_time` are set to empty in the markdown file. Test the video in step 4 for this case. Similarly test for the remaining 3 test cases in (7) step by editing the video's markdown file and saving it. Terminate the project and run `yarn start course` for each of the test case (along with clearing cache measures). Make sure that the video starts to the given `start_time`, and **automatically** ends at the given `end_time` (if you force this behavior through keyboard arrow keys, the video will not end at the given end time. So let the video end naturally at the given end time mentioned in the file)

#### Screenshots (if appropriate)
<img width="874" alt="image" src="https://user-images.githubusercontent.com/109785089/231247123-7dc6ab8e-e28e-4871-a19b-e9b8ac198630.png">
<img width="478" alt="image" src="https://user-images.githubusercontent.com/109785089/231412703-fe059aad-d444-469f-8a84-e28d0b3e3c0d.png">
