### PR TITLE
fix offline video player for videos with no archive_url

### DIFF
--- a/base-offline/layouts/partials/video.html
+++ b/base-offline/layouts/partials/video.html
@@ -1,5 +1,6 @@
 {{ $youtubeKey := trim .Params.video_metadata.youtube_id " "}}
 {{ $archiveUrl := .Params.video_files.archive_url }}
+{{ $downloadLink := .Params.file }}
 {{ $relatedResourses := .Params.related_resources_text | default "" }}
 {{ $optionalTabTitle := .Params.optional_tab_title | default "" }}
 {{ $optionalTabContent := .Params.optional_text | default ""}}
@@ -14,7 +15,7 @@
   	<div class="description">
     	{{ .Content }}
   	</div>
-  	{{ partial "video_player.html" (dict "context" $context "youtubeKey" $youtubeKey "archiveUrl" $archiveUrl "startTime" $startTime "endTime" $endTime)}}
+  	{{ partial "video_player.html" (dict "context" $context "youtubeKey" $youtubeKey "archiveUrl" $archiveUrl "downloadLink" $downloadLink "startTime" $startTime "endTime" $endTime) }}
 
   	{{ if $relatedResourses }}
 	  {{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "related-resource" "tabTitle" "Related Resources" "tabContent" $relatedResourses) }}

--- a/base-offline/layouts/partials/video_player.html
+++ b/base-offline/layouts/partials/video_player.html
@@ -1,5 +1,5 @@
 {{ $archiveVideoFound := false }}
-{{ $archiveUrl := .archiveUrl }}
+{{ $archiveUrl := .archiveUrl | default .downloadLink }}
 {{ $parsedArchiveUrl := urls.Parse $archiveUrl }}
 {{ $parsedArchiveUrlPath := path.Split $parsedArchiveUrl.Path }}
 {{ $archiveFile := $parsedArchiveUrlPath.File }}
@@ -8,7 +8,7 @@
 {{ $archiveVideoSearchResuts := $staticResourcesBundle.Resources.Match $archiveFile }}
 {{ $archiveVideoFound = gt (len $archiveVideoSearchResuts) 0 }}
 {{ if not $archiveVideoFound }}
-{{ partial "youtube_player.html" (dict "context" .context "youtubeKey" .youtubeKey "archiveUrl" .archiveUrl "startTime" .startTime "endTime" .endTime)}}
+{{ partial "youtube_player.html" (dict "context" .context "youtubeKey" .youtubeKey "archiveUrl" $archiveUrl "startTime" .startTime "endTime" .endTime)}}
 {{ else }}
-{{ partial "local_video_player.html" (dict "context" .context "youtubeKey" .youtubeKey "archiveUrl" .archiveUrl "startTime" .startTime "endTime" .endTime)}}
+{{ partial "local_video_player.html" (dict "context" .context "youtubeKey" .youtubeKey "archiveUrl" $archiveUrl "startTime" .startTime "endTime" .endTime)}}
 {{ end }}


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1193

# Description (What does it do?)
Videos uploaded to GDrive and handled by `ocw-studio` are not uploaded to archive.org and thus have no value on `metadata.video_files.archive_url`. The transcoded archive video is instead uploaded to S3 with the file path stored on the `metadata.file` property. This PR alters the offline video player templates to fall back to using the `file` property to obtain the archive video file name it should look for should `archive_url` not be available.

# How can this be tested?
 - Create a site in [`ocw-studio` RC](https://ocw-studio-rc.odl.mit.edu/)
 - Browse to the metadata section and fill out the required metadata to save it
 - Browse to the Resources section, click the link to open the GDrive folder and upload a sample video into the `videos_final` folder
 - Back in `ocw-studio`, click the Sync With GDrive button and wait for it to finish
 - Wait for the video transcoding process to finish (You can check on this in Django admin by going to the Videos section and finding the video we just uploaded, then waiting until you see that the transcoding process has completed)
 - Once transcoding is complete, browse to the Pages section and create a test page, embedding the video we just uploaded into the page content
 - Go to the menu section and add a link to the test page we just created
 - From the publish drawer, publish your course live, then once publishing is complete open the publish drawer again and click the link to view your site
 - Click the Download Course button, then right click the Download Course button on the download page and copy the link
 - Paste this link into a new window and append `-video` to the end of the ZIP filename to download the offline version of the course with videos
 - Find the repository generated for your site at https://github.mit.edu/ocw-content-rc and clone it locally
 - Clone `ocw-hugo-projects` locally
 - Inside the course content repo, create a folder at `content/static_resources`
 - Extract the ZIP we downloaded above, browse to the `static_resources` folder and copy the transcoded video into our course content repo's `content/static_resources` folder
 - In `ocw-hugo-themes`, on this branch, run `yarn build /path/to/course-id/ /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml` where `course-id` matches the folder name of your course content repo
 - Back in your course content repo, browse to the `dist` folder and double click on `index.html`
 - Browse to the test page we created and verify that the embedded video plays back locally and not from YouTube
 - Click the button to view the video page and verify that the local version of the video plays there as well.
