### PR TITLE
no roboto font

### DIFF
--- a/base-theme/assets/css/video.scss
+++ b/base-theme/assets/css/video.scss
@@ -4,7 +4,6 @@
   color: white;
   height: 37px;
   .tab-title {
-    font-family: "Roboto";
     line-height: 1.14rem;
     text-transform: uppercase;
     color: $video-tab-title-color !important;

--- a/base-theme/layouts/partials/head.html
+++ b/base-theme/layouts/partials/head.html
@@ -19,7 +19,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   {{ block "seo" . }}{{ end }}
   <title>{{ block "title" . }}{{ end }}</title>
-  <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">
   <style>
   @font-face {
     font-family: 'Material Icons';


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1314

# Description (What does it do?)
Removes roboto font.

# Screenshots (if appropriate):
The screenshot is WITH the change. The pasted in bit is the old version.

<img width="766" alt="Screenshot 2024-02-09 at 9 41 34 AM" src="https://github.com/mitodl/ocw-hugo-themes/assets/9010790/64dbe2d1-514b-48d0-ba12-2749314ef001">



# How can this be tested?
View a video page and confirm it looks almost exactly the same as it does on the live site.

