### PR TITLE
fix course-offline image gallery bug

### DIFF
--- a/base-theme/layouts/shortcodes/image-gallery.html
+++ b/base-theme/layouts/shortcodes/image-gallery.html
@@ -1,5 +1,5 @@
 {{ $baseUrl := .Get "baseUrl" }}
-<div id="{{ .Get "id" }}" class="image-gallery" data-nanogallery2='{ "itemsBaseURL": "{{ partial "resource_url.html" (dict "context" . "url" $baseUrl) }}" }'>
+<div id="{{ .Get "id" }}" class="image-gallery" data-nanogallery2='{ "itemsBaseURL": "{{ partial "resource_url.html" (dict "context" .Page "url" $baseUrl) }}" }'>
 {{ .Inner }}
 </div>
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1142

#### What's this PR do?
This PR fixes a bug with the use of the `image-gallery.html` shortcode in sites that use the `course-offline` theme. The error is caused by passing the improper context variable to the `resource_url.html` partial. The `.` variable is set on `context`, whereas in shortcodes it should be `.Page`.

#### How should this be manually tested?
 - Clone https://github.mit.edu/ocw-content-rc/5.36-spring-2009
 - Clone [`ocw-hugo-projects`](https://github.com/mitodl/ocw-hugo-projects)
 - In `ocw-hugo-themes` on this branch, run `yarn build /path/to/ocw-content-rc/5.36-spring-2009 /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`
 - Verify that the site builds correctly

#### Any background context you want to provide?
If you visit the image gallery in the offline site after rendering, you may notice that it does not display properly. This is because of this issue: https://github.com/mitodl/ocw-hugo-themes/issues/1143. I believe this has to do with the Webpack bundle splitting functionality we added recently. The CSS link tag is being added dynamically at runtime with JS and the URL being used is a relative URL of type path-absolute, meaning it starts with a backslash. When running a site completely offline without a web server, the browser treats this as the root of your filesystem and the file is not found. The `course-offline` theme uses the `relativeUrls: true` Hugo setting to post-process `href`, `src` and other tags containing links, making them relative to the site root. This does not work, however, if the links are written in dynamically at runtime. We will need to use a different approach for offline sites in this regard.
