### PR TITLE
fix: course-info toggle accessibility

### DIFF
--- a/course-v2/assets/css/course-info.scss
+++ b/course-v2/assets/css/course-info.scss
@@ -19,17 +19,7 @@ $panel-course-info-text-color: #464646;
   }
 }
 
-.close-course-info {
-  margin-left: auto;
-  background-color: $course-info-btn-color !important;
-  border-radius: 0px !important;
-}
-
-.close-course-info:hover {
-  background-color: $course-info-btn-hover-color !important;
-}
-
-.show-course-info {
+.course-info-button {
   position: absolute;
   top: 0;
   right: 0;
@@ -37,7 +27,7 @@ $panel-course-info-text-color: #464646;
   border-radius: 0px !important;
 }
 
-.show-course-info:hover {
+.course-info-button:hover {
   background-color: $course-info-btn-hover-color !important;
 }
 

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -160,6 +160,9 @@ pre {
 
 .course-detail-title {
   margin-bottom: 10px;
+  min-height: 35px;
+  display: flex;
+  align-items: center;
 
   h2 {
     font-size: $course-heading-four-font !important;

--- a/course-v2/assets/css/drawer.scss
+++ b/course-v2/assets/css/drawer.scss
@@ -6,3 +6,44 @@
     max-width: 75% !important;
   }
 }
+
+#desktop-course-drawer {
+  &.collapsing {
+    -webkit-transition: none;
+    transition: none;
+    display: none;
+  }
+}
+
+#desktop-course-drawer-button {
+  z-index: 990;
+  height: 35px;
+  width: 35px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  & .drawer-icon-img {
+    display: none;
+  }
+
+  &[aria-expanded="true"] {
+    .collapse-drawer-img {
+      display: block;
+    }
+
+    .expand-drawer-img {
+      display: none;
+    }
+  }
+
+  &[aria-expanded="false"] {
+    .collapse-drawer-img {
+      display: none;
+    }
+
+    .expand-drawer-img {
+      display: block;
+    }
+  }
+}

--- a/course-v2/assets/css/drawer.scss
+++ b/course-v2/assets/css/drawer.scss
@@ -25,6 +25,7 @@
 
   & .drawer-icon-img {
     display: none;
+    height: 12px;
   }
 
   &[aria-expanded="true"] {

--- a/course-v2/assets/js/mobile_course_drawers.ts
+++ b/course-v2/assets/js/mobile_course_drawers.ts
@@ -7,11 +7,13 @@ export const initCourseDrawersClosingViaSwiping = () => {
   enableSwiping(
     "mobile-course-nav",
     "mobile-course-nav-toggle",
+    "close-mobile-course-menu-button",
     SwipeDirection.Left
   )
   enableSwiping(
     "course-info-drawer",
     "mobile-course-info-toggle",
+    "close-mobile-course-info-button",
     SwipeDirection.Right
   )
 }
@@ -21,14 +23,19 @@ export const initCourseDrawersClosingViaSwiping = () => {
  *
  * @param {string} elementId element on which touch eventlistenter is added.
  * @param {string} buttonId This button will be clicked on swiping
+ * @param {string} closeButtonId This button will be clicked to close the drawer
  * @param {string} swipeDirection L= Swipe left, R= Swipe Right
  */
 const enableSwiping = (
   elementId: string,
   buttonId: string,
+  closeButtonId: string,
   swipeDirection: SwipeDirection
 ) => {
   const element = document.getElementById(elementId)
+  const button = document.getElementById(buttonId)
+  const closeButton = document.getElementById(closeButtonId)
+
   if (!element) throw Error(`Element having ID: ${elementId} does not exist`)
 
   let touchstartX = 0
@@ -51,5 +58,13 @@ const enableSwiping = (
 
       buttonElement.click()
     }
+  })
+
+  button?.addEventListener("click", () => {
+    closeButton?.focus()
+  })
+
+  closeButton?.addEventListener("click", () => {
+    button?.focus()
   })
 }

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -38,29 +38,15 @@
         <div class="col-sm-12 col-lg-10 course-home-grid">
           <div class="">
             <div class="card">
-              <div class="d-flex">
-                <div class="col-12 p-0" id="main-course-section">
+              <div class="d-flex justify-content-between">
+                <div class="p-0" id="main-course-section">
                   <div class="card-body">
-                    {{ if not $isCourseHomePage }}
-                      <button 
-                        type="button" 
-                        class="btn show-course-info large-and-above-only"
-                        id="show-desktop-course-drawer"
-                        aria-label="Show Course Info"
-                        >
-                        <img src="/static_shared/images/left_arrow.svg" alt=""/>
-                      </button>
-                    {{ end }} 
                     {{ block "main" . }}{{ end }}
                   </div>
                 </div>
-                {{/*  adding d-none class here as this section (with id="desktop-course-drawer") is being controlled (shown/hidden) 
-                via script written below hence hidden at the start to avoid a quick glitch  */}}
-                <div class="p-0 large-and-above-only d-none" id="desktop-course-drawer">
-                  {{ if not $isCourseHomePage }}
-                    {{ partialCached "desktop_course_info.html" . }}
-                  {{ end }}
-                </div>
+                {{ if not $isCourseHomePage }}
+                  {{ partialCached "desktop_course_info.html" . }}
+                {{ end }}
               </div>
             </div>
           </div>
@@ -84,60 +70,45 @@
     const COURSE_DRAWER_CLOSED = "closed"
     // IDs of elements
     const DESKTOP_COURSE_DRAWER_ID = "desktop-course-drawer"
-    const SHOW_COURSE_DRAWER_BTN_ID = "show-desktop-course-drawer"
-    const HIDE_COURSE_DRAWER_BTN_ID = "hide-desktop-course-drawer"
-    const MAIN_COURSE_SECTION_ID = "main-course-section"
+    const COURSE_DRAWER_BTN_ID = "desktop-course-drawer-button"
 
     try{
 
       /*
       * Checks if user has already selected any option/state for drawer then it sets that else keep it open by default
       */
-      function maintainDesktopCourseDrawerState() {
-        const isCourseDrawerOpen = getLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY)
-        if (isCourseDrawerOpen === null) {
+      function initializeDesktopCourseDrawerState() {
+        const state = getLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY)
+        if (state === null) {
           // No preference found so setting to "opened" as default and opening the drawer
           setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_OPENED)
           showOrHideDesktopCourseDrawer(COURSE_DRAWER_OPENED)
         } else {
-          showOrHideDesktopCourseDrawer(isCourseDrawerOpen)
+          showOrHideDesktopCourseDrawer(state)
         }
-      }
 
-      /*
-      * Adds and defines "click" event listeners for show-drawer and hide-drawer buttons, making this function act as a drawer toggler.
-      */
-      function toggleDesktopCourseDrawer() {
-        const showCourseDrawerBtn = document.getElementById(SHOW_COURSE_DRAWER_BTN_ID)
-        const hideCourseDrawerBtn = document.getElementById(HIDE_COURSE_DRAWER_BTN_ID)
-        showCourseDrawerBtn.addEventListener("click", () => {
-          setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_OPENED)
-          showOrHideDesktopCourseDrawer(COURSE_DRAWER_OPENED)
-        })
-        hideCourseDrawerBtn.addEventListener("click", () => {
-          setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_CLOSED)
-          showOrHideDesktopCourseDrawer(COURSE_DRAWER_CLOSED)
+        document.addEventListener("DOMContentLoaded", () => {
+          const drawer = $(`#${DESKTOP_COURSE_DRAWER_ID}`)
+
+          drawer.on("shown.bs.collapse", (event) => {
+            setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_OPENED)
+          })
+      
+          drawer.on("hidden.bs.collapse", (event) => {
+            setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_CLOSED)
+          })
         })
       }
