### PR TITLE
fix: accessibility of video tabs

### DIFF
--- a/base-theme/assets/css/video.scss
+++ b/base-theme/assets/css/video.scss
@@ -1,5 +1,5 @@
 .video-tab-header {
-  padding: 5px 15px 5px;
+  padding: 5px 15px;
   border-top: 1px solid #3d3c3d;
   background-color: black;
   color: white;
@@ -14,6 +14,8 @@
     left: 2px;
   }
   .tab-title-section {
+    width: 100%;
+
     > * {
       padding-right: 10px;
       background: none;
@@ -59,7 +61,12 @@
   }
 }
 
-.video-tab-toggle-section[aria-expanded="true"] {
+.tab-toggle-button {
+  text-align: left;
+  width: 100%;
+}
+
+.tab-toggle-button[aria-expanded="true"] {
   i.toggle:after {
     content: "keyboard_arrow_down";
   }
@@ -80,7 +87,7 @@
   img.video-download-icon {
     height: 22px;
     position: relative;
-    left: 9px;
+    left: 5.25px;
     vertical-align: baseline;
   }
 }

--- a/base-theme/assets/css/video.scss
+++ b/base-theme/assets/css/video.scss
@@ -14,7 +14,8 @@
     left: 2px;
   }
   .tab-title-section {
-    width: 100%;
+    display: flex;
+    flex: 1;
 
     > * {
       padding-right: 10px;
@@ -62,8 +63,8 @@
 }
 
 .tab-toggle-button {
+  flex: auto;
   text-align: left;
-  width: 100%;
 }
 
 .tab-toggle-button[aria-expanded="true"] {

--- a/base-theme/assets/css/video.scss
+++ b/base-theme/assets/css/video.scss
@@ -88,7 +88,7 @@
   img.video-download-icon {
     height: 22px;
     position: relative;
-    left: 5.25px;
+    left: 9px;
     vertical-align: baseline;
   }
 }

--- a/base-theme/assets/css/video.scss
+++ b/base-theme/assets/css/video.scss
@@ -1,5 +1,4 @@
 .video-tab-header {
-  padding: 5px 15px;
   border-top: 1px solid #3d3c3d;
   background-color: black;
   color: white;
@@ -23,6 +22,7 @@
       border: none;
     }
     a {
+      padding: 5px 15px;
       text-decoration: none;
       display: inline-block;
     }
@@ -65,6 +65,7 @@
 .tab-toggle-button {
   flex: auto;
   text-align: left;
+  padding: 5px 0px 5px 15px;
 }
 
 .tab-toggle-button[aria-expanded="true"] {
@@ -79,6 +80,7 @@
   background: none;
   border: none;
   color: $white;
+  padding: 5px 15px 5px 0px;
   i.caret-down:after {
     content: "\e5c5";
   }

--- a/base-theme/assets/css/video.scss
+++ b/base-theme/assets/css/video.scss
@@ -22,7 +22,7 @@
       border: none;
     }
     a {
-      padding: 5px 15px;
+      padding: 5px 10px 5px 15px;
       text-decoration: none;
       display: inline-block;
     }

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -2,15 +2,8 @@
 {{ $videoHasTranscript := eq .tabTitle "Transcript" }}
 <div
   class="video-tab-toggle-section pointer"
-  data-target=".{{- .tabClass -}}"
-  data-toggle="collapse"
-  aria-controls="{{- .tabClass -}}"
-  {{ if (not $isEmbedVideo) }}
-    aria-label="{{ .tabTitle }}"
-    role="tab"
-  {{ end }}
   >
-  <div class="video-tab-header">
+  <div class="video-tab-header d-flex justify-content-between">
     {{ if .tabTitle }}
       <span class="tab-title-section">
         {{ if and .resourceUrl $isEmbedVideo }}
@@ -18,7 +11,7 @@
           {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </a>
         {{ else }}
-          <button aria-label="Open {{ .tabTitle }}">
+          <button class="tab-toggle-button" aria-label="{{ .tabTitle }}" role="tab" aria-expanded="false" data-toggle="collapse" aria-controls="{{- .tabClass -}}" data-target=".{{- .tabClass -}}">
             {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </button>
         {{ end }}
@@ -28,7 +21,7 @@
       Otherwise show download button in a standalone tab bar  */}}
     {{ if or ($videoHasTranscript) ($isEmbedVideo) (eq .tabTitle "") }}
       <div class="float-right">
-        <button class="video-download-icons" aria-label="Show Downloads" aria-expanded="false">
+        <button class="video-download-icons d-flex align-items-baseline" aria-label="Show Downloads" aria-expanded="false">
           <img class="video-download-icon" src="/static_shared/images/videojs_download.svg" aria-hidden="true"/>
           <i class="material-icons caret-down" aria-hidden="true"></i>
         </button>

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -13,11 +13,11 @@
     {{ if .tabTitle }}
       <span class="tab-title-section">
         {{ if and .resourceUrl $isEmbedVideo }}
-          <a href="{{ .resourceUrl }}">
+          <a href="{{ .resourceUrl }}" aria-hidden="true">
           {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </a>
         {{ else }}
-          <button>
+          <button aria-hidden="true">
             {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </button>
         {{ end }}
@@ -28,8 +28,8 @@
     {{ if or ($videoHasTranscript) ($isEmbedVideo) (eq .tabTitle "") }}
       <div class="float-right">
         <button class="video-download-icons" aria-label="Download Video and Transcript" aria-expanded="false">
-          <img class="video-download-icon" src="/static_shared/images/videojs_download.svg"/>
-          <i class="material-icons caret-down"></i>
+          <img class="video-download-icon" src="/static_shared/images/videojs_download.svg" aria-hidden="true"/>
+          <i class="material-icons caret-down" aria-hidden="true"></i>
         </button>
       </div>
     {{ end }}
@@ -49,7 +49,7 @@
     </ul>
   </div>
 </div>
-<div class="video-tab container collapse pr-0 {{ .tabClass }}" role="tabpanel" aria-label="test">
+<div class="video-tab container collapse pr-0 {{ .tabClass }}" role="tabpanel">
   <div class="video-tab-content-section">
     {{ .context.RenderString .tabContent }}
   </div>

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -5,8 +5,9 @@
   data-target=".{{- .tabClass -}}"
   data-toggle="collapse"
   aria-controls="{{- .tabClass -}}"
-  aria-expanded=""
+  aria-expanded="false"
   role="tab"
+  aria-label="{{ .tabTitle }}"
   >
   <div class="video-tab-header">
     {{ if .tabTitle }}
@@ -26,7 +27,7 @@
       Otherwise show download button in a standalone tab bar  */}}
     {{ if or ($videoHasTranscript) ($isEmbedVideo) (eq .tabTitle "") }}
       <div class="float-right">
-        <button class="video-download-icons" aria-label="Download Video and Transcript">
+        <button class="video-download-icons" aria-label="Download Video and Transcript" aria-expanded="false">
           <img class="video-download-icon" src="/static_shared/images/videojs_download.svg"/>
           <i class="material-icons caret-down"></i>
         </button>
@@ -48,7 +49,7 @@
     </ul>
   </div>
 </div>
-<div class="video-tab container collapse pr-0 {{ .tabClass }}" role="tabpanel">
+<div class="video-tab container collapse pr-0 {{ .tabClass }}" role="tabpanel" aria-label="test">
   <div class="video-tab-content-section">
     {{ .context.RenderString .tabContent }}
   </div>

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -1,7 +1,7 @@
 {{ $isEmbedVideo := eq .tabTitle "View video page" }}
 {{ $videoHasTranscript := eq .tabTitle "Transcript" }}
 <div class="video-tab-toggle-section pointer">
-  <div class="video-tab-header d-flex justify-content-end">
+  <div class="video-tab-header d-flex">
     {{ if .tabTitle }}
       <span class="tab-title-section">
         {{ if and .resourceUrl $isEmbedVideo }}
@@ -18,7 +18,7 @@
     {{/*  If we have transcript or the video is embed video, show download button on those tabs.
       Otherwise show download button in a standalone tab bar  */}}
     {{ if or ($videoHasTranscript) ($isEmbedVideo) (eq .tabTitle "") }}
-      <div>
+      <div class="ml-auto">
         <button class="video-download-icons" aria-label="Show Downloads" aria-expanded="false">
           <img class="video-download-icon" src="/static_shared/images/videojs_download.svg" aria-hidden="true"/>
           <i class="material-icons caret-down" aria-hidden="true"></i>

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -7,17 +7,19 @@
   aria-controls="{{- .tabClass -}}"
   aria-expanded="false"
   role="tab"
-  aria-label="{{ .tabTitle }}"
+  {{ if ne .tabTitle "View video page" }}
+    aria-label="{{ .tabTitle }}"
+  {{ end }}
   >
   <div class="video-tab-header">
     {{ if .tabTitle }}
       <span class="tab-title-section">
         {{ if and .resourceUrl $isEmbedVideo }}
-          <a href="{{ .resourceUrl }}" aria-hidden="true">
+          <a href="{{ .resourceUrl }}" aria-label="{{.tabTitle}}">
           {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </a>
         {{ else }}
-          <button aria-hidden="true">
+          <button aria-label="Open {{.tabTitle}} tab">
             {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </button>
         {{ end }}
@@ -49,7 +51,7 @@
     </ul>
   </div>
 </div>
-<div class="video-tab container collapse pr-0 {{ .tabClass }}" role="tabpanel">
+<div class="video-tab container collapse pr-0 {{ .tabClass }}" role="tabpanel" aria-labelledby="tab-1">
   <div class="video-tab-content-section">
     {{ .context.RenderString .tabContent }}
   </div>

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -1,8 +1,6 @@
 {{ $isEmbedVideo := eq .tabTitle "View video page" }}
 {{ $videoHasTranscript := eq .tabTitle "Transcript" }}
-<div
-  class="video-tab-toggle-section pointer"
-  >
+<div class="video-tab-toggle-section pointer">
   <div class="video-tab-header d-flex">
     {{ if .tabTitle }}
       <span class="tab-title-section">

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -1,7 +1,7 @@
 {{ $isEmbedVideo := eq .tabTitle "View video page" }}
 {{ $videoHasTranscript := eq .tabTitle "Transcript" }}
 <div class="video-tab-toggle-section pointer">
-  <div class="video-tab-header d-flex">
+  <div class="video-tab-header d-flex justify-content-end">
     {{ if .tabTitle }}
       <span class="tab-title-section">
         {{ if and .resourceUrl $isEmbedVideo }}

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -5,21 +5,20 @@
   data-target=".{{- .tabClass -}}"
   data-toggle="collapse"
   aria-controls="{{- .tabClass -}}"
-  aria-expanded="false"
-  role="tab"
-  {{ if ne .tabTitle "View video page" }}
+  {{ if (not $isEmbedVideo) }}
     aria-label="{{ .tabTitle }}"
+    role="tab"
   {{ end }}
   >
   <div class="video-tab-header">
     {{ if .tabTitle }}
       <span class="tab-title-section">
         {{ if and .resourceUrl $isEmbedVideo }}
-          <a href="{{ .resourceUrl }}" aria-label="{{.tabTitle}}">
+          <a href="{{ .resourceUrl }}" aria-label="{{ .tabTitle }}">
           {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </a>
         {{ else }}
-          <button aria-label="Open {{.tabTitle}} tab">
+          <button aria-label="Open {{ .tabTitle }}">
             {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </button>
         {{ end }}

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -13,11 +13,11 @@
     {{ if .tabTitle }}
       <span class="tab-title-section">
         {{ if and .resourceUrl $isEmbedVideo }}
-          <a href="{{ .resourceUrl }}" aria-label="{{ .tabTitle }}">
+          <a href="{{ .resourceUrl }}">
           {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </a>
         {{ else }}
-          <button aria-label="{{ .tabTitle }}">
+          <button>
             {{ partial "video_tab_title.html" (dict "tabTitle" .tabTitle) }}
           </button>
         {{ end }}

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -20,8 +20,8 @@
     {{/*  If we have transcript or the video is embed video, show download button on those tabs.
       Otherwise show download button in a standalone tab bar  */}}
     {{ if or ($videoHasTranscript) ($isEmbedVideo) (eq .tabTitle "") }}
-      <div class="float-right">
-        <button class="video-download-icons d-flex align-items-baseline" aria-label="Show Downloads" aria-expanded="false">
+      <div>
+        <button class="video-download-icons" aria-label="Show Downloads" aria-expanded="false">
           <img class="video-download-icon" src="/static_shared/images/videojs_download.svg" aria-hidden="true"/>
           <i class="material-icons caret-down" aria-hidden="true"></i>
         </button>

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -3,7 +3,7 @@
 <div
   class="video-tab-toggle-section pointer"
   >
-  <div class="video-tab-header d-flex justify-content-between">
+  <div class="video-tab-header d-flex">
     {{ if .tabTitle }}
       <span class="tab-title-section">
         {{ if and .resourceUrl $isEmbedVideo }}

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -28,7 +28,7 @@
       Otherwise show download button in a standalone tab bar  */}}
     {{ if or ($videoHasTranscript) ($isEmbedVideo) (eq .tabTitle "") }}
       <div class="float-right">
-        <button class="video-download-icons" aria-label="Download Video and Transcript" aria-expanded="false">
+        <button class="video-download-icons" aria-label="Show Downloads" aria-expanded="false">
           <img class="video-download-icon" src="/static_shared/images/videojs_download.svg" aria-hidden="true"/>
           <i class="material-icons caret-down" aria-hidden="true"></i>
         </button>
@@ -50,7 +50,7 @@
     </ul>
   </div>
 </div>
-<div class="video-tab container collapse pr-0 {{ .tabClass }}" role="tabpanel" aria-labelledby="tab-1">
+<div class="video-tab container collapse pr-0 {{ .tabClass }}" role="tabpanel">
   <div class="video-tab-content-section">
     {{ .context.RenderString .tabContent }}
   </div>

--- a/base-theme/layouts/partials/video_tab_title.html
+++ b/base-theme/layouts/partials/video_tab_title.html
@@ -1,4 +1,4 @@
-<i class="material-icons toggle md-18"></i>
+<i class="material-icons toggle md-18" aria-hidden="true"></i>
 <span class="tab-title">
   {{- .tabTitle -}}
 </span>

--- a/course-v2/assets/js/video_download_popup.ts
+++ b/course-v2/assets/js/video_download_popup.ts
@@ -2,6 +2,7 @@ export const initVideoDownloadPopup = () => {
   const downloadIcons = document.querySelectorAll(".video-download-icons")
   const popups = document.querySelectorAll(".video-tab-download-popup")
   let activePopup: HTMLElement | null = null
+  let activePopupDownloadIconIndex = -1
 
   downloadIcons.forEach((downloadIcon, index) => {
     const popup = popups[index] as HTMLElement
@@ -9,22 +10,37 @@ export const initVideoDownloadPopup = () => {
       event.stopPropagation()
       if (popup === activePopup) {
         // Clicked on the same download button, toggle the popup
+        if (downloadIcon.getAttribute("aria-expanded") === "true") {
+          downloadIcon.setAttribute("aria-expanded", "false")
+        } else {
+          downloadIcon.setAttribute("aria-expanded", "true")
+        }
         popup.classList.toggle("hidden")
         activePopup = null
       } else {
         // Clicked on a different download button, close previous popup (if any) and toggle open new popup
         if (activePopup) {
+          downloadIcons[activePopupDownloadIconIndex].setAttribute(
+            "aria-expanded",
+            "false"
+          )
           activePopup.classList.add("hidden")
         }
         // Show the clicked popup
+        downloadIcon.setAttribute("aria-expanded", "true")
         popup.classList.remove("hidden")
         activePopup = popup
+        activePopupDownloadIconIndex = index
       }
     })
   })
   // Click anywhere on page (other than download buttons), and the active popup will close
   document.addEventListener("click", () => {
     if (activePopup) {
+      downloadIcons[activePopupDownloadIconIndex].setAttribute(
+        "aria-expanded",
+        "false"
+      )
       activePopup.classList.add("hidden")
       activePopup = null
     }

--- a/course-v2/assets/js/video_download_popup.ts
+++ b/course-v2/assets/js/video_download_popup.ts
@@ -10,11 +10,7 @@ export const initVideoDownloadPopup = () => {
       event.stopPropagation()
       if (popup === activePopup) {
         // Clicked on the same download button, toggle the popup
-        if (downloadIcon.getAttribute("aria-expanded") === "true") {
-          downloadIcon.setAttribute("aria-expanded", "false")
-        } else {
-          downloadIcon.setAttribute("aria-expanded", "true")
-        }
+        downloadIcon.setAttribute("aria-expanded", "false")
         popup.classList.toggle("hidden")
         activePopup = null
       } else {

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -58,8 +58,9 @@ test("Embed video redirects to video page using keyboard navigation", async ({
 }) => {
   const coursePage = new CoursePage(page, "course")
   await coursePage.goto("pages/video-series-overview/")
-  const videoRedirectLink = page
-    .getByRole("tab", {
+  const videoPage = new VideoElement(page)
+  const videoRedirectLink = videoPage
+    .tab({
       name: "View video page"
     })
     .locator("a")
@@ -114,8 +115,8 @@ test("Expand and collapse video tabs using keyboard navigation", async ({
   }
 
   for (const [tabClass, tabTitle] of Object.entries(tabClassToTitle)) {
-    const tabButton = page
-      .getByRole("tab", {
+    const tabButton = videoPage
+      .tab({
         name:  `${tabTitle}`,
         exact: true
       })

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -84,7 +84,8 @@ test("Video tabs content (links) are keyoard navigable", async ({ page }) => {
   for (const tab of tabs) {
     const coursePage = new CoursePage(page, "course")
     await coursePage.goto("resources/ocw_test_course_mit8_01f16_l01v01_360p")
-    const tabButton = page.getByRole("tab", {
+    const videoPage = new VideoElement(page)
+    const tabButton = videoPage.tab({
       name: `${tab.title}`
     })
     await tabButton.focus()
@@ -109,7 +110,7 @@ test("Expand and collapse video tabs using keyboard navigation", async ({
   }
 
   for (const [tabClass, tabTitle] of Object.entries(tabClassToTitle)) {
-    const tabButton = page.getByRole("tab", {
+    const tabButton = videoPage.tab({
       name:  `${tabTitle}`,
       exact: true
     })

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -58,13 +58,9 @@ test("Embed video redirects to video page using keyboard navigation", async ({
 }) => {
   const coursePage = new CoursePage(page, "course")
   await coursePage.goto("pages/video-series-overview/")
-  const videoPage = new VideoElement(page)
-  const videoRedirectLink = videoPage
-    .tab({
-      name: "View video page"
-    })
-    .locator("a")
-    .first()
+  const videoRedirectLink = page.getByRole("link", {
+    name: "View video page"
+  })
   await videoRedirectLink.focus()
   page.keyboard.press("Enter")
   await coursePage.page.waitForURL(
@@ -88,11 +84,9 @@ test("Video tabs content (links) are keyoard navigable", async ({ page }) => {
   for (const tab of tabs) {
     const coursePage = new CoursePage(page, "course")
     await coursePage.goto("resources/ocw_test_course_mit8_01f16_l01v01_360p")
-    const tabButton = page
-      .getByRole("tab", {
-        name: `${tab.title}`
-      })
-      .locator("button")
+    const tabButton = page.getByRole("button", {
+      name: `Open ${tab.title}`
+    })
     await tabButton.focus()
     page.keyboard.press("Enter")
     page.keyboard.press("Tab")
@@ -115,13 +109,10 @@ test("Expand and collapse video tabs using keyboard navigation", async ({
   }
 
   for (const [tabClass, tabTitle] of Object.entries(tabClassToTitle)) {
-    const tabButton = videoPage
-      .tab({
-        name:  `${tabTitle}`,
-        exact: true
-      })
-      .locator("button")
-      .first()
+    const tabButton = page.getByRole("button", {
+      name:  `Open ${tabTitle}`,
+      exact: true
+    })
     await expect(tabButton).toBeVisible()
     await tabButton.focus()
 

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -58,9 +58,12 @@ test("Embed video redirects to video page using keyboard navigation", async ({
 }) => {
   const coursePage = new CoursePage(page, "course")
   await coursePage.goto("pages/video-series-overview/")
-  const videoRedirectLink = page.getByRole("link", {
-    name: "View video page"
-  })
+  const videoRedirectLink = page
+    .getByRole("tab", {
+      name: "View video page"
+    })
+    .locator("a")
+    .first()
   await videoRedirectLink.focus()
   page.keyboard.press("Enter")
   await coursePage.page.waitForURL(
@@ -84,9 +87,11 @@ test("Video tabs content (links) are keyoard navigable", async ({ page }) => {
   for (const tab of tabs) {
     const coursePage = new CoursePage(page, "course")
     await coursePage.goto("resources/ocw_test_course_mit8_01f16_l01v01_360p")
-    const tabButton = page.getByRole("button", {
-      name: `${tab.title}`
-    })
+    const tabButton = page
+      .getByRole("tab", {
+        name: `${tab.title}`
+      })
+      .locator("button")
     await tabButton.focus()
     page.keyboard.press("Enter")
     page.keyboard.press("Tab")
@@ -109,10 +114,13 @@ test("Expand and collapse video tabs using keyboard navigation", async ({
   }
 
   for (const [tabClass, tabTitle] of Object.entries(tabClassToTitle)) {
-    const tabButton = page.getByRole("button", {
-      name:  `${tabTitle}`,
-      exact: true
-    })
+    const tabButton = page
+      .getByRole("tab", {
+        name:  `${tabTitle}`,
+        exact: true
+      })
+      .locator("button")
+      .first()
     await expect(tabButton).toBeVisible()
     await tabButton.focus()
 

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -34,7 +34,7 @@ test("Verify that the 'Download video' and 'Download transcript' links are keybo
     "https://live-qa.ocw.mit.edu/courses/8-01sc-classical-mechanics-fall-2016/33f61131009a6cd12d9a4c0e42eb7f44_ErlP_SBcA1s.pdf"
   ]
   const downloadButton = page.getByRole("button", {
-    name: `Download Video and Transcript`
+    name: `Show Downloads`
   })
   await downloadButton.focus()
   await page.keyboard.press("Enter")
@@ -84,8 +84,8 @@ test("Video tabs content (links) are keyoard navigable", async ({ page }) => {
   for (const tab of tabs) {
     const coursePage = new CoursePage(page, "course")
     await coursePage.goto("resources/ocw_test_course_mit8_01f16_l01v01_360p")
-    const tabButton = page.getByRole("button", {
-      name: `Open ${tab.title}`
+    const tabButton = page.getByRole("tab", {
+      name: `${tab.title}`
     })
     await tabButton.focus()
     page.keyboard.press("Enter")
@@ -109,8 +109,8 @@ test("Expand and collapse video tabs using keyboard navigation", async ({
   }
 
   for (const [tabClass, tabTitle] of Object.entries(tabClassToTitle)) {
-    const tabButton = page.getByRole("button", {
-      name:  `Open ${tabTitle}`,
+    const tabButton = page.getByRole("tab", {
+      name:  `${tabTitle}`,
       exact: true
     })
     await expect(tabButton).toBeVisible()

--- a/tests-e2e/util/VideoElement.ts
+++ b/tests-e2e/util/VideoElement.ts
@@ -31,7 +31,7 @@ export class VideoElement {
 
   downloadButton(): Locator {
     return this.container.getByRole("button", {
-      name: `Download Video and Transcript`
+      name: `Show Downloads`
     })
   }
 


### PR DESCRIPTION
# What are the relevant tickets?
Closes #1219 

# Description (What does it do?)
Fixes accessibility related issues of video tabs by restructuring the code. This includes the toggleable video tabs and the download button.

# How can this be tested?
You may use a screenreader for testing or check the accessibility using inspect element. Make sure the screen reader would correctly read the text now (and no redundancy/repeats).
In addition to this, we also want to make sure that the UI does not break because there were styling changes. (Check for different screen sizes)

Here are some courses names:
1. 3.091-fall-2018 (Example of multiple video instances in a single page -- Goodie Bag Tutorials from left menu). Contains embed videos + click on 'View video page' for regular video pages.
2. 18.06sc-fall-2011 (Another example of embed videos -- Instructor Insights from left menu)
3. 16.885j-fall-2005 (Example of video + nanogallery in same page -- Related Resources from left menu)

Make sure to check for offline theme as well. Steps same as mentioned here for offline course theme only:
https://github.com/mitodl/ocw-hugo-themes/pull/1227

Checkout to this branch, `yarn start course <name>` and then do the above mentioned instructions.


To run playwright tests:
`yarn test:e2e video-tabs.spec.ts `