### PR TITLE
offline search for mirror drives

### DIFF
--- a/base-theme/layouts/partials/header.html
+++ b/base-theme/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!-- navbar for mobile screens -->
-{{ $siteRootUrl := partial "site_root_url.html" "/" }}
+{{ $homeUrl := partial "home_url.html" }}
 {{ $giveNowUrl := "https://giving.mit.edu/give/to/ocw/?utm_source=ocw&utm_medium=homepage_banner&utm_campaign=nextgen_home" }}
 {{ $aboutUrl := partial "site_root_url.html" "/about" }}
 {{ $zenDeskUrl := "https://mitocw.zendesk.com/hc/en-us" }}
@@ -18,7 +18,7 @@
       <i class="material-icons display-4 text-white align-bottom">menu</i>
     </button>
     <div class="mx-auto">
-      <a href="{{ $siteRootUrl }}">
+      <a href="{{ $homeUrl }}">
         <img width="250" src="/static_shared/images/ocw_logo_white_v2.svg" alt="MIT OpenCourseWare"/>
       </a>
     </div>
@@ -47,7 +47,7 @@
   <div class="contents">
     <div class="left">
       <div class="ocw-logo mr-6">
-        <a href="{{ $siteRootUrl }}">
+        <a href="{{ $homeUrl }}">
           <img src="/static_shared/images/ocw_logo_white_v2.svg" alt="MIT OpenCourseWare" />
         </a>
       </div>

--- a/base-theme/layouts/partials/home_url.html
+++ b/base-theme/layouts/partials/home_url.html
@@ -1,0 +1,2 @@
+{{ $siteRootUrl := partial "site_root_url.html" "/" }}
+{{ return $siteRootUrl }}

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "expose-loader": "^4.0.0",
     "fancy-log": "^1.3.2",
     "file-loader": "^5.0.2",
-    "fuse.js": "^6.5.3",
+    "fuse.js": "^6.6.2",
     "gulp": "^4.0.2",
     "history": "^5.3.0",
     "hugo-bin-extended": "~0.112.7",

--- a/www-offline/assets/www-offline.tsx
+++ b/www-offline/assets/www-offline.tsx
@@ -1,13 +1,16 @@
 import "./css/www-offline.scss"
+import Fuse from "fuse.js"
 import Popper from "popper.js"
 
 export interface OCWWindow extends Window {
   $: JQueryStatic
   jQuery: JQueryStatic
   Popper: typeof Popper
+  Fuse: typeof Fuse
 }
 declare let window: OCWWindow
 
 window.jQuery = $
 window.$ = $
 window.Popper = Popper
+window.Fuse = Fuse

--- a/www-offline/content/_index.md
+++ b/www-offline/content/_index.md
@@ -1,0 +1,3 @@
+---
+renderSearchIcon: true
+---

--- a/www-offline/content/_index.md
+++ b/www-offline/content/_index.md
@@ -1,3 +1,0 @@
----
-renderSearchIcon: true
----

--- a/www-offline/content/search/_index.md
+++ b/www-offline/content/search/_index.md
@@ -1,0 +1,5 @@
+---
+title: Search
+type: search
+renderSearchIcon: false
+---

--- a/www-offline/layouts/home.html
+++ b/www-offline/layouts/home.html
@@ -1,8 +1,7 @@
 {{ define "main" }}
 <div>
   {{ block "header" . }}
-  {{ $renderSearchIcon := index .Params "renderSearchIcon" | default true }}
-  {{ partial "header" . $renderSearchIcon }}
+  {{ partial "header" . }}
   {{ end }}
 </div>
 <div class="search-wrapper">

--- a/www-offline/layouts/home.html
+++ b/www-offline/layouts/home.html
@@ -1,17 +1,17 @@
 {{ define "main" }}
 <div>
   {{ block "header" . }}
-  {{ $renderSearchIcon := false }}
+  {{ $renderSearchIcon := index .Params "renderSearchIcon" | default true }}
   {{ partial "header" . $renderSearchIcon }}
   {{ end }}
 </div>
 <div class="search-wrapper">
   <div class="search-page row justify-content-center">
