### PR TITLE
replace <div> with semantic heading tags in course theme

### DIFF
--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -7,10 +7,7 @@ $panel-course-info-text-color: #464646;
 }
 
 .panel-course-info-title {
-  font-size: $course-heading-five-font;
-  line-height: $course-heading-five-line-height;
   text-transform: uppercase;
-  font-weight: bold;
   color: $panel-course-info-text-color !important;
 }
 

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -161,9 +161,6 @@ pre {
 }
 
 .course-detail-title {
-  font-size: $course-heading-four-font;
-  line-height: $course-heading-four-line-height;
-  font-weight: bold;
   margin-bottom: 10px;
 }
 

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -164,6 +164,11 @@ pre {
   margin-bottom: 10px;
 }
 
+.course-detail-title h2 {
+  font-size: $course-heading-four-font !important;
+  line-height: $course-heading-four-line-height !important;
+}
+
 // TODO: overriding some css of header and footer in this new theme
 // when we roll out this theme completely then we can move this css to thier respective files in base-theme
 

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -81,13 +81,11 @@ h5 {
 
   a {
     text-decoration: none;
-    font-size: $course-heading-one-font-lg;
-    line-height: $course-heading-one-line-height-lg;
+  }
+
+  h1 {
     font-weight: 400;
-    @include media-breakpoint-down(xs) {
-      font-size: $course-heading-one-font-xs;
-      line-height: $course-heading-one-line-height-xs;
-    }
+    margin-bottom: 0px;
   }
 }
 
