### PR TITLE
disable bundle splitting in offline sites

### DIFF
--- a/base-offline/layouts/shortcodes/image-gallery.html
+++ b/base-offline/layouts/shortcodes/image-gallery.html
@@ -1,0 +1,11 @@
+{{ $baseUrl := .Get "baseUrl" }}
+<div id="{{ .Get "id" }}" class="image-gallery" data-nanogallery2='{ "itemsBaseURL": "{{ partial "resource_url.html" (dict "context" .Page "url" "/") }}" }'>
+{{ .Inner }}
+</div>
+
+<script>
+    window.onload = function() {
+      if (window.initNanogallery2)
+        window.initNanogallery2()
+    }
+</script>

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -16,6 +16,7 @@ const fromRoot = (pathFromRoot: string) =>
 const entryNames = {
   instructorInsights: "instructor_insights",
   courseV2:           "course_v2",
+  courseOffline:      "course_offline",
   www:                "www",
   wwwOffline:         "www_offline",
   fields:             "fields"
@@ -29,6 +30,10 @@ const config: webpack.Configuration = {
   entry: {
     [entryNames.courseV2]: [
       fromRoot("./course-v2/assets/course-v2.ts"),
+      fromRoot("./base-theme/assets/index.ts")
+    ],
+    [entryNames.courseOffline]: [
+      fromRoot("./course-offline/assets/course-offline.ts"),
       fromRoot("./base-theme/assets/index.ts")
     ],
     [entryNames.instructorInsights]: [

--- a/course-offline/assets/course-offline.ts
+++ b/course-offline/assets/course-offline.ts
@@ -14,11 +14,6 @@ import {
   checkAnswer,
   showSolution
 } from "../../course-v2/assets/js/quiz_multiple_choice"
-import { initVideoDownloadPopup } from "../../course-v2/assets/js/video_download_popup"
-import { initVideoTranscriptTrack } from "../../course-v2/assets/js/video_transcript_track"
-import { initPlayBackSpeedButton } from "../../course-v2/assets/js/video_playback_speed"
-import { initVideoFullscreenToggle } from "../../course-v2/assets/js/video_fullscreen_toggle"
-import { initDownloadButton } from "../../course-v2/assets/js/video-download-button"
 import "nanogallery2/src/jquery.nanogallery2.core.js"
 import "nanogallery2/src/css/nanogallery2.css"
 import "videojs-youtube"
@@ -32,11 +27,3 @@ $(function() {
   showSolution()
   initCourseDrawersClosingViaSwiping()
 })
-
-export const initVideoJS = () => {
-  initVideoDownloadPopup()
-  initDownloadButton()
-  initPlayBackSpeedButton()
-  initVideoTranscriptTrack()
-  initVideoFullscreenToggle()
-}

--- a/course-offline/assets/course-offline.ts
+++ b/course-offline/assets/course-offline.ts
@@ -1,0 +1,42 @@
+import "video.js/dist/video-js.css"
+
+import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
+import "promise-polyfill/src/polyfill.js"
+import "../../course-v2/assets/css/course-v2.scss"
+import { initDivToggle } from "../../course-v2/assets/js/div_toggle"
+import {
+  initCourseInfoExpander,
+  initCourseDescriptionExpander
+} from "../../course-v2/assets/js/course_expander"
+import { initCourseDrawersClosingViaSwiping } from "../../course-v2/assets/js/mobile_course_drawers"
+import {
+  clearSolution,
+  checkAnswer,
+  showSolution
+} from "../../course-v2/assets/js/quiz_multiple_choice"
+import { initVideoDownloadPopup } from "../../course-v2/assets/js/video_download_popup"
+import { initVideoTranscriptTrack } from "../../course-v2/assets/js/video_transcript_track"
+import { initPlayBackSpeedButton } from "../../course-v2/assets/js/video_playback_speed"
+import { initVideoFullscreenToggle } from "../../course-v2/assets/js/video_fullscreen_toggle"
+import { initDownloadButton } from "../../course-v2/assets/js/video-download-button"
+import "nanogallery2/src/jquery.nanogallery2.core.js"
+import "nanogallery2/src/css/nanogallery2.css"
+import "videojs-youtube"
+
+$(function() {
+  initCourseDescriptionExpander(document)
+  initCourseInfoExpander(document)
+  initDivToggle()
+  clearSolution()
+  checkAnswer()
+  showSolution()
+  initCourseDrawersClosingViaSwiping()
+})
+
+export const initVideoJS = () => {
+  initVideoDownloadPopup()
+  initDownloadButton()
+  initPlayBackSpeedButton()
+  initVideoTranscriptTrack()
+  initVideoFullscreenToggle()
+}

--- a/course-offline/layouts/partials/basejs.html
+++ b/course-offline/layouts/partials/basejs.html
@@ -1,0 +1,5 @@
+{{- define "extrajs" -}}
+{{- $webpack := .Site.Data.webpack -}}
+{{- $js_urls := slice $webpack.course_offline.js -}}
+{{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
+{{- end -}}

--- a/course-offline/layouts/partials/basejs.html
+++ b/course-offline/layouts/partials/basejs.html
@@ -1,4 +1,4 @@
-{{- define "extrajs" -}}
+{{- define "basejs" -}}
 {{- $webpack := .Site.Data.webpack -}}
 {{- $js_urls := slice $webpack.course_offline.js -}}
 {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}

--- a/course-offline/layouts/partials/extrahead.html
+++ b/course-offline/layouts/partials/extrahead.html
@@ -1,0 +1,5 @@
+{{ define "title" }}{{ partial "title.html" . }}{{ end }}
+{{ define "extrahead" }}
+{{ $css_urls := slice .Site.Data.webpack.course_offline.css }}
+{{ partial "include_css.html" (dict "context" . "urls" $css_urls ) }}
+{{ end }}

--- a/course-offline/layouts/partials/resource_url.html
+++ b/course-offline/layouts/partials/resource_url.html
@@ -1,4 +1,4 @@
 {{ $pathToRoot := partial "path_to_root.html" .context.RelPermalink }}
 {{ $resourcePath := (urls.Parse .url).Path }}
 {{ $resourceFileName := path.Base $resourcePath }}
-{{ return (printf "%s/static_resources/%s" (strings.TrimSuffix "/" $pathToRoot) $resourceFileName) }}
+{{ return (printf "%s/static_resources/%s" (strings.TrimSuffix "/" $pathToRoot) (strings.TrimPrefix "/" $resourceFileName)) }}

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -178,15 +178,8 @@
 
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
-  {{- $webpack := .Site.Data.webpack -}}
-  {{- $js_urls := slice $webpack.common.js $webpack.course_v2.js -}}
-  {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
-  <!-- Appzi: Capture Insightful Feedback -->
-  {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
-
-  <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
-
-  <!-- End Appzi -->
+  {{ block "basejs" . }}{{ end }}
+  {{ block "extrajs" . }}{{ end }}
 </body>
 
 </html>

--- a/course-v2/layouts/partials/basejs.html
+++ b/course-v2/layouts/partials/basejs.html
@@ -1,4 +1,4 @@
-{{- define "extrajs" -}}
+{{- define "basejs" -}}
 {{- $webpack := .Site.Data.webpack -}}
 {{- $js_urls := slice $webpack.common.js $webpack.course_v2.js -}}
 {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}

--- a/course-v2/layouts/partials/basejs.html
+++ b/course-v2/layouts/partials/basejs.html
@@ -1,0 +1,6 @@
+{{- define "extrajs" -}}
+{{- $webpack := .Site.Data.webpack -}}
+{{- $js_urls := slice $webpack.common.js $webpack.course_v2.js -}}
+{{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
+{{ partial "mathjax_if_necessary.html" (dict "context" .) }}
+{{- end -}}

--- a/course-v2/layouts/partials/extrajs.html
+++ b/course-v2/layouts/partials/extrajs.html
@@ -1,0 +1,5 @@
+{{- define "extrajs" -}}
+<!-- Appzi: Capture Insightful Feedback -->
+<script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
+<!-- End Appzi -->
+{{- end -}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1143

#### What's this PR do?
This PR adds a new Webpack entry point called `course_offline` and defines that within the `course-offline` theme. Its main purpose is to import libraries for use in the site without lazy loading them, so the bundles are not split.

In https://github.com/mitodl/ocw-hugo-themes/pull/1089 and https://github.com/mitodl/ocw-hugo-themes/pull/1108, we added functionality that splits out VideoJS and NanoGallery using Webpack bundle splitting, lazy loading the artifacts when they are needed to save on network requests on the live site. This had the effect of breaking both of these libraries in the `course-offline` theme when viewing the sites using the `file://` protocol. We generate relative URLs in our offline sites using the Hugo setting `relativeUrls`. This is a post-processing feature that crawls your rendered Hugo site after it is built and transforms all URLs that are not fully qualified into path-relative URLs. The setting does not work on every URL property (https://github.com/gohugoio/hugo/issues/8734), and one of those places happens to be requesting a URL through Javascript. The path to the lazy-loaded bundle is written in starting with a slash like `/static_shared/whatever.js`, which results in a request for `file:///static_shared/whatever.js` which will not work unless your offline site is located at the root of your filesystem.

#### How should this be manually tested?
 - Download the following content repositories:
   - https://github.mit.edu/ocw-content-rc/5.36-spring-2009
   - https://github.mit.edu/ocw-content-rc/6.041sc-fall-2013
 - Download `ocw-hugo-projects` locally
 - Put `ocw-studio` production AWS credentials into your terminal, then run the following in each of the repository folders to download each site's static resources:
   - `mkdir -p content/static_resources && aws s3 sync s3://ol-ocw-studio-app-production/courses/5-36-biochemistry-laboratory-spring-2009/ ./content/static_resources/`
   - `mkdir -p content/static_resources && aws s3 sync s3://ol-ocw-studio-app-production/courses/6-041sc-probabilistic-systems-analysis-and-applied-probability-fall-2013/ ./content/static_resources/`
 - In `ocw-hugo-themes` on this branch, run :
   - `yarn build /path/to/5.36-spring-2009/ /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`
   - `yarn build /path/to/6.041sc-fall-2013/ /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`
 - In your file browser, browse to the `5.36-spring-2009` folder and enter the `dist` folder inside, then open `index.html`
 - Click "Image Gallery" on the left hand nav, browse through the image galleries, click the images and make sure everything functions properly
 - In your file browser, browse to the `6.041sc-fall-2013` folder and enter the `dist` folder inside, then open `index.html`
 - Click on "Resource Index" in the left hand nav, then click any of the videos under the "Help Videos" column
 - Verify that the YouTube player loads and you can play the video

#### Where should the reviewer start?
`course-offline/assets/js/course-offline.ts`