-    <div class="search-results-area col-9 py-4">
+    <div class="search-results-area col-12 py-4">
       {{ $websites := where site.Pages ".Params.content_type" "==" "website" }}
       {{ $sortedWebsites := partial "sort_websites_by_course_number.html" $websites }}
       {{ $paginator := .Paginate $sortedWebsites }}
-      <section class="m-auto">
+      <section class="m-auto px-8">
       {{ range $paginator.Pages }}
       {{ $pathToRoot := strings.TrimSuffix "/" (partial "path_to_root.html" $paginator.URL) }}
       {{ $urlPath := strings.TrimPrefix "/" .Params.url_path }}

--- a/www-offline/layouts/partials/extraheader.html
+++ b/www-offline/layouts/partials/extraheader.html
@@ -1,0 +1,8 @@
+{{ define "extraheader" }}
+  {{ $renderSearchIcon := index .Params "renderSearchIcon" | default true}}
+  {{ if $renderSearchIcon}}
+    <a class="nav-link search-icon pr-6" href="/search.html">
+      <i class="material-icons">search</i>
+    </a>
+  {{end}}
+{{ end }}

--- a/www-offline/layouts/partials/home_url.html
+++ b/www-offline/layouts/partials/home_url.html
@@ -1,0 +1,1 @@
+{{ return "/index.html" }}

--- a/www-offline/layouts/partials/include_css.html
+++ b/www-offline/layouts/partials/include_css.html
@@ -2,6 +2,6 @@
 {{ $urls := .urls }}
 {{ range $url := $urls }}
     {{ with $url }}
-    <link href="{{ printf "%s/%s" (strings.TrimSuffix "/" $context.Permalink) (strings.TrimPrefix "/" $url) }}" rel="stylesheet">
+    <link href="{{ printf "%s/%s" (strings.TrimSuffix "/" (path.Dir $context.Permalink)) (strings.TrimPrefix "/" $url) }}" rel="stylesheet">
     {{ end }}
 {{ end }}

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -46,116 +46,120 @@
   </div>
 </div>
 <script>
-  const searchResultTemplate = document.createElement("template")
-  searchResultTemplate.innerHTML = `
-<article>
-  <div class="card learning-resource-card compact-view">
-    <div class="card-contents">
-      <div class="lr-info search-result">
-        <div class="col-2 course-num">
-        </div>
-        <div class="course-title">
-          <a class="course-link"></a>
-        </div>
-        <div class="col-2 resource-level">
+window.onload = function() {
+  if (window.Fuse) {
+    // define the search-result web component and add it for use
+    const searchResultTemplate = document.createElement("template")
+    searchResultTemplate.innerHTML = `
+    <article>
+      <div class="card learning-resource-card compact-view">
+        <div class="card-contents">
+          <div class="lr-info search-result">
+            <div class="col-2 course-num">
+            </div>
+            <div class="course-title">
+              <a class="course-link"></a>
+            </div>
+            <div class="col-2 resource-level">
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
-</article>
-`
+    </article>
+    `
 
