### PR TITLE
Change OCW News mobile(xs) display to horizontal

### DIFF
--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -46,10 +46,13 @@ $panel-course-info-text-color: #464646;
 // OCW news in homepage
 $featured-news-heading-font-lg: 1.875rem;
 $featured-news-line-height-lg: 2.325rem;
-$featured-news-heading-font-sm: 1.25rem;
-$featured-news-line-height-sm: 1.56rem;
 $featured-news-heading-font-md: 1.4rem;
 $featured-news-line-height-md: 1.8rem;
+$featured-news-heading-font-sm: 1.25rem;
+$featured-news-line-height-sm: 1.56rem;
+$featured-news-headong-font-xs: 1rem;
+$featured-news-line-height-xs: 1.3rem;
+$featured-news-font-weight-xs: 400;
 $featured-news-date-font: 0.875rem;
 $featured-news-date-line-height: 1rem;
 $news-card-content-color: rgba(255, 255, 255, 0.6);

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -50,7 +50,7 @@ $featured-news-heading-font-md: 1.4rem;
 $featured-news-line-height-md: 1.8rem;
 $featured-news-heading-font-sm: 1.25rem;
 $featured-news-line-height-sm: 1.56rem;
-$featured-news-headong-font-xs: 1rem;
+$featured-news-heading-font-xs: 1rem;
 $featured-news-line-height-xs: 1.3rem;
 $featured-news-font-weight-xs: 400;
 $featured-news-date-font: 0.875rem;

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -527,6 +527,7 @@ $promo-carousel-height: 200px;
 .news-container:not(.mobile) {
   height: 500px;
 }
+
 .news-container {
   font-family: "Arial", sans-serif;
   display: flex;
@@ -587,9 +588,9 @@ $promo-carousel-height: 200px;
 
     .featured-news-heading.mobile {
       @include media-breakpoint-down(xs) {
-        font-size: 1rem;
-        line-height: 1.3rem;
-        font-weight: 400;
+        font-size: $featured-news-heading-font-xs;
+        line-height: $featured-news-line-height-xs;
+        font-weight: $featured-news-font-weight-xs;
       }
     }
 

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -553,7 +553,7 @@ $promo-carousel-height: 200px;
         height: 500px;
         width: 100%;
       }
-      @include  media-breakpoint-down(xs){
+      @include media-breakpoint-down(xs) {
         height: 215px;
       }
     }

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -524,12 +524,15 @@ $promo-carousel-height: 200px;
   }
 }
 
+.news-container:not(.mobile) {
+  height: 500px;
+}
 .news-container {
   font-family: "Arial", sans-serif;
   display: flex;
   border-radius: 8px;
   overflow: hidden;
-  height: 500px;
+  // height: 500px;
 
   @include breakpoint(ipad) {
     display: none;
@@ -544,10 +547,14 @@ $promo-carousel-height: 200px;
       width: 100%;
       height: 100%;
       object-fit: cover;
+      background-size: cover;
 
       @include breakpoint(ipad) {
         height: 500px;
         width: 100%;
+      }
+      @include  media-breakpoint-down(xs){
+        height: 215px;
       }
     }
 

--- a/www/assets/css/home.scss
+++ b/www/assets/css/home.scss
@@ -532,7 +532,6 @@ $promo-carousel-height: 200px;
   display: flex;
   border-radius: 8px;
   overflow: hidden;
-  // height: 500px;
 
   @include breakpoint(ipad) {
     display: none;
@@ -550,7 +549,7 @@ $promo-carousel-height: 200px;
       background-size: cover;
 
       @include breakpoint(ipad) {
-        height: 500px;
+        height: 450px;
         width: 100%;
       }
       @include media-breakpoint-down(xs) {
@@ -586,11 +585,23 @@ $promo-carousel-height: 200px;
       }
     }
 
+    .featured-news-heading.mobile {
+      @include media-breakpoint-down(xs) {
+        font-size: 1rem;
+        line-height: 1.3rem;
+        font-weight: 400;
+      }
+    }
+
     .featured-news-date {
       color: $white;
       font-size: $featured-news-date-font;
       line-height: $featured-news-date-line-height;
       padding-bottom: 7px;
+
+      @include media-breakpoint-down(xs) {
+        padding-bottom: 5px;
+      }
     }
 
     .featured-news-content {
@@ -609,6 +620,9 @@ $promo-carousel-height: 200px;
       }
       @include breakpoint(ipad) {
         padding: 20px;
+      }
+      @include media-breakpoint-down(xs) {
+        padding: 10px 15px;
       }
     }
   }


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1388

# Description (What does it do?)
This is a follow up PR to the original issue for some design modification.
Such that currently for small screens(xs), the news images stay a fixed height and tend to go vertical. But we want them to follow the same fashion for small screens as it was originally, i.e, horizontal. This is to help stay consistent with the image sizes and cropping work.

# Screenshots (In progress):
<img width="1296" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/02775564-3511-4561-a5a2-4dd3299e5ec8">
<img width="464" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/4e7a4c51-bbed-4c83-8840-f7e7f2666984">
<img width="485" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/b21768e1-1f49-426b-9a69-0fe5ddcdab59">
<img width="626" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/c9c5799a-89bd-4902-a91a-54067ce43933">
<img width="544" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/97c8648e-dbdc-45d5-90c4-508860ed6627">


# How can this be tested?
The overall functionality/layout/design structure has already been tested. For this PR we just want to make sure for smaller screens the view looks correct. Make sure that the changes applied (changed related to numerical values) are actually visible on the page (that they are not overridden by some other properties) and nothing breaks.

For mobile interface (on all sizes where we have one news on display) make sure that no kind of images break the design. I tried testing with 100x100 images and it was ok, you're free to test anything you have in mind too.
You can use the netlify link/local host server and inspect element and add any image link from google in one of the already existing `img` tags to do this.
