### PR TITLE
Improve request parallelization, particularly on Chrome

### DIFF
--- a/base-theme/layouts/partials/head.html
+++ b/base-theme/layouts/partials/head.html
@@ -2,7 +2,6 @@
 {{- $noindex := getenv "NOINDEX" -}}
 
 <head>
-  {{ block "extrahead" . }}{{ end }}
   {{ if $gtmId }}
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -12,6 +11,7 @@
     })(window,document,'script','dataLayer','{{ $gtmId }}');</script>
     <!-- End Google Tag Manager -->
   {{ end }}
+  {{ block "extrahead" . }}{{ end }}
   {{ if eq $noindex "true" }}
   <meta name="robots" content="noindex">
   {{ end }}


### PR DESCRIPTION
### What are the relevant tickets?
Related to #1196 

### Description (What does it do?)
This PR moves Google Tag Manager script to the top of `<head />`, as [recommended](https://support.google.com/tagmanager/answer/6103696?hl=en): 

> Place the <script> code snippet in the <head> of your web page's HTML output, preferably as close to the opening <head> tag as possible, but below any dataLayer declarations.

**Why?** The goal is to better parallelize network requests, particularly in Chrome. Previously, in Chrome, many requests were being queued after some CSS. Similar queueing seemed to occur in firefox, though to a much lesser extent.

<img width="1000" alt="Screenshot 2023-07-14 at 4 33 05 PM" src="https://github.com/mitodl/ocw-hugo-themes/assets/9010790/e2eed914-f5a8-4cf1-991e-e196791ba6cb">

Notes:
- Despite research and trying to reproduce with very minimal examples, I don't have a great understanding of why moving the GTM script above the `<link />` has this effect. But since putting GTM at the top is recommended anyway, I feel good about this change. 

### How can this be tested?

> **Warning**
> This behavior is hard to observe locally: 
> - the assets need to be served via http2, which will only happen if using https and a server configured for it.
> - the hugo build environment needs to have GTM_ACCOUNT_ID set.

Consequently, you can observe the behavior easily in Prod or on RC, but not on our default PR builds deployed with netlify (no `GTM_ACCOUNT_ID`) and not easily on localhost (http1.1, which is limited to 6 concurrent connections per host).

To help test this change, I've made two separate PRs just for the netlify deployments:
1.  https://ocw-hugo-themes-course-v2-pr-1202--ocw-next.netlify.app/ is exactly the `main` branch netlify deployment, but with `GTM_ACCOUNT_ID` set to the RC value.
1.  https://ocw-hugo-themes-course-v2-pr-1200--ocw-next.netlify.app/ is exactly the `cc/move-gtm` branch netlify deployment, but with `GTM_ACCOUNT_ID` set to the RC value.

**To observe old blocking behavior:**
1. Use Chrome in Incognito mode.
3. In the dev console network tab, disable caching and set throttling to Fast 3G. *Effect is easier to see on slow networks.*
4. In performance tab, start recording.
5. Visit https://ocw-hugo-themes-course-v2-pr-1202--ocw-next.netlify.app/
6. Stop recording.
7. View the "Network" panel of performance tab.
8. Observe the blocking behavior shown above: requests do not start (only queued) until after the first CSS request finishes.

**To observe new behavior:** Repeat steps above, but use  https://ocw-hugo-themes-course-v2-pr-1202--ocw-next.netlify.app/

**Additional Tests:**
- repeat in firefox if you like. There's an improvement there, too, but it's not as dramatic.
- assure yourself that performance hasn't gotten *worse*. _It should be noticeably better, particularly on slow connections._

### Additional Notes
Because Lighthouse and PageSpeed Insights both use Chromium, I expect this to help or Core Web Vitals scores:
- First Contentful Paint (FCP) should benefit from faster loading
- Largest Contentful Paint (LCP) should benefit from faster loading
- Cumulative Layout Shift (LCS) benefits indirectly: The page won't render untill CSS has been downloaded. That happens just as quickly as before. But now images may have downloaded before CSS finishes, so we may get less content shift.

Lighthouse performance scores are variable, but they do seem better on `1200` link than on 1202` link. Try https://pagespeed.web.dev/ if you're interested. 