-  class SearchResult extends HTMLElement {
-    constructor() {
-      super()
+    class SearchResult extends HTMLElement {
+      constructor() {
+        super()
+      }
+
+      connectedCallback() {
+        this.innerHTML = searchResultTemplate.innerHTML
+        this.courseNumberDiv = this.querySelector(".course-num")
+        this.courseLink = this.querySelector(".course-link")
+        this.levelDiv = this.querySelector(".resource-level")
+        this.courseNumberDiv.innerHTML = this.primaryCourseNumber
+        this.courseLink.setAttribute("href", this.url)
+        this.courseLink.innerHTML = this.title
+        this.levelDiv.innerHTML = this.level
+      }
+
+      get title() {
+        return this.getAttribute("data-title")
+      }
+
+      get primaryCourseNumber() {
+        return this.getAttribute("data-primary-course-number")
+      }
+
+      get level() {
+        return this.getAttribute("data-level")
+      }
+
+      get url() {
+        return this.getAttribute("data-url")
+      }
     }
 
-    connectedCallback() {
-      this.innerHTML = searchResultTemplate.innerHTML
-      this.courseNumberDiv = this.querySelector(".course-num")
-      this.courseLink = this.querySelector(".course-link")
-      this.levelDiv = this.querySelector(".resource-level")
-      this.courseNumberDiv.innerHTML = this.primaryCourseNumber
-      this.courseLink.setAttribute("href", this.url)
-      this.courseLink.innerHTML = this.title
-      this.levelDiv.innerHTML = this.level
-    }
+    window.customElements.define("search-result", SearchResult)
 
-    get title() {
-      return this.getAttribute("data-title")
-    }
-
-    get primaryCourseNumber() {
-      return this.getAttribute("data-primary-course-number")
-    }
-
-    get level() {
-      return this.getAttribute("data-level")
-    }
-
-    get url() {
-      return this.getAttribute("data-url")
-    }
-  }
-
-  window.customElements.define("search-result", SearchResult)
-
-  window.onload = function() {
-    if (window.Fuse) {
-      const websites = [
-        {{ $websites := where site.Pages ".Params.content_type" "==" "website" }}
-        {{ range $websites }}
-        {{ $urlPath := strings.TrimPrefix "/" .Params.url_path }}
-        {{ $url := printf "%s/%s/index.html" $pathToRoot $urlPath }}
-        {
-          "title": {{- .Title | jsonify -}},
-          "primary_course_number": {{- .Params.primary_course_number | jsonify -}},
-          "url": {{- $url -}},
-          {{ if .Params.level }}
-          "level": {{ (delimit .Params.level ", ") | jsonify }}
-          {{ else }}
-          "level": ""
-          {{ end }}
-        },
+    // an array of known websites generated at build time
+    const websites = [
+      {{ $websites := where site.Pages ".Params.content_type" "==" "website" }}
+      {{ range $websites }}
+      {{ $urlPath := strings.TrimPrefix "/" .Params.url_path }}
+      {{ $url := printf "%s/%s/index.html" $pathToRoot $urlPath }}
+      {
+        "title": {{- .Title | jsonify -}},
+        "primary_course_number": {{- .Params.primary_course_number | jsonify -}},
+        "url": {{- $url -}},
+        {{ if .Params.level }}
+        "level": {{ (delimit .Params.level ", ") | jsonify }}
+        {{ else }}
+        "level": ""
         {{ end }}
-      ]
-      const Fuse = window.Fuse
-      const searchOptions = {
-        shouldSort: true,
-        threshold: 0.4,
-        location: 0,
-        distance: 100,
-        matchAllTokens: true,
-        includeScore: true,
-        maxPatternLength: 32,
-        minMatchCharLength: 5,
-        keys: ["title", "primary_course_number"]
-      }
-      const fuse = new Fuse(websites, searchOptions)
-      const searchInput = document.getElementById("search-input")
-      const searchButton = document.getElementById("search-button")
-      const performSearch = searchString => {
-        const searchResults = fuse.search(searchString)
-        const searchResultComponents = searchResults.map(searchResult => {
-          return `<search-result data-url="${searchResult.item["url"]}" data-title=${searchResult.item["title"]} data-primary-course-number=${searchResult.item["primary_course_number"]} data-level=${searchResult.item["level"]}></search-result>`
-        })
-        const searchResultsSection = document.getElementById("search-results")
-        searchResultsSection.innerHTML = searchResultComponents.join("")
-      }
-      const onInput = e => {
-        if (e.target.value) {
-          const searchString = e.target.value
-          performSearch(searchString)
-        }
-      }
-      const onSearchButtonClick = e => {
-        e.preventDefault()
-        performSearch(searchInput.value)
-      }
-      
-      searchInput.addEventListener("input", onInput)
-      searchButton.addEventListener("click", onSearchButtonClick)
+      },
+      {{ end }}
+    ]
+
+    // initialize Fuse and bind event listeners
+    const Fuse = window.Fuse
+    const searchOptions = {
+      shouldSort: true,
+      threshold: 0.4,
+      location: 0,
+      distance: 100,
+      matchAllTokens: true,
+      includeScore: true,
+      maxPatternLength: 32,
+      minMatchCharLength: 5,
+      keys: ["title", "primary_course_number"]
     }
+    const fuse = new Fuse(websites, searchOptions)
+    const searchInput = document.getElementById("search-input")
+    const searchButton = document.getElementById("search-button")
+    const performSearch = searchString => {
+      const searchResults = fuse.search(searchString)
+      const searchResultComponents = searchResults.map(searchResult => {
+        return `<search-result data-url="${searchResult.item["url"]}" data-title=${searchResult.item["title"]} data-primary-course-number=${searchResult.item["primary_course_number"]} data-level=${searchResult.item["level"]}></search-result>`
+      })
+      const searchResultsSection = document.getElementById("search-results")
+      searchResultsSection.innerHTML = searchResultComponents.join("")
+    }
+    const onInput = e => {
+      if (e.target.value) {
+        const searchString = e.target.value
+        performSearch(searchString)
+      }
+    }
+    const onSearchButtonClick = e => {
+      e.preventDefault()
+      performSearch(searchInput.value)
+    }
+    
+    searchInput.addEventListener("input", onInput)
+    searchButton.addEventListener("click", onSearchButtonClick)
   }
+}
 </script>
 {{ end }}

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -78,7 +78,7 @@ window.onload = function() {
       matchAllTokens: true,
       includeScore: true,
       maxPatternLength: 32,
-      minMatchCharLength: 5,
+      minMatchCharLength: 3,
       keys: ["title", "primary_course_number"]
     }
     const fuse = new Fuse(websites, searchOptions)

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -36,6 +36,7 @@
                   </div>
                 </div>
                 <section id="search-results" class="m-auto px-lg-8">
+                  <h3 class="col-3 text-center m-auto">Start typing to search</h3>
                 </section>
               </div>
             </div>
@@ -86,29 +87,34 @@ window.onload = function() {
     const searchButton = document.getElementById("search-button")
     const performSearch = searchString => {
       const searchResults = fuse.search(searchString)
-      const searchResultComponents = searchResults.map(searchResult => {
-        return `
-        <article>
-          <div class="card learning-resource-card compact-view">
-            <div class="card-contents">
-              <div class="lr-info search-result">
-                <div class="col-2 course-num">
-                  ${searchResult.item["primary_course_number"]}
-                </div>
-                <div class="course-title">
-                  <a class="course-link" href="${searchResult.item["url"]}">${searchResult.item["title"]}</a>
-                </div>
-                <div class="col-2 resource-level">
-                  ${searchResult.item["level"]}
+      if (searchResults.length > 0) {
+        const searchResultComponents = searchResults.map(searchResult => {
+          return `
+          <article>
+            <div class="card learning-resource-card compact-view">
+              <div class="card-contents">
+                <div class="lr-info search-result">
+                  <div class="col-2 course-num">
+                    ${searchResult.item["primary_course_number"]}
+                  </div>
+                  <div class="course-title">
+                    <a class="course-link" href="${searchResult.item["url"]}">${searchResult.item["title"]}</a>
+                  </div>
+                  <div class="col-2 resource-level">
+                    ${searchResult.item["level"]}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </article>
-        `
-      })
-      const searchResultsSection = document.getElementById("search-results")
-      searchResultsSection.innerHTML = searchResultComponents.join("")
+          </article>
+          `
+        })
+        const searchResultsSection = document.getElementById("search-results")
+        searchResultsSection.innerHTML = searchResultComponents.join("")
+      }
+      else {
+        searchResultsSection.innerHTML = `<h3 class="col-3 text-center m-auto">No results found</h3>`
+      }
     }
     const onInput = e => {
       if (e.target.value) {

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -1,30 +1,49 @@
 {{ define "main" }}
 {{ $pathToRoot := strings.TrimSuffix "/" (partial "path_to_root.html" .Permalink) }}
 {{ $websites := where site.Pages ".Params.content_type" "==" "website" }}
+{{ block "header" . }}
+{{ $renderSearchIcon := index .Params "renderSearchIcon" | default true }}
+{{ partial "header" . $renderSearchIcon }}
+{{ end }}
 <div class="search-wrapper">
-  {{ block "header" . }}
-  {{ $renderSearchIcon := index .Params "renderSearchIcon" | default true }}
-  {{ partialCached "header" . $renderSearchIcon }}
-  {{ end }}
-  <div class="container-fluid">
-    <main>
-      <div class="container-fluid p-0">
-        <div class="row m-0">
-          <div id="search-page" class="w-100">
-            <div class="d-flex flex-column flex-md-row p-2 p-md-0">
-              <input
-                id="search-input"
-                class="w-100"
-                type="text"
-                aria-label="Search"
-                />
+  <div class="search-page row justify-content-center">
+    <div class="search-results-area col-12 py-4">
+      <div class="container-fluid">
+        <main>
+          <div class="container-fluid p-0">
+            <div class="row m-0">
+              <div id="search-page" class="w-100">
+                <div class="container">
+                  <div class="search-box py-sm-5 py-md-7 py-lg-5 row">
+                    <div class="col-lg-3"></div>
+                    <div class="col-lg-6 search-box-inner d-flex flex-column align-items-center mb-2 mb-sm-5 mb-md-4">
+                      <h1>Explore OpenCourseWare</h1>
+                      <div class="w-100 d-flex flex-column align-items-center search-input-wrapper mt-5">
+                        <div class="w-100">
+                          <form role="search" class="search-box d-flex flex-direction-row">
+                            <input
+                              id="search-input"
+                              class="w-100 pl-2"
+                              type="text"
+                              aria-label="Search"
+                              placeholder="Search OpenCourseWare"
+                              />
+                            <button id="search-button" type="submit" class="py-2 px-3">Search</button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>                
+                    <div class="col-lg-3"></div>
+                  </div>
+                </div>
+                <section id="search-results" class="m-auto px-8">
+                </section>
+              </div>
             </div>
-            <section id="search-results" class="m-auto">
-            </section>
           </div>
-        </div>
+        </main>
       </div>
-    </main>
+    </div>
   </div>
 </div>
 <script>
@@ -114,19 +133,29 @@
         keys: ["title", "primary_course_number"]
       }
       const fuse = new Fuse(websites, searchOptions)
+      const searchInput = document.getElementById("search-input")
+      const searchButton = document.getElementById("search-button")
+      const performSearch = searchString => {
+        const searchResults = fuse.search(searchString)
+        const searchResultComponents = searchResults.map(searchResult => {
+          return `<search-result data-url="${searchResult.item["url"]}" data-title=${searchResult.item["title"]} data-primary-course-number=${searchResult.item["primary_course_number"]} data-level=${searchResult.item["level"]}></search-result>`
+        })
+        const searchResultsSection = document.getElementById("search-results")
+        searchResultsSection.innerHTML = searchResultComponents.join("")
+      }
       const onInput = e => {
         if (e.target.value) {
           const searchString = e.target.value
-          const searchResults = fuse.search(searchString)
-          const searchResultComponents = searchResults.map(searchResult => {
-            return `<search-result data-url="${searchResult.item["url"]}" data-title=${searchResult.item["title"]} data-primary-course-number=${searchResult.item["primary_course_number"]} data-level=${searchResult.item["level"]}></search-result>`
-          })
-          const searchResultsSection = document.getElementById("search-results")
-          searchResultsSection.innerHTML = searchResultComponents.join("")
+          performSearch(searchString)
         }
       }
-      const searchInput = document.getElementById("search-input")
+      const onSearchButtonClick = e => {
+        e.preventDefault()
+        performSearch(searchInput.value)
+      }
+      
       searchInput.addEventListener("input", onInput)
+      searchButton.addEventListener("click", onSearchButtonClick)
     }
   }
 </script>

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -35,7 +35,7 @@
                     <div class="col-lg-3"></div>
                   </div>
                 </div>
