### PR TITLE
fix: main section layout

### DIFF
--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -39,7 +39,7 @@
           <div class="">
             <div class="card">
               <div class="d-flex justify-content-between">
-                <div class="p-0" id="main-course-section">
+                <div class="p-0 col-9" id="main-course-section">
                   <div class="card-body">
                     {{ block "main" . }}{{ end }}
                   </div>
@@ -71,6 +71,7 @@
     // IDs of elements
     const DESKTOP_COURSE_DRAWER_ID = "desktop-course-drawer"
     const COURSE_DRAWER_BTN_ID = "desktop-course-drawer-button"
+    const MAIN_COURSE_SECTION_ID = "main-course-section"
 
     try{
 
@@ -89,12 +90,18 @@
 
         document.addEventListener("DOMContentLoaded", () => {
           const drawer = $(`#${DESKTOP_COURSE_DRAWER_ID}`)
+          const mainSection = $(`#${MAIN_COURSE_SECTION_ID}`)
+          
 
           drawer.on("shown.bs.collapse", (event) => {
+            mainSection.addClass("col-9")
+            mainSection.removeClass("col-12")
             setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_OPENED)
           })
       
           drawer.on("hidden.bs.collapse", (event) => {
+            mainSection.addClass("col-12")
+            mainSection.removeClass("col-9")
             setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_CLOSED)
           })
         })
@@ -103,12 +110,16 @@
       function showOrHideDesktopCourseDrawer(state) {
         const drawer = document.getElementById(DESKTOP_COURSE_DRAWER_ID)
         const button = document.getElementById(COURSE_DRAWER_BTN_ID)
+        const mainSection = document.getElementById(MAIN_COURSE_SECTION_ID)
+
         if (state === COURSE_DRAWER_OPENED) {
           drawer.classList.add("show")
           button.setAttribute("aria-expanded", "true")
         } else {
           drawer.classList.remove("show")
           button.setAttribute("aria-expanded", "false")
+          mainSection.classList.remove("col-9")
+          mainSection.classList.add("col-12")
         }
       }
 

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -39,7 +39,7 @@
           <div class="">
             <div class="card">
               <div class="d-flex justify-content-between">
-                <div class="p-0 col-9" id="main-course-section">
+                <div class="p-0 col-lg-9" id="main-course-section">
                   <div class="card-body">
                     {{ block "main" . }}{{ end }}
                   </div>
@@ -94,14 +94,14 @@
           
 
           drawer.on("shown.bs.collapse", (event) => {
-            mainSection.addClass("col-9")
+            mainSection.addClass("col-lg-9")
             mainSection.removeClass("col-12")
             setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_OPENED)
           })
       
           drawer.on("hidden.bs.collapse", (event) => {
             mainSection.addClass("col-12")
-            mainSection.removeClass("col-9")
+            mainSection.removeClass("col-lg-9")
             setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_CLOSED)
           })
         })
@@ -118,7 +118,7 @@
         } else {
           drawer.classList.remove("show")
           button.setAttribute("aria-expanded", "false")
-          mainSection.classList.remove("col-9")
+          mainSection.classList.remove("col-lg-9")
           mainSection.classList.add("col-12")
         }
       }


### PR DESCRIPTION
# What are the relevant tickets?

Fixes a side effect of https://github.com/mitodl/ocw-hugo-themes/pull/1228

# Description (What does it do?)
Fixes a side effect of https://github.com/mitodl/ocw-hugo-themes/pull/1228

Some elements in the main section do not behave well without the main section having a defined width. See screenshots for examples.

# Screenshots (if appropriate):

Before
<img width="1621" alt="Screenshot 2023-08-25 at 3 56 13 PM" src="https://github.com/mitodl/ocw-hugo-themes/assets/71316217/c8d7fd4d-909b-4236-b371-8460a9f9c3d3">

After

<img width="1632" alt="Screenshot 2023-08-25 at 3 56 29 PM" src="https://github.com/mitodl/ocw-hugo-themes/assets/71316217/1c094e4b-a8f9-4643-bede-114ea6c3008c">


# How can this be tested?

1. Grab any course content from [ocw-content-rc](https://github.mit.edu/ocw-content-rc) and place it inside your local content directory.
2. Navigate to your local setup of ocw-hugo-themes and check the branch `hussaintaj/fix-main-section-layout`.
3. Run
    ```
    yarn start course <course-dir-name>
    ```
4. Visit any page other than the homepage.
5. Toggle course info and see if different pages behave correctly i.e. video page, video gallery pages etc.