@@ -162,11 +160,11 @@ pre {
 
 .course-detail-title {
   margin-bottom: 10px;
-}
 
-.course-detail-title h2 {
-  font-size: $course-heading-four-font !important;
-  line-height: $course-heading-four-line-height !important;
+  h2 {
+    font-size: $course-heading-four-font !important;
+    line-height: $course-heading-four-line-height !important;
+  }
 }
 
 // TODO: overriding some css of header and footer in this new theme

--- a/course-v2/layouts/partials/course_banner.html
+++ b/course-v2/layouts/partials/course_banner.html
@@ -1,13 +1,15 @@
-{{ $bannerClass := "text-capitalize display-4 m-0 text-white" }}
+{{ $bannerClass := "text-capitalize m-0 text-white" }}
 {{ $currentPage := . }}
 <div id="course-banner" class="p-0">
   <div class="max-content-width course-banner-content m-auto py-3">
     {{ $courseData := .Site.Data.course }}
     <span class="course-number-term-detail">{{ $courseData.primary_course_number }} | {{ $courseData.term }} {{ $courseData.year }} | {{ delimit $courseData.level ", " }}</span>
     <br>
-    <a
-      class="{{ $bannerClass }}"
-      href="{{ partial "course_home_page_url.html" . }}"
-    >{{ $courseData.course_title }}</a>
+    <h1>
+      <a
+        class="{{ $bannerClass }}"
+        href="{{ partial "course_home_page_url.html" . }}"
+      >{{ $courseData.course_title }}</a>
+    </h1>
   </div>
 </div>

--- a/course-v2/layouts/partials/course_description.html
+++ b/course-v2/layouts/partials/course_description.html
@@ -4,9 +4,9 @@
   {{ $shouldCollapseDescription = gt (len .) 320 }}
 {{ end }}
 <div id="course-description">
-  <div class="course-detail-title">
+  <h4 class="course-detail-title">
     Course Description
-  </div>
+  </h4>
   {{ if $shouldCollapseDescription }}
   <div id="collapsed-description" class="description">
     {{- .context.RenderString (truncate 320 $courseData.course_description) -}}

--- a/course-v2/layouts/partials/course_info.html
+++ b/course-v2/layouts/partials/course_info.html
@@ -4,9 +4,9 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
 <div class="course-info">
   <div class="course-detail-title {{ if $inPanel }}bg-light-gray{{ end }}">
     <div class="d-flex">
-      <div class="font-black {{ if $inPanel }}py-1 pl-3 mt-2 m-0{{ end }}">
+      <h4 class="font-black {{ if $inPanel }}py-1 pl-3 mt-2 m-0{{ end }}">
         Course Info
-      </div>
+      </h4>
       {{ if $inPanel }}
       <button
         type="button"
@@ -30,10 +30,10 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
         {{ with $courseData.instructors.content }}
         <div class="">
           {{ $instructors := partial "get_instructors.html" . }}
-          <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+          <h5 class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
             {{ if eq (len $instructors) 1 }}Instructor{{ else }}Instructors{{
             end }}
-          </div>
+            </h5>
           <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
             {{ partial "partial_collapse_list.html" (dict "list" $instructors
             "id" "instructors" "key" "title" "klass" "course-info-instructor"
@@ -43,9 +43,9 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
         {{ end }} {{ with $courseData.department_numbers }}
         <div class="mt-4">
           {{ $departments := partial "get_departments.html" . }}
-          <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+          <h5 class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
             Departments
-          </div>
+          </h5>
           <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
             {{ partial "partial_collapse_list.html" (dict "list" $departments
             "id" "departments" "key" "title" "klass" "course-info-department"
@@ -55,9 +55,9 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
         {{ end }} 
         {{ if $inPanel }}
         <div class="mt-4">
-          <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+          <h5 class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
             As Taught In
-          </div>
+          </h5>
           <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
             {{ $courseData.term }}
             {{ if isset $courseData "year" }}
@@ -67,9 +67,9 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
         </div>
 
         <div class="mt-4">
-          <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+          <h5 class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
             Level
-          </div>
+          </h5>
           <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
             {{ if eq (printf "%T" $courseData.level) "string" }} {{
             $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}

--- a/course-v2/layouts/partials/course_info.html
+++ b/course-v2/layouts/partials/course_info.html
@@ -4,9 +4,9 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
 <div class="course-info">
   <div class="course-detail-title {{ if $inPanel }}bg-light-gray{{ end }}">
     <div class="d-flex">
-      <h4 class="font-black {{ if $inPanel }}py-1 pl-3 mt-2 m-0{{ end }}">
+      <h2 class="font-black {{ if $inPanel }}py-1 pl-3 mt-2 m-0{{ end }}">
         Course Info
-      </h4>
+      </h2>
       {{ if $inPanel }}
       <button
         type="button"

--- a/course-v2/layouts/partials/learning_resource_types.html
+++ b/course-v2/layouts/partials/learning_resource_types.html
@@ -3,9 +3,9 @@
 
 {{ if gt (len ($courseData.learning_resource_types | default slice)) 0 }}
 <div class="">
-  <div class="course-detail-title {{ if $inPanel }}panel-course-info-title mt-3{{ end }}">
+  <h5 class="course-detail-title {{ if $inPanel }}panel-course-info-title mt-3{{ end }}">
     Learning Resource Types
-  </div>
+  </h5>
   <div>
     <div class="row {{ if $inPanel }}d-inline m-0{{ end }}">
       {{ range $courseData.learning_resource_types }}

--- a/course-v2/layouts/partials/topics.html
+++ b/course-v2/layouts/partials/topics.html
@@ -5,9 +5,9 @@
 {{ $device := .device }}
 {{ $renderMarginTop := .renderMarginTop | default true}}
 <div class=" {{ if $renderMarginTop }}mt-4{{ end }}">
-  <div class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+  <h5 class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
     Topics
-  </div>
+  </h5>
   <ul class="list-unstyled pb-2 m-0 {{ if $inPanel }}panel-course-info-text{{ end }}">
     {{- $topics := (slice (slice "Social Science" "Political Science" "American Politics") (slice "Social Science" "Public Administration" "Public Policy")) -}}
 

--- a/test-sites/ocw-ci-test-course/content/pages/assignments.md
+++ b/test-sites/ocw-ci-test-course/content/pages/assignments.md
@@ -6,3 +6,4 @@ title: Section 2
 uid: 018d07b5-0f37-493f-8025-53a3ee837168
 ---
 section 2 body
+## H3 heading

--- a/tests-e2e/ocw-ci-test-course/headings.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/headings.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test"
+import { CoursePage } from "../util"
+
+test(`Verify accesibility and semantic structure of headings`, async ({
+  page
+}) => {
+  const headingsData = [
+    {
+      label:                "OCW CI Test Course",
+      expectedHeadingLevel: "H1"
+    },
+    {
+      label:                "Section 2",
+      expectedHeadingLevel: "H2"
+    },
+    {
+      label:                "H3 heading",
+      expectedHeadingLevel: "H3"
+    },
+    {
+      label:                "Course Info",
+      expectedHeadingLevel: "H4"
+    },
+    {
+      label:                "INSTRUCTORS",
+      expectedHeadingLevel: "H5"
+    },
+    {
+      label:                "DEPARTMENTS",
+      expectedHeadingLevel: "H5"
+    },
+    {
+      label:                "AS TAUGHT IN",
+      expectedHeadingLevel: "H5"
+    },
+    {
+      label:                "LEVEL",
+      expectedHeadingLevel: "H5"
+    },
+    {
+      label:                "TOPICS",
+      expectedHeadingLevel: "H5"
+    },
+    {
+      label:                "LEARNING RESOURCE TYPES",
+      expectedHeadingLevel: "H5"
+    }
+  ]
+  const coursePage = new CoursePage(page, "course")
+  await coursePage.goto("pages/assignments")
+
+  for (const { label, expectedHeadingLevel } of headingsData) {
+    const heading = page.getByRole("heading", { name: label })
+    expect(heading).not.toBeNull()
+    if (heading) {
+      const accessibleHeadingLevel = await heading.evaluate(
+        node => node.tagName
+      )
+      expect(accessibleHeadingLevel).toBe(expectedHeadingLevel)
+    }
+  }
+})

--- a/tests-e2e/ocw-ci-test-course/headings.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/headings.spec.ts
@@ -52,9 +52,7 @@ test(`Verify accesibility and semantic structure of headings`, async ({
   for (const { label, expectedHeadingLevel } of headingsData) {
     const heading = page.getByRole("heading", { name: label })
     await heading.waitFor()
-    const accessibleHeadingLevel = await heading.evaluate(
-      node => node.tagName
-    )
+    const accessibleHeadingLevel = await heading.evaluate(node => node.tagName)
     expect(accessibleHeadingLevel).toBe(expectedHeadingLevel)
   }
 })

--- a/tests-e2e/ocw-ci-test-course/headings.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/headings.spec.ts
@@ -51,12 +51,10 @@ test(`Verify accesibility and semantic structure of headings`, async ({
 
   for (const { label, expectedHeadingLevel } of headingsData) {
     const heading = page.getByRole("heading", { name: label })
-    expect(heading).not.toBeNull()
-    if (heading) {
-      const accessibleHeadingLevel = await heading.evaluate(
-        node => node.tagName
-      )
-      expect(accessibleHeadingLevel).toBe(expectedHeadingLevel)
-    }
+    await heading.waitFor()
+    const accessibleHeadingLevel = await heading.evaluate(
+      node => node.tagName
+    )
+    expect(accessibleHeadingLevel).toBe(expectedHeadingLevel)
   }
 })

--- a/tests-e2e/ocw-ci-test-course/headings.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/headings.spec.ts
@@ -19,7 +19,7 @@ test(`Verify accesibility and semantic structure of headings`, async ({
     },
     {
       label:                "Course Info",
-      expectedHeadingLevel: "H4"
+      expectedHeadingLevel: "H2"
     },
     {
       label:                "INSTRUCTORS",

--- a/tests-e2e/ocw-ci-test-course/headings.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/headings.spec.ts
@@ -10,16 +10,16 @@ test(`Verify accesibility and semantic structure of headings`, async ({
       expectedHeadingLevel: "H1"
     },
     {
+      label:                "Course Info",
+      expectedHeadingLevel: "H2"
+    },
+    {
       label:                "Section 2",
       expectedHeadingLevel: "H2"
     },
     {
       label:                "H3 heading",
       expectedHeadingLevel: "H3"
-    },
-    {
-      label:                "Course Info",
-      expectedHeadingLevel: "H2"
     },
     {
       label:                "INSTRUCTORS",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1105

#### What's this PR do?
This PR replaces `div` tags with semantic heading tags. (eg. `h1`)
It also adds playwright test for the fix. The test checks for "headings" and also ensures they are correct level of headings.

#### How should this be manually tested?
Follow this [OCW Style Guide](https://projects.invisionapp.com/d/#/console/21537330/468374061/comments)

1. Checkout to this branch.
2. `yarn start course 9.40-spring-2018`
3. Inspect element and make sure the headings `h1`, `h2`, `h3`, `h4`, `h5` conform to the OCW Style Guide (that they're using `heading` tags, their `font-size` and `line-height` are correct). Check for both desktop and mobile.

So how it works is, in the Style Guide, `1rem=16px` however in the courses theme, `1rem=14px`, so for instance, if you notice `h2` of this branch, you will see it is 1.6rem for Desktop screens. If you calculate it according to `1rem=16px`, it actually becomes 1.4rem (as mentioned in the Style Guide). 
that is, 
```
1.6rem * 14px = 22.4px
22.4px/16px = 1.4rem
```
After it, run the playwright test:
I have ran it 250 times, so if you run it 200 times it should be enough:
`yarn test:e2e headings.spec.ts --repeat-each=200`