-                <section id="search-results" class="m-auto px-8">
+                <section id="search-results" class="m-auto px-lg-8">
                 </section>
               </div>
             </div>

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -48,73 +48,19 @@
 <script>
 window.onload = function() {
   if (window.Fuse) {
-    // define the search-result web component and add it for use
-    const searchResultTemplate = document.createElement("template")
-    searchResultTemplate.innerHTML = `
-    <article>
-      <div class="card learning-resource-card compact-view">
-        <div class="card-contents">
-          <div class="lr-info search-result">
-            <div class="col-2 course-num">
-            </div>
-            <div class="course-title">
-              <a class="course-link"></a>
-            </div>
-            <div class="col-2 resource-level">
-            </div>
-          </div>
-        </div>
-      </div>
-    </article>
-    `
-
-    class SearchResult extends HTMLElement {
-      constructor() {
-        super()
-      }
-
-      connectedCallback() {
-        this.innerHTML = searchResultTemplate.innerHTML
-        this.courseNumberDiv = this.querySelector(".course-num")
-        this.courseLink = this.querySelector(".course-link")
-        this.levelDiv = this.querySelector(".resource-level")
-        this.courseNumberDiv.innerHTML = this.primaryCourseNumber
-        this.courseLink.setAttribute("href", this.url)
-        this.courseLink.innerHTML = this.title
-        this.levelDiv.innerHTML = this.level
-      }
-
-      get title() {
-        return this.getAttribute("data-title")
-      }
-
-      get primaryCourseNumber() {
-        return this.getAttribute("data-primary-course-number")
-      }
-
-      get level() {
-        return this.getAttribute("data-level")
-      }
-
-      get url() {
-        return this.getAttribute("data-url")
-      }
-    }
-
-    window.customElements.define("search-result", SearchResult)
-
     // an array of known websites generated at build time
     const websites = [
       {{ $websites := where site.Pages ".Params.content_type" "==" "website" }}
       {{ range $websites }}
       {{ $urlPath := strings.TrimPrefix "/" .Params.url_path }}
       {{ $url := printf "%s/%s/index.html" $pathToRoot $urlPath }}
+      {{ $delimiter := ", " }}
       {
-        "title": {{- .Title | jsonify -}},
-        "primary_course_number": {{- .Params.primary_course_number | jsonify -}},
-        "url": {{- $url -}},
+        "title": "{{- .Title -}}",
+        "primary_course_number": "{{- .Params.primary_course_number -}}",
+        "url": "{{- $url -}}",
         {{ if .Params.level }}
-        "level": {{ (delimit .Params.level ", ") | jsonify }}
+        "level": "{{- delimit .Params.level $delimiter -}}"
         {{ else }}
         "level": ""
         {{ end }}
@@ -141,7 +87,25 @@ window.onload = function() {
     const performSearch = searchString => {
       const searchResults = fuse.search(searchString)
       const searchResultComponents = searchResults.map(searchResult => {
-        return `<search-result data-url="${searchResult.item["url"]}" data-title=${searchResult.item["title"]} data-primary-course-number=${searchResult.item["primary_course_number"]} data-level=${searchResult.item["level"]}></search-result>`
+        return `
+        <article>
+          <div class="card learning-resource-card compact-view">
+            <div class="card-contents">
+              <div class="lr-info search-result">
+                <div class="col-2 course-num">
+                  ${searchResult.item["primary_course_number"]}
+                </div>
+                <div class="course-title">
+                  <a class="course-link" href="${searchResult.item["url"]}">${searchResult.item["title"]}</a>
+                </div>
+                <div class="col-2 resource-level">
+                  ${searchResult.item["level"]}
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+        `
       })
       const searchResultsSection = document.getElementById("search-results")
       searchResultsSection.innerHTML = searchResultComponents.join("")

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -27,7 +27,7 @@
                               aria-label="Search"
                               placeholder="Search OpenCourseWare"
                               />
-                            <button id="search-button" type="submit" class="py-2 px-3">Search</button>
+                            <button id="search-button" type="button" class="py-2 px-3">Search</button>
                           </form>
                         </div>
                       </div>
@@ -123,7 +123,6 @@ window.onload = function() {
       }
     }
     const onSearchButtonClick = e => {
-      e.preventDefault()
       performSearch(searchInput.value)
     }
     

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -2,8 +2,7 @@
 {{ $pathToRoot := strings.TrimSuffix "/" (partial "path_to_root.html" .Permalink) }}
 {{ $websites := where site.Pages ".Params.content_type" "==" "website" }}
 {{ block "header" . }}
-{{ $renderSearchIcon := index .Params "renderSearchIcon" | default true }}
-{{ partial "header" . $renderSearchIcon }}
+{{ partial "header" . }}
 {{ end }}
 <div class="search-wrapper">
   <div class="search-page row justify-content-center">

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -1,0 +1,133 @@
+{{ define "main" }}
+{{ $pathToRoot := strings.TrimSuffix "/" (partial "path_to_root.html" .Permalink) }}
+{{ $websites := where site.Pages ".Params.content_type" "==" "website" }}
+<div class="search-wrapper">
+  {{ block "header" . }}
+  {{ $renderSearchIcon := index .Params "renderSearchIcon" | default true }}
+  {{ partialCached "header" . $renderSearchIcon }}
+  {{ end }}
+  <div class="container-fluid">
+    <main>
+      <div class="container-fluid p-0">
+        <div class="row m-0">
+          <div id="search-page" class="w-100">
+            <div class="d-flex flex-column flex-md-row p-2 p-md-0">
+              <input
+                id="search-input"
+                class="w-100"
+                type="text"
+                aria-label="Search"
+                />
+            </div>
+            <section id="search-results" class="m-auto">
+            </section>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+<script>
+  const searchResultTemplate = document.createElement("template")
+  searchResultTemplate.innerHTML = `
+<article>
+  <div class="card learning-resource-card compact-view">
+    <div class="card-contents">
+      <div class="lr-info search-result">
+        <div class="col-2 course-num">
+        </div>
+        <div class="course-title">
+          <a class="course-link"></a>
+        </div>
+        <div class="col-2 resource-level">
+        </div>
+      </div>
+    </div>
+  </div>
+</article>
+`
+
+  class SearchResult extends HTMLElement {
+    constructor() {
+      super()
+    }
+
+    connectedCallback() {
+      this.innerHTML = searchResultTemplate.innerHTML
+      this.courseNumberDiv = this.querySelector(".course-num")
+      this.courseLink = this.querySelector(".course-link")
+      this.levelDiv = this.querySelector(".resource-level")
+      this.courseNumberDiv.innerHTML = this.primaryCourseNumber
+      this.courseLink.setAttribute("href", this.url)
+      this.courseLink.innerHTML = this.title
+      this.levelDiv.innerHTML = this.level
+    }
+
+    get title() {
+      return this.getAttribute("data-title")
+    }
+
+    get primaryCourseNumber() {
+      return this.getAttribute("data-primary-course-number")
+    }
+
+    get level() {
+      return this.getAttribute("data-level")
+    }
+
+    get url() {
+      return this.getAttribute("data-url")
+    }
+  }
+
+  window.customElements.define("search-result", SearchResult)
+
+  window.onload = function() {
+    if (window.Fuse) {
+      const websites = [
+        {{ $websites := where site.Pages ".Params.content_type" "==" "website" }}
+        {{ range $websites }}
+        {{ $urlPath := strings.TrimPrefix "/" .Params.url_path }}
+        {{ $url := printf "%s/%s/index.html" $pathToRoot $urlPath }}
+        {
+          "title": {{- .Title | jsonify -}},
+          "primary_course_number": {{- .Params.primary_course_number | jsonify -}},
+          "url": {{- $url -}},
+          {{ if .Params.level }}
+          "level": {{ (delimit .Params.level ", ") | jsonify }}
+          {{ else }}
+          "level": ""
+          {{ end }}
+        },
+        {{ end }}
+      ]
+      const Fuse = window.Fuse
+      const searchOptions = {
+        shouldSort: true,
+        threshold: 0.4,
+        location: 0,
+        distance: 100,
+        matchAllTokens: true,
+        includeScore: true,
+        maxPatternLength: 32,
+        minMatchCharLength: 5,
+        keys: ["title", "primary_course_number"]
+      }
+      const fuse = new Fuse(websites, searchOptions)
+      const onInput = e => {
+        if (e.target.value) {
+          const searchString = e.target.value
+          const searchResults = fuse.search(searchString)
+          const searchResultComponents = searchResults.map(searchResult => {
+            return `<search-result data-url="${searchResult.item["url"]}" data-title=${searchResult.item["title"]} data-primary-course-number=${searchResult.item["primary_course_number"]} data-level=${searchResult.item["level"]}></search-result>`
+          })
+          const searchResultsSection = document.getElementById("search-results")
+          searchResultsSection.innerHTML = searchResultComponents.join("")
+        }
+      }
+      const searchInput = document.getElementById("search-input")
+      searchInput.addEventListener("input", onInput)
+    }
+  }
+</script>
+{{ end }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8230,10 +8230,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fuse.js@npm:^6.5.3":
-  version: 6.5.3
-  resolution: "fuse.js@npm:6.5.3"
-  checksum: f7c14f4422000e7f7e3515c66f7cefdfc38adec4cf380097f4146a201ea438af60b67dc5849b3c0de0115ce3f9bc5afad6fc6570c08dcfcef5bf6e95eb8e6d6f
+"fuse.js@npm:^6.6.2":
+  version: 6.6.2
+  resolution: "fuse.js@npm:6.6.2"
+  checksum: 17ae758ce205276ebd88bd9c9f088a100be0b4896abac9f6b09847151269d1690f41d7f98ff5813d4a58973162dbd99d0072ce807020fee6f9de60170f6b08eb
   languageName: node
   linkType: hard
 
@@ -12910,7 +12910,7 @@ __metadata:
     expose-loader: ^4.0.0
     fancy-log: ^1.3.2
     file-loader: ^5.0.2
-    fuse.js: ^6.5.3
+    fuse.js: ^6.6.2
     gulp: ^4.0.2
     history: ^5.3.0
     hugo-bin-extended: ~0.112.7


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1174

# Description (What does it do?)
This PR adds the [Fuse.js](https://fusejs.io/) library to the project and utilizes it to provide offline search functionality in the `www-offline` theme, used as the home page of mirror drives. The search icon is now displayed in the header on pages that aren't the search page, linking to a new `search.html` page at the root. In https://github.com/mitodl/ocw-studio/pull/1705, we set up `ocw-studio` to publish a file under `content/websites` for each website that has been published live at least once inside the root website, `ocw-www`. This content is currently being used to generate a paginated list of sites at the root when using the `www-offline` theme in `index.html`. In `search.html`, we put that same list into an array in Javascript and feed it into Fuse.js as a data source, indexing on `primary_course_number` and `title`. The search page mostly replicates a basic version of the online search without any facets or resource search, providing links to sites relative to the root of the mirror drive in the same way the paginated index does. Everything is done in raw Javascript right in a script tag on the page to avoid any issues with CORS when viewing the page without a web server offline.

# Screenshots (if appropriate):
![image](https://github.com/mitodl/ocw-hugo-themes/assets/12089658/a92c0815-bab5-44c5-9e30-2cf7cd39504d)
![image](https://github.com/mitodl/ocw-hugo-themes/assets/12089658/2f7d9d1a-1484-400f-8b22-a04870a37c33)


# How can this be tested?
 - Clone `ocw-hugo-themes` on this branch as well as https://github.mit.edu/ocw-content-rc/ocw-www and `ocw-hugo-projects` on the `cg/www-offline-enable-section` branch
 - In `ocw-hugo-themes`, run `yarn install` to make sure you install the latest dependencies
 - In `ocw-hugo-themes`, run `yarn build /path/to/ocw-content-rc/ocw-www/ /path/to/ocw-hugo-projects/ocw-www/config-offline.yaml`
 - Browse to your `ocw-content-rc/ocw-www/dist` folder and double click on `index.html`
 - Click the search icon in the header
 - Type any query you want here and search for courses
 - Click on any of the courses and verify that the path in your browser looks something like `file://path/to/ocw-content-rc/ocw-www/dist/courses/course-name`
 - These courses will not be present because this isn't a full mirror drive build, but if you want to test browsing to an offline site this way you can download the course ZIP from the live site, create a `courses` folder under `dist` and extract it there to a folder matching the course`s `name` property

# Release process
https://github.com/mitodl/ocw-hugo-projects/pull/255 should be merged and released before this PR