-
-      // helper functions
 
       function showOrHideDesktopCourseDrawer(state) {
-        const desktopCourseDrawer = document.getElementById(DESKTOP_COURSE_DRAWER_ID)
-        const showCourseDrawerBtn = document.getElementById(SHOW_COURSE_DRAWER_BTN_ID)
-        const mainCourseSection = document.getElementById(MAIN_COURSE_SECTION_ID)
+        const drawer = document.getElementById(DESKTOP_COURSE_DRAWER_ID)
+        const button = document.getElementById(COURSE_DRAWER_BTN_ID)
         if (state === COURSE_DRAWER_OPENED) {
-          desktopCourseDrawer.classList.add("col-3")
-          desktopCourseDrawer.classList.remove("d-none")
-          showCourseDrawerBtn.classList.add("d-none")
-          mainCourseSection.classList.add("col-lg-9")
-          mainCourseSection.classList.remove("col-md-12")
+          drawer.classList.add("show")
+          button.setAttribute("aria-expanded", "true")
         } else {
-          desktopCourseDrawer.classList.remove("col-3")
-          desktopCourseDrawer.classList.add("d-none")
-          showCourseDrawerBtn.classList.remove("d-none")
-          mainCourseSection.classList.remove("col-lg-9")
-          mainCourseSection.classList.add("col-md-12")
+          drawer.classList.remove("show")
+          button.setAttribute("aria-expanded", "false")
         }
       }
 
