### PR TITLE
feat: add mobile device warning to download course page

### DIFF
--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -167,6 +167,14 @@ pre {
   }
 }
 
+.touch-device-only {
+  display: none;
+
+  @media (pointer: coarse) {
+    display: block;
+  }
+}
+
 // TODO: overriding some css of header and footer in this new theme
 // when we roll out this theme completely then we can move this css to thier respective files in base-theme
 

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -167,10 +167,10 @@ pre {
   }
 }
 
-.touch-device-only {
+.limited-pointer-only {
   display: none;
 
-  @media (pointer: coarse) {
+  @media (pointer: coarse), (pointer: none) {
     display: block;
   }
 }

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -8,11 +8,6 @@
 {{- else -}}
 <div class="mb-2">
   <h2>Download</h2>
-  <div class="alert-warning p-2 touch-device-only">
-    <strong>Note: </strong>
-    The downloaded course may not work on mobile devices.
-    We recommend using a desktop computer.
-  </div>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
     <div class="row align-items-center">
       <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
@@ -26,6 +21,11 @@
         For help downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
       </div>
     </div>
+  </div>
+  <div class="alert-warning p-2 touch-device-only">
+    <strong>Note: </strong>
+    The downloaded course may not work on mobile devices.
+    We recommend using a desktop computer.
   </div>
 </div>
 {{- if $noResourcesFound -}}

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -9,7 +9,7 @@
 <div class="mb-2">
   <h2>Download</h2>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
-    <div class="row">
+    <div class="row align-items-center">
       <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
         <a class="download-course-button p-2" href="{{ $downloadCourseUrl }}">
           <span aria-hidden="true" class="material-icons">file_download</span> Download course
@@ -19,6 +19,8 @@
         This package contains the same content as the online version of the course
         {{- if $containsVideos }}, <em>except for the audio/video materials</em>. These can be downloaded below{{ end }}.
         For help downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
+        <br />
+        <em>Note: the downloaded course package does not currently work on mobile devices.</em>
       </div>
     </div>
   </div>

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -25,7 +25,7 @@
   <div class="alert-warning p-2 touch-device-only">
     <strong>Note: </strong>
     The downloaded course may not work on mobile devices.
-    We recommend using a desktop computer.
+    We recommend using a computer with the downloaded course package.
   </div>
 </div>
 {{- if $noResourcesFound -}}

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -9,7 +9,7 @@
 <div class="mb-2">
   <h2>Download</h2>
   <div class="alert-warning p-2 touch-device-only">
-    <strong>Warning</strong>
+    <strong>Note: </strong>
     The downloaded course may not work on mobile devices.
     We recommend using a desktop computer.
   </div>

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -8,6 +8,11 @@
 {{- else -}}
 <div class="mb-2">
   <h2>Download</h2>
+  <div class="alert-warning p-2 touch-device-only">
+    <strong>Warning</strong>
+    The downloaded course may not work on mobile devices.
+    We recommend using a desktop computer.
+  </div>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
     <div class="row align-items-center">
       <div class="d-flex justify-content-center col-12 col-md-3 px-3 pb-2 pb-md-0">
@@ -19,8 +24,6 @@
         This package contains the same content as the online version of the course
         {{- if $containsVideos }}, <em>except for the audio/video materials</em>. These can be downloaded below{{ end }}.
         For help downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
-        <br />
-        <em>Note: the downloaded course package does not currently work on mobile devices.</em>
       </div>
     </div>
   </div>

--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -22,7 +22,7 @@
       </div>
     </div>
   </div>
-  <div class="alert-warning p-2 touch-device-only">
+  <div class="alert-warning p-2 limited-pointer-only">
     <strong>Note: </strong>
     The downloaded course may not work on mobile devices.
     We recommend using a computer with the downloaded course package.


### PR DESCRIPTION
# What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/2065

# Description (What does it do?)

Adds a message to the download course page.

The message only appears on touch devices. I've used the `pointer` property for this purpose. [MSDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer#:~:text=a%20pointing%20device.-,coarse,-The%20primary%20input). This might not be perfect but works in most cases from what I've seen.

# Screenshots (if appropriate):

- [x] Mobile width screenshots


![demo4](https://github.com/mitodl/ocw-hugo-themes/assets/71316217/6b4e16db-70a8-432f-b13d-a2b359dc4c01)





# How can this be tested?

## Prerequsites

* You'll need a markdown of a course. Any course would work. You can pick one from here https://github.mit.edu/ocw-content-rc/. Place this in your local ocw-content folder.

## Steps

1. Navigate to your local ocw-hugo-themes setup. Checkout branch `hussaintaj/2065`.
2. Run
    ```
    yarn start course course-id
    ```
3. Navigate to [localhost:3000/download](http://localhost:3000/download)
4. Open devtools, toggle the device toolbar and select a mobile device to view the page. Alternatively, open the link on your phone `<your-local-ip>:3000/download`.
5. **Expected Behavior**: You see the new message clearly. Please take a look at the screenshots for reference. The message should only appear on mobile (touch) devices.

