### PR TITLE
Stop layout shift on videos

### DIFF
--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -5,17 +5,18 @@
   data-target=".{{- .tabClass -}}"
   data-toggle="collapse"
   aria-controls="{{- .tabClass -}}"
+  aria-expanded=""
   role="tab"
   >
   <div class="video-tab-header">
     {{ if .tabTitle }}
-      <span class="tab-title-section" aria-label="{{ .tabTitle }}">
+      <span class="tab-title-section">
         {{ if and .resourceUrl $isEmbedVideo }}
-          <a href="{{ .resourceUrl }}">
+          <a href="{{ .resourceUrl }}" aria-label="{{ .tabTitle }}">
           {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </a>
         {{ else }}
-          <button>
+          <button aria-label="{{ .tabTitle }}">
             {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </button>
         {{ end }}
@@ -24,8 +25,8 @@
     {{/*  If we have transcript or the video is embed video, show download button on those tabs.
       Otherwise show download button in a standalone tab bar  */}}
     {{ if or ($videoHasTranscript) ($isEmbedVideo) (eq .tabTitle "") }}
-      <div class="float-right" aria-label="Download Video and Transcript">
-        <button class="video-download-icons">
+      <div class="float-right">
+        <button class="video-download-icons" aria-label="Download Video and Transcript">
           <img class="video-download-icon" src="/static_shared/images/videojs_download.svg"/>
           <i class="material-icons caret-down"></i>
         </button>

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -5,18 +5,17 @@
   data-target=".{{- .tabClass -}}"
   data-toggle="collapse"
   aria-controls="{{- .tabClass -}}"
-  aria-expanded=""
   role="tab"
   >
   <div class="video-tab-header">
     {{ if .tabTitle }}
-      <span class="tab-title-section">
+      <span class="tab-title-section" aria-label="{{ .tabTitle }}">
         {{ if and .resourceUrl $isEmbedVideo }}
-          <a href="{{ .resourceUrl }}" aria-label="{{ .tabTitle }}">
+          <a href="{{ .resourceUrl }}">
           {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </a>
         {{ else }}
-          <button aria-label="{{ .tabTitle }}">
+          <button>
             {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </button>
         {{ end }}
@@ -25,8 +24,8 @@
     {{/*  If we have transcript or the video is embed video, show download button on those tabs.
       Otherwise show download button in a standalone tab bar  */}}
     {{ if or ($videoHasTranscript) ($isEmbedVideo) (eq .tabTitle "") }}
-      <div class="float-right">
-        <button class="video-download-icons" aria-label="Download Video and Transcript">
+      <div class="float-right" aria-label="Download Video and Transcript">
+        <button class="video-download-icons">
           <img class="video-download-icon" src="/static_shared/images/videojs_download.svg"/>
           <i class="material-icons caret-down"></i>
         </button>

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -151,7 +151,7 @@ a.video-download-button:visited {
   display: none !important;
 }
 
-// Stop layout shift when the video player has not yet dynamically loaded
+//video element is replaced by VideoJS; set dimensions to prevent layout shift when VJS loads.
 .youtube-container > video {
   height: 0;
   max-width: 100%;

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -151,6 +151,14 @@ a.video-download-button:visited {
   display: none !important;
 }
 
+// Stop layout shift when the video player has not yet dynamically loaded
+.youtube-container > video {
+  height: 0;
+  max-width: 100%;
+  width: 100%;
+  padding-top: 56.25%;
+}
+
 .video-tab-toggle-section {
   position: relative;
 }

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -156,7 +156,7 @@ a.video-download-button:visited {
   height: 0;
   max-width: 100%;
   width: 100%;
-  padding-top: 56.25%;
+  padding-top: 56.25%; // apply aspect ratio padding of (9,16)
 }
 
 .video-tab-toggle-section {

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -156,7 +156,7 @@ a.video-download-button:visited {
   height: 0;
   max-width: 100%;
   width: 100%;
-  padding-top: 56.25%; // apply aspect ratio padding of (9,16)
+  padding-top: 56.25%;
 }
 
 .video-tab-toggle-section {


### PR DESCRIPTION
# What are the relevant tickets?
Closes #1213 

# Description (What does it do?)
Stops the layout shift on video player when `videojs` has not yet dynamically loaded by adding height and width styling.

# Testing

We will test for:
1. Regular videos
2. Embed videos
3. Offline videos (youtube player)
4. Offline videos (local video player)

**How to test:**
I tested using `low end mobile` throttling setting in inspect element. And refreshing the page several times, and stopping the loading right after the page opens. Make sure there is no shift in layout (as demonstrated in the video in the issue).

For embed videos and regular videos, let's use this course: `18.06-spring-2010`
1. `yarn start course 18.06-spring-2010`
2.  This is an example of embed video: http://localhost:3000/pages/instructor-insights/
3.  This is an example of regular video: http://localhost:3000/resources/an-interview-with-gilbert-strang-on-teaching-linear-algebra/
4.  Test the layouts in both cases^

For offline theme, use any course whose content (static resources -- a video) you already have downloaded to ensure local video player runs as expected after this change. If you don't have that, use the testing instructions in this PR to download course contents: https://github.com/mitodl/ocw-hugo-themes/pull/1160

Afterwards, if you haven't made a build, do so with:
`yarn build /path/to/18.06-spring-2010/ /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`

Go to your local course `18.06-spring-2010/dist` directory, open up `index.html` and go to video lectures. Go to lecture 2. Test the local video player layout. 

Now, go to `18.06-spring-2010/content/static_resources` and delete `02.mp4`
Run again: `yarn build /path/to/18.06-spring-2010/ /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`
Go to lecture 2 again now from the above steps (dist directory). Test the youtube video player layout.