@@ -168,8 +139,7 @@
         return setOrGetLocalStorageItem("get", key)
       }
 
-      maintainDesktopCourseDrawerState()
-      toggleDesktopCourseDrawer()
+      initializeDesktopCourseDrawerState();
     }
     catch(e){
       console.error("Something went wrong in maintaining/toggling course drawer state", e)

--- a/course-v2/layouts/partials/course_info.html
+++ b/course-v2/layouts/partials/course_info.html
@@ -3,26 +3,9 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
 
 <div class="course-info">
   <div class="course-detail-title {{ if $inPanel }}bg-light-gray{{ end }}">
-    <div class="d-flex">
-      <h2 class="font-black {{ if $inPanel }}py-1 pl-3 mt-2 m-0{{ end }}">
-        Course Info
-      </h2>
-      {{ if $inPanel }}
-      <button
-        type="button"
-        class="btn close-course-info large-and-above-only"
-        id="{{ if $isDesktopCourseDrawer }}hide-desktop-course-drawer{{ end }}"
-        aria-label="Close Course Info"
-        >
-        <img
-          class="toggle navbar-toggle offcanvas-toggle"
-          src="/static_shared/images/close_small.svg"
-          alt=""
-          width="12px"
-        />
-      </button>
-      {{ end }}
-    </div>
+    <h2 class="font-black {{ if $inPanel }}py-1 pl-3 m-0{{ end }}">
+      Course Info
+    </h2>
   </div>
   <div class="position-relative {{ if $inPanel }}px-3 mt-4{{ end }}">
     <div class="row">

--- a/course-v2/layouts/partials/course_info.html
+++ b/course-v2/layouts/partials/course_info.html
@@ -7,7 +7,7 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
       Course Info
     </h2>
   </div>
-  <div class="position-relative {{ if $inPanel }}px-3 mt-4{{ end }}">
+  <div class="{{ if $inPanel }}px-3 mt-4{{ end }}">
     <div class="row">
       <div class="col-12 {{ if not $inPanel }}col-sm-6{{ end }}">
         {{ with $courseData.instructors.content }}

--- a/course-v2/layouts/partials/desktop_course_info.html
+++ b/course-v2/layouts/partials/desktop_course_info.html
@@ -1,10 +1,30 @@
-<div class="border-left">
-  <div>
-    {{ partial "course_info.html" (dict "context" . "inPanel" true "isDesktopCourseDrawer" true) }}
-    <div class="px-3">
-      {{ partial "topics.html" (dict "context" . "inPanel" true "device" "desktop") }}
-      {{ partial "learning_resource_types.html" (dict "context" . "inPanel" true) }}
-      {{ partial "download_course_link_button.html" (dict "context" . "inPanel" true) }}
-    </div>
+<button 
+  type="button" 
+  class="btn course-info-button large-and-above-only"
+  id="desktop-course-drawer-button"
+  data-target="#desktop-course-drawer"
+  data-toggle="collapse"
+  aria-label="Course Info"
+  aria-controls="desktop-course-drawer"
+  aria-expanded="false"
+>
+  <img
+    class="expand-drawer-img drawer-icon-img"
+    src="/static_shared/images/left_arrow.svg"
+    alt=""
+  />
+  <img
+    class="collapse-drawer-img drawer-icon-img"
+    src="/static_shared/images/close_small.svg"
+    alt=""
+  />
+</button>
+
+<div class="collapse border-left p-0 large-and-above-only col-3" id="desktop-course-drawer">
+  {{ partial "course_info.html" (dict "context" . "inPanel" true "isDesktopCourseDrawer" true) }}
+  <div class="px-3">
+    {{ partial "topics.html" (dict "context" . "inPanel" true "device" "desktop") }}
+    {{ partial "learning_resource_types.html" (dict "context" . "inPanel" true) }}
+    {{ partial "download_course_link_button.html" (dict "context" . "inPanel" true) }}
   </div>
 </div>

--- a/course-v2/layouts/partials/mobile_course_info.html
+++ b/course-v2/layouts/partials/mobile_course_info.html
@@ -8,6 +8,7 @@
       type="button"
       aria-label="Close Course Info"
       onclick="$('#mobile-course-info-toggle').click();"
+      id="close-mobile-course-info-button"
       >
       <img
         class=""

--- a/course-v2/layouts/partials/mobile_course_nav.html
+++ b/course-v2/layouts/partials/mobile_course_nav.html
@@ -8,6 +8,7 @@
       type="button"
       aria-label="Close Course Menu"
       onclick="$('#mobile-course-nav-toggle').click();"
+      id="close-mobile-course-menu-button"
       >
       <img
         src="/static_shared/images/close_small.svg"

--- a/tests-e2e/ocw-ci-test-course/course-info.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/course-info.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test"
+import { CoursePage } from "../util"
+
+test("Course info section can be toggled", async ({ page }) => {
+  const course = new CoursePage(page, "course")
+  await course.goto("/pages/section-1")
+
+  const heading = await page.getByRole("heading", { name: "Course Info" })
+  const button = await page.getByRole("button", { name: "Course Info" })
+
+  await expect(heading).toBeVisible()
+  await button.click()
+  await expect(heading).toBeHidden()
+  await button.click()
+  await expect(heading).toBeVisible()
+})


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/1974

# Description (What does it do?)

This PR:

- reactors desktop view course info panel.
  - The two buttons (open and close) have been merged into one. Allowing the focus to persist.
- programmatically gives focus to side drawers for mobile view.

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
- [x] Mobile width screenshots


https://github.com/mitodl/ocw-hugo-themes/assets/71316217/5b31431e-ef2e-4517-9b8c-170c40ff7639

https://github.com/mitodl/ocw-hugo-themes/assets/71316217/462fa244-e496-4a63-aa7c-e001e449716a


# How can this be tested?

## Steps

1. Grab any course content from [ocw-content-rc](https://github.mit.edu/ocw-content-rc) and place it inside your local content directory.
2. Navigate to your local setup of ocw-hugo-themes and check the branch `hussaintaj/1974-course-info`.
3. Run
    ```
    yarn start course <course-dir-name>
    ```
4. Visit any page other than the homepage.
5. In desktop view:
    * Click the course info toggle button to hide and show the course info panel. Please take a look at the video recording for reference.
    * **Expected Behavior**: When you click the button, the focus remains on the button. You can use the keyboard to toggle the menu as well.
6. In mobile view:
    * Click the "more info" link to open the side drawer. Please take a look at the video recording for reference.
    * **Expected Behavior**: When you click the link, the focus shifts to the close button in the side drawer. You can use the keyboard to toggle the drawer as well.

