### PR TITLE
adjust fuse threshold in offline search to better filter out irrelevant results

### DIFF
--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -73,12 +73,8 @@ window.addEventListener('load', function() {
     const Fuse = window.Fuse
     const searchOptions = {
       shouldSort: true,
-      threshold: 0.2,
-      location: 0,
-      distance: 100,
-      matchAllTokens: true,
       includeScore: true,
-      maxPatternLength: 32,
+      threshold: 0.2,
       minMatchCharLength: 3,
       keys: ["title", "primary_course_number"]
     }

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -84,6 +84,7 @@ window.addEventListener('load', function() {
     const searchButton = document.getElementById("search-button")
     const performSearch = searchString => {
       const searchResults = fuse.search(searchString)
+      const searchResultsSection = document.getElementById("search-results")
       if (searchResults.length > 0) {
         const searchResultComponents = searchResults.map(searchResult => {
           return `
@@ -106,7 +107,6 @@ window.addEventListener('load', function() {
           </article>
           `
         })
-        const searchResultsSection = document.getElementById("search-results")
         searchResultsSection.innerHTML = searchResultComponents.join("")
       }
       else {

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -73,6 +73,7 @@ window.addEventListener('load', function() {
     const Fuse = window.Fuse
     const searchOptions = {
       shouldSort: true,
+      ignoreLocation: true,
       includeScore: true,
       threshold: 0.2,
       minMatchCharLength: 3,

--- a/www-offline/layouts/search/section.html
+++ b/www-offline/layouts/search/section.html
@@ -73,7 +73,7 @@ window.addEventListener('load', function() {
     const Fuse = window.Fuse
     const searchOptions = {
       shouldSort: true,
-      threshold: 0.4,
+      threshold: 0.2,
       location: 0,
       distance: 100,
       matchAllTokens: true,


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1182

# Description (What does it do?)
This PR simply adjusts the `threshold` value in the FuseJS configuration for offline search in `www-offline` to 0.2 from 0.4. After some testing, this seems to be a good place to set it in order to filter out irrelevant results.

# Screenshots (if appropriate):
![image](https://github.com/mitodl/ocw-hugo-themes/assets/12089658/2fee3dd8-771f-4efe-8f36-86fd015c5661)

# How can this be tested?
Follow the same instructions as https://github.com/mitodl/ocw-hugo-themes/pull/1175, but pay extra attention to the results and verify that irrelevant results have been minimized
