### PR TITLE
fix video download popup for multiple instances of videos

### DIFF
--- a/course-v2/assets/js/video_download_popup.js
+++ b/course-v2/assets/js/video_download_popup.js
@@ -1,16 +1,22 @@
 export const initVideoDownloadPopup = () => {
-  const downloadIcon = document.querySelector(".video-download-icons")
-  const popup = document.querySelector(".video-tab-download-popup")
-  if (downloadIcon) {
-    downloadIcon.addEventListener("click", event => {
-      event.stopPropagation()
-      if (popup) popup.classList.toggle("hidden")
+  const downloadIcons = document.querySelectorAll(".video-download-icons")
+  const popups = document.querySelectorAll(".video-tab-download-popup")
+
+  if (downloadIcons.length > 0) {
+    downloadIcons.forEach((downloadIcon, index) => {
+      const popup = popups[index]
+      downloadIcon.addEventListener("click", event => {
+        event.stopPropagation()
+        if (popup) popup.classList.toggle("hidden")
+      })
     })
   }
 
   document.addEventListener("click", () => {
-    if (popup) {
-      popup.classList.add("hidden")
-    }
+    popups.forEach(popup => {
+      if (popup) {
+        popup.classList.add("hidden")
+      }
+    })
   })
 }

--- a/course-v2/assets/js/video_download_popup.ts
+++ b/course-v2/assets/js/video_download_popup.ts
@@ -8,21 +8,19 @@ export const initVideoDownloadPopup = () => {
       const popup = popups[index] as HTMLElement
       downloadIcon.addEventListener("click", event => {
         event.stopPropagation()
-        if (popup) {
-          // Clicked on the same download button, toggle the popup
-          if (popup === activePopup) {
-            popup.classList.toggle("hidden")
-            activePopup = null
+        // Clicked on the same download button, toggle the popup
+        if (popup === activePopup) {
+          popup.classList.toggle("hidden")
+          activePopup = null
+        }
+        // Clicked on a different download button, close previous popup (if any) and toggle open new popup
+        else {
+          if (activePopup) {
+            activePopup.classList.add("hidden")
           }
-          // Clicked on a different download button, close previous popup (if any) and toggle open new popup
-          else {
-            if (activePopup) {
-              activePopup.classList.add("hidden")
-            }
-            // Show the clicked popup
-            popup.classList.remove("hidden")
-            activePopup = popup
-          }
+          // Show the clicked popup
+          popup.classList.remove("hidden")
+          activePopup = popup
         }
       })
     })

--- a/course-v2/assets/js/video_download_popup.ts
+++ b/course-v2/assets/js/video_download_popup.ts
@@ -3,27 +3,25 @@ export const initVideoDownloadPopup = () => {
   const popups = document.querySelectorAll(".video-tab-download-popup")
   let activePopup: HTMLElement | null = null
 
-  if (downloadIcons.length > 0) {
-    downloadIcons.forEach((downloadIcon, index) => {
-      const popup = popups[index] as HTMLElement
-      downloadIcon.addEventListener("click", event => {
-        event.stopPropagation()
-        if (popup === activePopup) {
-          // Clicked on the same download button, toggle the popup
-          popup.classList.toggle("hidden")
-          activePopup = null
-        } else {
-          // Clicked on a different download button, close previous popup (if any) and toggle open new popup
-          if (activePopup) {
-            activePopup.classList.add("hidden")
-          }
-          // Show the clicked popup
-          popup.classList.remove("hidden")
-          activePopup = popup
+  downloadIcons.forEach((downloadIcon, index) => {
+    const popup = popups[index] as HTMLElement
+    downloadIcon.addEventListener("click", event => {
+      event.stopPropagation()
+      if (popup === activePopup) {
+        // Clicked on the same download button, toggle the popup
+        popup.classList.toggle("hidden")
+        activePopup = null
+      } else {
+        // Clicked on a different download button, close previous popup (if any) and toggle open new popup
+        if (activePopup) {
+          activePopup.classList.add("hidden")
         }
-      })
+        // Show the clicked popup
+        popup.classList.remove("hidden")
+        activePopup = popup
+      }
     })
-  }
+  })
   // Click anywhere on page (other than download buttons), and the active popup will close
   document.addEventListener("click", () => {
     if (activePopup) {

--- a/course-v2/assets/js/video_download_popup.ts
+++ b/course-v2/assets/js/video_download_popup.ts
@@ -14,9 +14,7 @@ export const initVideoDownloadPopup = () => {
 
   document.addEventListener("click", () => {
     popups.forEach(popup => {
-      if (popup) {
-        popup.classList.add("hidden")
-      }
+      popup.classList.add("hidden")
     })
   })
 }

--- a/course-v2/assets/js/video_download_popup.ts
+++ b/course-v2/assets/js/video_download_popup.ts
@@ -8,13 +8,12 @@ export const initVideoDownloadPopup = () => {
       const popup = popups[index] as HTMLElement
       downloadIcon.addEventListener("click", event => {
         event.stopPropagation()
-        // Clicked on the same download button, toggle the popup
         if (popup === activePopup) {
+          // Clicked on the same download button, toggle the popup
           popup.classList.toggle("hidden")
           activePopup = null
-        }
-        // Clicked on a different download button, close previous popup (if any) and toggle open new popup
-        else {
+        } else {
+          // Clicked on a different download button, close previous popup (if any) and toggle open new popup
           if (activePopup) {
             activePopup.classList.add("hidden")
           }

--- a/course-v2/assets/js/video_download_popup.ts
+++ b/course-v2/assets/js/video_download_popup.ts
@@ -1,20 +1,37 @@
 export const initVideoDownloadPopup = () => {
   const downloadIcons = document.querySelectorAll(".video-download-icons")
   const popups = document.querySelectorAll(".video-tab-download-popup")
+  let activePopup: HTMLElement | null = null
 
   if (downloadIcons.length > 0) {
     downloadIcons.forEach((downloadIcon, index) => {
-      const popup = popups[index]
+      const popup = popups[index] as HTMLElement
       downloadIcon.addEventListener("click", event => {
         event.stopPropagation()
-        if (popup) popup.classList.toggle("hidden")
+        if (popup) {
+          // Clicked on the same download button, toggle the popup
+          if (popup === activePopup) {
+            popup.classList.toggle("hidden")
+            activePopup = null
+          }
+          // Clicked on a different download button, close previous popup (if any) and toggle open new popup
+          else {
+            if (activePopup) {
+              activePopup.classList.add("hidden")
+            }
+            // Show the clicked popup
+            popup.classList.remove("hidden")
+            activePopup = popup
+          }
+        }
       })
     })
   }
-
+  // Click anywhere on page (other than download buttons), and the active popup will close
   document.addEventListener("click", () => {
-    popups.forEach(popup => {
-      popup.classList.add("hidden")
-    })
+    if (activePopup) {
+      activePopup.classList.add("hidden")
+      activePopup = null
+    }
   })
 }

--- a/test-sites/ocw-ci-test-course/config/_default/menus.yaml
+++ b/test-sites/ocw-ci-test-course/config/_default/menus.yaml
@@ -29,6 +29,10 @@ leftnav:
   name: Video Series Overview
   url: /pages/video-series-overview/
   weight: 50
+- identifier: a7716d12-f128-bdd2-a11b-02e75f786ba1
+  name: Multiple Videos Series Overview
+  url: /pages/multiple-videos-series-overview/
+  weight: 60
 - identifier: 79392061-a205-4e93-83f2-276dbc9668e6
   name: Resource List
   url: /lists/a-resource-list

--- a/test-sites/ocw-ci-test-course/content/pages/multiple-videos-series-overview.md
+++ b/test-sites/ocw-ci-test-course/content/pages/multiple-videos-series-overview.md
@@ -1,0 +1,17 @@
+---
+content_type: page
+description: This section includes a video by Cleve Moler and Gilbert Strang introducing
+  the video series.
+learning_resource_types: []
+ocw_type: SupplementalResourceSection
+title: Multiple Videos Series Overview
+uid: a7716d12-f128-bdd2-a11b-02e75f786ba1
+---
+
+{{< resource e95c5f3f-e4ba-4b8d-b505-824aa2a322d0 >}}
+{{< resource e95c5f3f-e4ba-4b8d-b505-824aa2a322d0 >}}
+{{< resource e95c5f3f-e4ba-4b8d-b505-824aa2a322d0 >}}
+
+Cleve Moler, founder and chief mathematician at MathWorks, and Gilbert Strang, professor and mathematician at Massachusetts Institute of Technology, provide an overview to their in-depth video series about differential equations and the MATLAB{{< sup "®" >}} ODE suite.
+
+Differential equations and linear algebra are two crucial subjects in science and engineering. Gilbert Strang's video series develops those subjects both separately and together and supplements Gil Strang's textbook on this subject. Cleve Moler introduces computation for differential equations and explains the MATLAB ODE suite and its mathematical background. Cleve Moler's video series starts with Euler method and builds up to Runge Kutta and includes hands-on MATLAB exercises.

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -2,13 +2,15 @@ import { test, expect } from "@playwright/test"
 import { CoursePage } from "../util"
 import { VideoElement } from "../util/VideoElement"
 
-test("Verify that the Download Button works for multiple embed videos in a page", async ({
+test("that the Download Button works for multiple embed videos in a page", async ({
   page
 }) => {
   const coursePage = new CoursePage(page, "course")
   await coursePage.goto("pages/multiple-videos-series-overview/")
   const videoElementsCount = await new VideoElement(page).count()
-  for (let i = 0; i < videoElementsCount; i++) {
+  expect(videoElementsCount).toBe(3)
+
+  for (let i = 0; i < 3; i++) {
     const videoElement = new VideoElement(page, i)
     await videoElement.downloadButton().click()
     expect(videoElement.downloadVideo()).toHaveAttribute(

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -2,25 +2,24 @@ import { test, expect } from "@playwright/test"
 import { CoursePage } from "../util"
 import { VideoElement } from "../util/VideoElement"
 
-test("Verify that the Download Button works for multiple embed videos in a page", async ({
+test.only("Verify that the Download Button works for multiple embed videos in a page", async ({
   page
 }) => {
   const coursePage = new CoursePage(page, "course")
   await coursePage.goto("pages/multiple-videos-series-overview/")
-  const videoPage = new VideoElement(page)
-  const downloadButtons = videoPage.downloadButton()
-  const downloadButtonsCount = await downloadButtons.count()
-  for (let i = 0; i < downloadButtonsCount; i++) {
-    await downloadButtons.nth(i).click()
-    expect(videoPage.downloadVideo()).toHaveAttribute(
+  const videoElementsCount = await new VideoElement(page).count()
+  for (let i = 0; i < videoElementsCount; i++) {
+    const videoElement = new VideoElement(page, i)
+    await videoElement.downloadButton().click()
+    expect(videoElement.downloadVideo()).toHaveAttribute(
       "href",
       "https://live-qa.ocw.mit.edu/courses/123-ocw-ci-test-course-fall-2022/ocw_test_course_mit8_01f16_l01v01_360p_360p_16_9.mp4"
     )
-    expect(videoPage.downloadTranscript()).toHaveAttribute(
+    expect(videoElement.downloadTranscript()).toHaveAttribute(
       "href",
       "https://live-qa.ocw.mit.edu/courses/8-01sc-classical-mechanics-fall-2016/33f61131009a6cd12d9a4c0e42eb7f44_ErlP_SBcA1s.pdf"
     )
-    await videoPage.downloadButton().nth(i).click()
+    await videoElement.downloadButton().click()
   }
 })
 test("Verify that the 'Download video' and 'Download transcript' links are keyboard navigable and have the correct download URLs", async ({

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test"
 import { CoursePage } from "../util"
 import { VideoElement } from "../util/VideoElement"
 
-test("that the Download Button works for multiple embed videos in a page", async ({
+test.only("that the Download Button works for multiple embed videos in a page", async ({
   page
 }) => {
   const coursePage = new CoursePage(page, "course")
@@ -10,7 +10,7 @@ test("that the Download Button works for multiple embed videos in a page", async
   const videoElementsCount = await new VideoElement(page).count()
   expect(videoElementsCount).toBe(3)
 
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < videoElementsCount; i++) {
     const videoElement = new VideoElement(page, i)
     await videoElement.downloadButton().click()
     expect(videoElement.downloadVideo()).toHaveAttribute(

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test"
 import { CoursePage } from "../util"
 import { VideoElement } from "../util/VideoElement"
 
-test.only("Verify that the Download Button works for multiple embed videos in a page", async ({
+test("Verify that the Download Button works for multiple embed videos in a page", async ({
   page
 }) => {
   const coursePage = new CoursePage(page, "course")

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -2,6 +2,27 @@ import { test, expect } from "@playwright/test"
 import { CoursePage } from "../util"
 import { VideoElement } from "../util/VideoElement"
 
+test("Verify that the Download Button works for multiple embed videos in a page", async ({
+  page
+}) => {
+  const coursePage = new CoursePage(page, "course")
+  await coursePage.goto("pages/multiple-videos-series-overview/")
+  const videoPage = new VideoElement(page)
+  const downloadButtons = videoPage.downloadButton()
+  const downloadButtonsCount = await downloadButtons.count()
+  for (let i = 0; i < downloadButtonsCount; i++) {
+    await downloadButtons.nth(i).click()
+    expect(videoPage.downloadVideo()).toHaveAttribute(
+      "href",
+      "https://live-qa.ocw.mit.edu/courses/123-ocw-ci-test-course-fall-2022/ocw_test_course_mit8_01f16_l01v01_360p_360p_16_9.mp4"
+    )
+    expect(videoPage.downloadTranscript()).toHaveAttribute(
+      "href",
+      "https://live-qa.ocw.mit.edu/courses/8-01sc-classical-mechanics-fall-2016/33f61131009a6cd12d9a4c0e42eb7f44_ErlP_SBcA1s.pdf"
+    )
+    await videoPage.downloadButton().nth(i).click()
+  }
+})
 test("Verify that the 'Download video' and 'Download transcript' links are keyboard navigable and have the correct download URLs", async ({
   page
 }) => {

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test"
 import { CoursePage } from "../util"
 import { VideoElement } from "../util/VideoElement"
 
-test.only("that the Download Button works for multiple embed videos in a page", async ({
+test("that the Download Button works for multiple embed videos in a page", async ({
   page
 }) => {
   const coursePage = new CoursePage(page, "course")

--- a/tests-e2e/util/VideoElement.ts
+++ b/tests-e2e/util/VideoElement.ts
@@ -3,9 +3,22 @@ import { Locator, Page, FrameLocator, expect } from "@playwright/test"
 type ByRoleOptions = Parameters<Page["getByRole"]>[1]
 export class VideoElement {
   readonly container: Locator
+  private readonly page: Page
 
-  constructor(page: Page) {
-    this.container = page.locator(".video-embed, .video-page")
+  constructor(page: Page, n?: number) {
+    this.page = page
+    this.container = page.locator(".video-page, .video-embed")
+    if (n !== undefined) {
+      this.container = this.container.nth(n)
+    }
+  }
+
+  async count(): Promise<number> {
+    return await this.container.count()
+  }
+
+  nth(n: number): VideoElement {
+    return new VideoElement(this.page, n)
   }
 
   tab(opts: ByRoleOptions): Locator {

--- a/tests-e2e/util/VideoElement.ts
+++ b/tests-e2e/util/VideoElement.ts
@@ -5,7 +5,7 @@ export class VideoElement {
   readonly container: Locator
 
   constructor(page: Page) {
-    this.container = page.locator(".video-page")
+    this.container = page.locator(".video-embed, .video-page")
   }
 
   tab(opts: ByRoleOptions): Locator {
@@ -14,6 +14,24 @@ export class VideoElement {
 
   tabPanel(opts: ByRoleOptions): Locator {
     return this.container.getByRole("tabpanel", opts)
+  }
+
+  downloadButton(): Locator {
+    return this.container.getByRole("button", {
+      name: `Download Video and Transcript`
+    })
+  }
+
+  downloadVideo(): Locator {
+    return this.container.getByRole("link", {
+      name: `Download video`
+    })
+  }
+
+  downloadTranscript(): Locator {
+    return this.container.getByRole("link", {
+      name: `Download transcript`
+    })
   }
 
   /**


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/1518

#### What's this PR do?
This video fixes video download popups for multiple instances of videos (sometimes we have multiple embed videos in a single page). Previously the download button was working only for first video if there are multiple in a page.

#### How should this be manually tested?
The issue was reported for the courses:
3.091-fall-2018
cms.611j-fall-2014
20.219-january-iap-2015

For `3.091-fall-2018`:
- Instructor Insights, Goodie Bag Tutorials and Problems

For `cms.611j-fall-2014`:
- on all pages under Student Games Projects

For `20.219-january-iap-2015`:
- on all pages starting with "Day X" and the Student projects

1. Checkout to this branch
2. `yarn start course X` (where X is the above course IDs)
3. Browse over to the mentioned pages above, and where there are multiple embed videos, make sure all of them have working download buttons. Although they might be too many (and there maybe other courses also), just check for few of them on each course and that should be good to go.
4. Make sure it's also working for single video pages.

After it, run playwright tests:
use `test.only` for the test`test("Verify that the Download Button works for multiple embed videos in a page")` or simply run this command to run all video-tab tests once:
`yarn test:e2e video-tabs.spec.ts`

