### PR TITLE
Course theme accessibility fixes (aria-hidden and aria-expanded)

### DIFF
--- a/base-theme/layouts/partials/resource_body_v2.html
+++ b/base-theme/layouts/partials/resource_body_v2.html
@@ -15,7 +15,7 @@
       {{- if .Params.file -}}
       <div class="row">
           <div class="col-12 d-flex flex-direction-row align-items-center">
-              <a class="download-file" href="{{ partial "resource_url.html" (dict "context" . "url" .Params.file) }}"><span class="material-icons">file_download</span> Download File</a>
+              <a class="download-file" href="{{ partial "resource_url.html" (dict "context" . "url" .Params.file) }}"><span aria-hidden="true" class="material-icons">file_download</span> Download File</a>
           </div>
       </div>
       {{- end -}}

--- a/course-v2/layouts/partials/learning_resource_type.html
+++ b/course-v2/layouts/partials/learning_resource_type.html
@@ -3,7 +3,7 @@
 
 <div class="{{ if not $inPanel }}learning-resource-type-item{{ end }}">
   <div class="d-flex">
-    <i class="material-icons pr-1">
+    <i aria-hidden="true" class="material-icons pr-1">
       {{- if eq $context "Course Introduction" -}}
       groups
       {{- else if in $context "Audio" -}}

--- a/course-v2/layouts/partials/resource_list_collapsible.html
+++ b/course-v2/layouts/partials/resource_list_collapsible.html
@@ -17,7 +17,7 @@
   class="{{ if not $expand }}collapsed {{ end }}py-3"
   data-toggle="collapse"
   aria-controls="resource-list-container-{{ $resourceSlug }}"
-  aria-expanded="{{ if $expand }}true {{ else }}false{{ end }}">
+  aria-expanded="{{ if $expand }}true{{ else }}false{{ end }}">
     <i aria-hidden="true" class="material-icons"></i>
     <h4 class="my-4">{{ .Title }}</h4>  
   </a>

--- a/course-v2/layouts/partials/resource_list_collapsible.html
+++ b/course-v2/layouts/partials/resource_list_collapsible.html
@@ -17,8 +17,8 @@
   class="{{ if not $expand }}collapsed {{ end }}py-3"
   data-toggle="collapse"
   aria-controls="resource-list-container-{{ $resourceSlug }}"
-  aria-expanded="{{ if $expand }}true{{ end }}">
-    <i class="material-icons"></i>
+  aria-expanded="{{ if $expand }}true {{ else }}false{{ end }}">
+    <i aria-hidden="true" class="material-icons"></i>
     <h4 class="my-4">{{ .Title }}</h4>  
   </a>
   </div>

--- a/course-v2/layouts/partials/resource_list_item.html
+++ b/course-v2/layouts/partials/resource_list_item.html
@@ -14,10 +14,11 @@
         {{ $downloadableLink := partial "get_resource_download_link.html" .params }}
           <span class="pr-2">
             {{ if $downloadableLink }}
-              <a href="{{- $downloadableLink -}}" target="_blank" download>
+              <a href="{{- $downloadableLink -}}" aria-label="Download file" target="_blank" download>
                 <img
                   class="hide-offline resource-download"
                   src="/static_shared/images/download.svg"
+                  aria-hidden="true"
                 />
               </a>
             {{ end }}

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -10,7 +10,7 @@
     <div class="row">
       <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
         <a class="download-course-button p-2" href="{{ $downloadCourseUrl }}">
-          <span class="material-icons">file_download</span> Download course
+          <span aria-hidden="true" class="material-icons">file_download</span> Download course
         </a>
       </div>
       <div class="col-12 col-md-9">

--- a/course-v2/layouts/partials/see_all.html
+++ b/course-v2/layouts/partials/see_all.html
@@ -1,6 +1,6 @@
 <div>
   <a class="text-decoration-none font-weight-bold" href="{{ .permalink }}">
     <span>See all</span>
-    <i class="material-icons see-all-resources-icon align-middle">arrow_forward</i>
+    <i aria-hidden="true" class="material-icons see-all-resources-icon align-middle">arrow_forward</i>
   </a>
 </div>

--- a/course-v2/layouts/partials/topic.html
+++ b/course-v2/layouts/partials/topic.html
@@ -13,7 +13,7 @@
     data-toggle="collapse"
     aria-controls="subtopic-container_{{ $device }}_{{ $index }}"
     aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}">
-    <i class="material-icons"></i>
+    <i aria-hidden="true" class="material-icons"></i>
   </a>
   {{ end }}
   <span class="topic-text-wrapper">
@@ -34,7 +34,7 @@
       data-toggle="collapse"
       aria-controls="speciality-container_{{ $device }}_{{ $index }}_{{ $subtopicIndex }}"
       aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}">
-      <i class="material-icons"></i>
+      <i aria-hidden="true" class="material-icons"></i>
     </a>
     {{ end }}
     <span class="topic-text-wrapper">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested for online + offline theme
  - [x] Changes have been tested using VoiceOver (Mac's screen reader)

# What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/1972
Closes https://github.com/mitodl/hq/issues/1973

# Description (What does it do?)
This PR fixes accessibility related issues on course pages. It focuses on `aria-hidden` and `aria-expanded`.
Apart from the above mentioned issues (sub-tasks), it also fixes the mentioned 3 problems: https://github.com/mitodl/hq/issues/1918#issuecomment-1645290474

# How can this be tested?
We will be using this course to test changes: `16.885j-fall-2005`
This is not the same course as mentioned in the issues (https://ocw.mit.edu/courses/res-7-005-biology-teaching-assistant-ta-training-fall-2021/download/). We need this course to check for other changes. Also, [the course](https://github.mit.edu/mitocwcontent/RES.7-005-Summer-2020) in` ocw-content-rc` it had some missing content which was needed for testing. (I tried changing `RESOURCE_BASE_URL` but the resources in `./download` still would not appear.) If anyone knows this fix, please let me know.

But we don't have to test for that course since these are theme related changes. So we will be using `16.885j-fall-2005 `instead. 
Checkout to this branch,
Run `yarn start course 16.885j-fall-2005 `.
Go to `http://localhost:3000/download/`

And then, check for the issues mentioned in https://github.com/mitodl/hq/issues/1972. And then check for https://github.com/mitodl/hq/issues/1973. And then check for the 3 fixes I mentioned here https://github.com/mitodl/hq/issues/1918#issuecomment-1645290474. 

All of these changes are present in `http://localhost:3000/download/`.
Except one change, for resource file download. Click on any resource and observe the `Download File` button.
You can use this link: `http://localhost:3000/resources/cohen_bio/`

If you're on Mac, you can also use Mac's VoiceOver to confirm how screen reader now reads those fixes, as compared to before: https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2004/download/

I also tested the changes for offline theme (because it uses the same files) just to be safe. But testing for just online (course) theme should be sufficient.
