### PR TITLE
Update quiz partial

### DIFF
--- a/course-v2/layouts/partials/quiz_multiple_choice_choice.html
+++ b/course-v2/layouts/partials/quiz_multiple_choice_choice.html
@@ -1,5 +1,5 @@
 <div class="multiple-choice-div">
-	<input type='radio' name={{ .questionId }} class="multiple-choice-radio"}>
+	<input type='radio' name={{ .questionId }} class="multiple-choice-radio">
 	<span> {{.choiceText}} </span>
 	{{ if eq .correct "true" }}
 		<span class="toggle material-icons correctness-icon correctness-icon-correct">


### PR DESCRIPTION
# What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/757.

# Description (What does it do?)
There are no functional changes, but there was an empty closing brace in the partial that could potentially cause problems depending on the surrounding context.

# How can this be tested?

There are two ways of testing this, via OCW Studio (to test the entire publishing process) or via just this repository. 

**Testing using OCW Studio**

To test via OCW Studio, first set the environment variable `OCW_HUGO_THEMES_BRANCH=pt/fix_quiz_partial`. Then, upsert the relevant theme assets pipeline by running `docker-compose exec web ./manage.py upsert_theme_assets_pipeline --themes-branch pt/fix_quiz_partial`. Trigger a theme assets build with the Concourse UI. Once the build completes, upsert the pipeline for some course using `docker-compose exec web ./manage.py backpopulate_pipelines --filter <some_course_id>`. Create a page for the course using the Studio UI. Now, go into Django admin, and edit the markdown for that page to include a quiz. An example is below:

`
{{< quiz_multiple_choice questionId="question_id" >}} What is a quiz question? {{< quiz_choices >}} {{< quiz_choice isCorrect="false" >}} not the correct answer {{< /quiz_choice >}} {{< quiz_choice isCorrect="false" >}} not the correct answer{{< /quiz_choice >}} {{< quiz_choice isCorrect="true" >}} the correct answer {{< /quiz_choice >}} {{< /quiz_choices >}} {{< quiz_solution />}} {{< /quiz_multiple_choice >}}
`

Save the object, and publish the course. Verify that everything looks and works as expected.

**Testing using OCW Studio**

Run `yarn start course <course_id>`, and modify the markdown for a course page to include a quiz, such as the example given above. Verify that everything looks and works as expected.
