### PR TITLE
Video player not loading for Spaced Youtube IDs

### DIFF
--- a/base-theme/layouts/partials/video.html
+++ b/base-theme/layouts/partials/video.html
@@ -1,4 +1,4 @@
-{{ $youtubeKey := .Params.video_metadata.youtube_id }}
+{{ $youtubeKey := trim .Params.video_metadata.youtube_id " "}}
 {{ $captionsLocation := partial "video_captions_file_url.html" (dict "context" . "url" .Params.video_files.video_captions_file) }}
 {{ $transcriptPdfLocation := partial "resource_url.html" (dict "context" . "url" .Params.video_files.video_transcript_file) }}
 {{ $downloadLink := .Params.file }}

--- a/base-theme/layouts/partials/video_embed.html
+++ b/base-theme/layouts/partials/video_embed.html
@@ -1,6 +1,6 @@
 {{ $context := .context }}
 {{ $resource := .resource }}
-{{ $youtubeKey := $resource.Params.video_metadata.youtube_id }}
+{{ $youtubeKey := trim $resource.Params.video_metadata.youtube_id " "}}
 {{ $captionsLocation := partial "video_captions_file_url.html" (dict "context" . "url" $resource.Params.video_files.video_captions_file) }}
 {{ $uid := $resource.Params.uid }}
 {{ $startTime := $resource.Params.start_time | default "" }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1200

#### What's this PR do?
It trims the spaces in youtube ids which were causing the player to not load for some videos

#### How should this be manually tested?
1. Go to the main branch
2. Download this course https://github.mit.edu/ocw-content-rc/6.01sc-spring-2011
3. In ocw-hugo-theme, run `yarn start course 6.01sc-spring-2011`
4. Go to lecture 2 video  (the video should not load)
5. Now checkout to this branch,
6. Repeat step 3, 4 (The video should now be loaded correctly)
