### PR TITLE
feat: add aria attributes to www search page

### DIFF
--- a/www/assets/css/search-filter.scss
+++ b/www/assets/css/search-filter.scss
@@ -2,15 +2,18 @@
   .input-wrapper {
     position: relative;
 
-    i.material-icons {
+    i.input-postfix-icon,
+    button.input-postfix-button {
       position: absolute;
       right: 5px;
       top: 8px;
       color: $medium-gray;
     }
 
-    i.clear-icon {
-      cursor: pointer;
+    button.input-postfix-button {
+      border: none;
+      background: none;
+      padding-right: 0;
     }
   }
 
@@ -34,14 +37,15 @@
   }
 }
 
-.filter-section-title {
+.filter-section-button {
   font-size: $font-md;
   font-weight: 600;
-  cursor: pointer;
   display: flex;
   justify-content: space-between;
   border-radius: 4px 4px 0 0;
   background-color: #f6f6f6;
+  width: 100%;
+  border: none;
 }
 
 .filter-section-main-title {
@@ -113,11 +117,13 @@
     }
   }
 
-  .facet-more-less {
-    cursor: pointer;
+  .facet-more-less-button {
     color: $search-gray;
     font-size: $font-sm;
     text-align: right;
+    background: none;
+    border: none;
+    width: 100%;
   }
 }
 
@@ -130,12 +136,14 @@
 .active-search-filters {
   margin: 0rem 1rem 1.4rem 1rem;
 
-  .clear-all-filters {
+  .clear-all-filters-button {
     font-size: $font-normal;
     font-weight: normal;
     text-decoration: underline;
-    cursor: pointer;
     margin-top: 0.15rem;
+    background: none;
+    border: none;
+    padding-right: 0;
   }
 
   .active-search-filter {
@@ -149,12 +157,16 @@
     border: 1px solid $medium-gray;
     border-radius: 14px;
 
-    .remove-filter {
+    .remove-filter-button {
       max-height: 18px;
       margin-right: 5px;
-      cursor: pointer;
 
-      i {
+      border: none;
+      background: none;
+      padding-right: 0;
+      padding-top: 0;
+
+      .material-icons {
         font-size: $font-md;
       }
     }

--- a/www/assets/css/search.scss
+++ b/www/assets/css/search.scss
@@ -177,11 +177,13 @@
       display: flex;
       justify-content: flex-end;
 
-      i {
+      button {
         margin-right: 18px;
         margin-top: 18px;
-        font-size: 2rem;
-        cursor: pointer;
+        padding: 0;
+        span.material-icons {
+          font-size: 2rem;
+        }
       }
     }
 
@@ -195,11 +197,14 @@
     }
   }
 
-  .filter-controls {
+  .filter-drawer-button {
     display: flex;
     align-items: center;
-    cursor: pointer;
     font-size: $font-normal;
+
+    background: none;
+    border: 0;
+    padding: 0;
 
     i.material-icons {
       font-size: 2.25rem;

--- a/www/assets/js/components/Facet.tsx
+++ b/www/assets/js/components/Facet.tsx
@@ -36,7 +36,9 @@ function SearchFacet(props: Props) {
         tabIndex={0}
       >
         {title}
-        <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">{titleLineIcon}</i>
+        <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">
+          {titleLineIcon}
+        </i>
       </div>
       {showFacetList ? (
         <React.Fragment>

--- a/www/assets/js/components/Facet.tsx
+++ b/www/assets/js/components/Facet.tsx
@@ -28,18 +28,17 @@ function SearchFacet(props: Props) {
 
   return results && results.buckets && results.buckets.length === 0 ? null : (
     <div className="facets mb-3">
-      <div
-        className="filter-section-title pl-3 pt-2 pb-2"
-        onClick={() => setShowFacetList(!showFacetList)}
-        role="button"
+      <button
+        className="filter-section-button pl-3 py-2 pr-0"
+        type="button"
         aria-expanded={showFacetList ? "true" : "false"}
-        tabIndex={0}
+        onClick={() => setShowFacetList(!showFacetList)}
       >
         {title}
         <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">
           {titleLineIcon}
         </i>
-      </div>
+      </button>
       {showFacetList ? (
         <React.Fragment>
           {results && results.buckets ?
@@ -58,12 +57,13 @@ function SearchFacet(props: Props) {
             ) :
             null}
           {results && results.buckets.length >= FACET_COLLAPSE_THRESHOLD ? (
-            <div
-              className={"facet-more-less"}
+            <button
+              className="facet-more-less-button"
               onClick={() => setShowAllFacets(!showAllFacets)}
+              type="button"
             >
               {showAllFacets ? "View less" : "View more"}
-            </div>
+            </button>
           ) : null}
         </React.Fragment>
       ) : null}

--- a/www/assets/js/components/Facet.tsx
+++ b/www/assets/js/components/Facet.tsx
@@ -31,9 +31,12 @@ function SearchFacet(props: Props) {
       <div
         className="filter-section-title pl-3 pt-2 pb-2"
         onClick={() => setShowFacetList(!showFacetList)}
+        role="button"
+        aria-expanded={showFacetList ? "true" : "false"}
+        tabIndex={0}
       >
         {title}
-        <i className={`material-icons ${titleLineIcon}`}>{titleLineIcon}</i>
+        <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">{titleLineIcon}</i>
       </div>
       {showFacetList ? (
         <React.Fragment>

--- a/www/assets/js/components/FacetDisplay.test.tsx
+++ b/www/assets/js/components/FacetDisplay.test.tsx
@@ -70,7 +70,7 @@ describe("FacetDisplay component", () => {
         .find("SearchFilter")
         .map(el => el.prop("value"))
     ).toEqual(["Academic Writing", "Accounting", "Aerodynamics", "Mathematics"])
-    wrapper.find(".clear-all-filters").simulate("click")
+    wrapper.find(".clear-all-filters-button").simulate("click")
     expect(clearAllFilters).toHaveBeenCalled()
   })
 })

--- a/www/assets/js/components/FacetDisplay.tsx
+++ b/www/assets/js/components/FacetDisplay.tsx
@@ -48,19 +48,18 @@ const FacetDisplay = React.memo(
         <div className="active-search-filters">
           <div className="filter-section-main-title">
             Filters
-            <span
-              className="clear-all-filters"
+            <button
+              className="clear-all-filters-button"
+              type="button"
               onClick={clearAllFilters}
               onKeyPress={e => {
                 if (e.key === "Enter") {
                   clearAllFilters()
                 }
               }}
-              tabIndex={0}
-              role="button"
             >
               Clear All
-            </span>
+            </button>
           </div>
           {facetMap.map(([name]) =>
             (activeFacets[name] || []).map((facet, i) => (

--- a/www/assets/js/components/FacetDisplay.tsx
+++ b/www/assets/js/components/FacetDisplay.tsx
@@ -52,11 +52,6 @@ const FacetDisplay = React.memo(
               className="clear-all-filters-button"
               type="button"
               onClick={clearAllFilters}
-              onKeyPress={e => {
-                if (e.key === "Enter") {
-                  clearAllFilters()
-                }
-              }}
             >
               Clear All
             </button>

--- a/www/assets/js/components/FacetDisplay.tsx
+++ b/www/assets/js/components/FacetDisplay.tsx
@@ -57,6 +57,7 @@ const FacetDisplay = React.memo(
                 }
               }}
               tabIndex={0}
+              role="button"
             >
               Clear All
             </span>

--- a/www/assets/js/components/FilterableFacet.tsx
+++ b/www/assets/js/components/FilterableFacet.tsx
@@ -94,15 +94,12 @@ function FilterableSearchFacet(props: Props) {
               <button
                 className="input-postfix-button"
                 type="button"
-                role="button"
                 onClick={() => setFilterText("")}
-                onKeyPress={e => {
-                  if (e.key === "Enter") {
-                    setFilterText("")
-                  }
-                }}
+                aria-label="clear search text"
               >
-                <span className="material-icons">clear</span>
+                <span className="material-icons" aria-hidden="true">
+                  clear
+                </span>
               </button>
             )}
           </div>

--- a/www/assets/js/components/FilterableFacet.tsx
+++ b/www/assets/js/components/FilterableFacet.tsx
@@ -62,18 +62,17 @@ function FilterableSearchFacet(props: Props) {
 
   return results && results.buckets && results.buckets.length === 0 ? null : (
     <div className="facets filterable-facet mb-3">
-      <div
-        className="filter-section-title pl-3 pt-2 pb-2"
-        onClick={() => setShowFacetList(!showFacetList)}
-        role="button"
+      <button
+        className="filter-section-button pl-3 py-2 pr-0"
+        type="button"
         aria-expanded={showFacetList ? "true" : "false"}
-        tabIndex={0}
+        onClick={() => setShowFacetList(!showFacetList)}
       >
         {title}
         <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">
           {titleLineIcon}
         </i>
-      </div>
+      </button>
       {showFacetList ? (
         <>
           <div className="input-wrapper">
@@ -85,23 +84,26 @@ function FilterableSearchFacet(props: Props) {
               placeholder={`Search ${title || ""}`}
             />
             {filterText === "" ? (
-              <i className="material-icons search-icon mt-1" aria-hidden="true">
+              <i
+                className="input-postfix-icon material-icons search-icon mt-1"
+                aria-hidden="true"
+              >
                 search
               </i>
             ) : (
-              <i
-                className="material-icons clear-icon"
+              <button
+                className="input-postfix-button"
+                type="button"
+                role="button"
                 onClick={() => setFilterText("")}
                 onKeyPress={e => {
                   if (e.key === "Enter") {
                     setFilterText("")
                   }
                 }}
-                tabIndex={0}
-                role="button"
               >
-                clear
-              </i>
+                <span className="material-icons">clear</span>
+              </button>
             )}
           </div>
           <div className="facet-list">

--- a/www/assets/js/components/FilterableFacet.tsx
+++ b/www/assets/js/components/FilterableFacet.tsx
@@ -65,9 +65,12 @@ function FilterableSearchFacet(props: Props) {
       <div
         className="filter-section-title pl-3 pt-2 pb-2"
         onClick={() => setShowFacetList(!showFacetList)}
+        role="button"
+        aria-expanded={showFacetList ? "true" : "false"}
+        tabIndex={0}
       >
         {title}
-        <i className={`material-icons ${titleLineIcon}`}>{titleLineIcon}</i>
+        <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">{titleLineIcon}</i>
       </div>
       {showFacetList ? (
         <>
@@ -80,7 +83,7 @@ function FilterableSearchFacet(props: Props) {
               placeholder={`Search ${title || ""}`}
             />
             {filterText === "" ? (
-              <i className="material-icons search-icon mt-1">search</i>
+              <i className="material-icons search-icon mt-1" aria-hidden="true">search</i>
             ) : (
               <i
                 className="material-icons clear-icon"
@@ -91,6 +94,7 @@ function FilterableSearchFacet(props: Props) {
                   }
                 }}
                 tabIndex={0}
+                role="button"
               >
                 clear
               </i>

--- a/www/assets/js/components/FilterableFacet.tsx
+++ b/www/assets/js/components/FilterableFacet.tsx
@@ -70,7 +70,9 @@ function FilterableSearchFacet(props: Props) {
         tabIndex={0}
       >
         {title}
-        <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">{titleLineIcon}</i>
+        <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">
+          {titleLineIcon}
+        </i>
       </div>
       {showFacetList ? (
         <>
@@ -83,7 +85,9 @@ function FilterableSearchFacet(props: Props) {
               placeholder={`Search ${title || ""}`}
             />
             {filterText === "" ? (
-              <i className="material-icons search-icon mt-1" aria-hidden="true">search</i>
+              <i className="material-icons search-icon mt-1" aria-hidden="true">
+                search
+              </i>
             ) : (
               <i
                 className="material-icons clear-icon"

--- a/www/assets/js/components/Footer.tsx
+++ b/www/assets/js/components/Footer.tsx
@@ -3,7 +3,11 @@ import React from "react"
 export default function Footer() {
   return (
     <footer className="search-footer px-2">
-      <img src="/static_shared/images/mit-ol.png" width="140px" />
+      <img
+        src="/static_shared/images/mit-ol.png"
+        width="140px"
+        alt="MIT Open Learning"
+      />
       <div className="mt-4">
         <a
           className="text-muted"

--- a/www/assets/js/components/SearchFilter.test.tsx
+++ b/www/assets/js/components/SearchFilter.test.tsx
@@ -28,7 +28,7 @@ describe("SearchFilter", () => {
   it("should trigger clearFacet function on click", async () => {
     const { render, onClickStub } = setup()
     const wrapper = render({ value: "ocw" })
-    wrapper.find(".remove-filter").simulate("click")
+    wrapper.find(".remove-filter-button").simulate("click")
     expect(onClickStub).toHaveBeenCalledTimes(1)
   })
 })

--- a/www/assets/js/components/SearchFilter.tsx
+++ b/www/assets/js/components/SearchFilter.tsx
@@ -10,19 +10,17 @@ export default function SearchFilter(props: Props) {
   const { value, clearFacet, labelFunction } = props
 
   return (
-    <div className="active-search-filter" aria-label="active search filters">
+    <div className="active-search-filter">
       <div>{labelFunction ? labelFunction(value) : value}</div>
       <button
         className="remove-filter-button"
         type="button"
         onClick={clearFacet}
-        onKeyPress={e => {
-          if (e.key === "Enter") {
-            clearFacet()
-          }
-        }}
+        aria-label="clear filter"
       >
-        <span className="material-icons">close</span>
+        <span className="material-icons" aria-hidden="true">
+          close
+        </span>
       </button>
     </div>
   )

--- a/www/assets/js/components/SearchFilter.tsx
+++ b/www/assets/js/components/SearchFilter.tsx
@@ -10,7 +10,7 @@ export default function SearchFilter(props: Props) {
   const { value, clearFacet, labelFunction } = props
 
   return (
-    <div className="active-search-filter">
+    <div className="active-search-filter" aria-label="active search filters">
       <div>{labelFunction ? labelFunction(value) : value}</div>
       <div
         className="remove-filter"
@@ -21,8 +21,10 @@ export default function SearchFilter(props: Props) {
           }
         }}
         tabIndex={0}
+        role="button"
+        aria-label="close"
       >
-        <i className="material-icons">close</i>
+        <i className="material-icons" aria-hidden="true">close</i>
       </div>
     </div>
   )

--- a/www/assets/js/components/SearchFilter.tsx
+++ b/www/assets/js/components/SearchFilter.tsx
@@ -12,22 +12,18 @@ export default function SearchFilter(props: Props) {
   return (
     <div className="active-search-filter" aria-label="active search filters">
       <div>{labelFunction ? labelFunction(value) : value}</div>
-      <div
-        className="remove-filter"
+      <button
+        className="remove-filter-button"
+        type="button"
         onClick={clearFacet}
         onKeyPress={e => {
           if (e.key === "Enter") {
             clearFacet()
           }
         }}
-        tabIndex={0}
-        role="button"
-        aria-label="close"
       >
-        <i className="material-icons" aria-hidden="true">
-          close
-        </i>
-      </div>
+        <span className="material-icons">close</span>
+      </button>
     </div>
   )
 }

--- a/www/assets/js/components/SearchFilter.tsx
+++ b/www/assets/js/components/SearchFilter.tsx
@@ -24,7 +24,9 @@ export default function SearchFilter(props: Props) {
         role="button"
         aria-label="close"
       >
-        <i className="material-icons" aria-hidden="true">close</i>
+        <i className="material-icons" aria-hidden="true">
+          close
+        </i>
       </div>
     </div>
   )

--- a/www/assets/js/components/SearchFilterDrawer.test.tsx
+++ b/www/assets/js/components/SearchFilterDrawer.test.tsx
@@ -28,10 +28,10 @@ describe("SearchFilterDrawer component", () => {
   test("phone mode renders a filter control and layout buttons", async () => {
     getViewportWidthMock.mockImplementation(() => 500)
     const wrapper = render()
-    const filterControl = wrapper.find(".filter-controls")
+    const filterDrawerButton = wrapper.find(".filter-drawer-button")
     const mockEvent = { preventDefault: jest.fn() }
-    expect(filterControl.text()).toBe("Filterarrow_drop_down")
-    filterControl.simulate("click", mockEvent)
+    expect(filterDrawerButton.text()).toBe("Filterarrow_drop_down")
+    filterDrawerButton.simulate("click", mockEvent)
     wrapper.update()
     expect(wrapper.find(".search-filter-drawer-open").exists()).toBeTruthy()
     expect(wrapper.find(FacetDisplay).exists()).toBeTruthy()

--- a/www/assets/js/components/SearchFilterDrawer.tsx
+++ b/www/assets/js/components/SearchFilterDrawer.tsx
@@ -53,12 +53,17 @@ export default function SearchFilterDrawer(props: Props) {
   return drawerOpen ? (
     <div className="search-filter-drawer-open">
       <div className="controls">
-        <i className="material-icons" onClick={closeDrawer}>
+        <i
+          className="material-icons"
+          onClick={closeDrawer}
+          role="button"
+          tabIndex={0}
+        >
           close
         </i>
       </div>
       <div className="apply-filters">
-        <button onClick={closeDrawer} className="blue-btn">
+        <button onClick={closeDrawer} className="blue-btn" role="button">
           Apply Filters
         </button>
       </div>
@@ -72,25 +77,37 @@ export default function SearchFilterDrawer(props: Props) {
   ) : (
     <div className="controls-outer">
       <div className="controls">
-        <div onClick={openDrawer} className="filter-controls">
+        <div
+          onClick={openDrawer}
+          className="filter-controls"
+          role="button"
+          tabIndex={0}
+        >
           Filter
-          <i className="material-icons">arrow_drop_down</i>
+          <i className="material-icons" aria-hidden="true">arrow_drop_down</i>
         </div>
       </div>
       <div className="layout-buttons layout-buttons-mobile">
-        <button onClick={() => updateUI(null)} className="layout-button-left">
+        <button
+          onClick={() => updateUI(null)}
+          className="layout-button-left"
+          aria-label="search results with thumbnails"
+        >
           <img
             src="/images/icons/list_ui_icon.png"
             alt="search results with thumbnails"
+            aria-hidden="true"
           />
         </button>
         <button
           onClick={() => updateUI(SEARCH_COMPACT_UI)}
           className="layout-button-right"
+          aria-label="compact search results"
         >
           <img
             src="/images/icons/compact_ui_icon.png"
             alt="compact search results"
+            aria-hidden="true"
           />
         </button>
       </div>

--- a/www/assets/js/components/SearchFilterDrawer.tsx
+++ b/www/assets/js/components/SearchFilterDrawer.tsx
@@ -53,17 +53,16 @@ export default function SearchFilterDrawer(props: Props) {
   return drawerOpen ? (
     <div className="search-filter-drawer-open">
       <div className="controls">
-        <i
-          className="material-icons"
+        <button
+          className="bg-transparent border-0"
           onClick={closeDrawer}
-          role="button"
-          tabIndex={0}
+          type="button"
         >
-          close
-        </i>
+          <span className="material-icons">close</span>
+        </button>
       </div>
       <div className="apply-filters">
-        <button onClick={closeDrawer} className="blue-btn" role="button">
+        <button onClick={closeDrawer} className="blue-btn" type="button">
           Apply Filters
         </button>
       </div>
@@ -77,17 +76,16 @@ export default function SearchFilterDrawer(props: Props) {
   ) : (
     <div className="controls-outer">
       <div className="controls">
-        <div
+        <button
+          className="filter-drawer-button"
+          type="button"
           onClick={openDrawer}
-          className="filter-controls"
-          role="button"
-          tabIndex={0}
         >
           Filter
           <i className="material-icons" aria-hidden="true">
             arrow_drop_down
           </i>
-        </div>
+        </button>
       </div>
       <div className="layout-buttons layout-buttons-mobile">
         <button

--- a/www/assets/js/components/SearchFilterDrawer.tsx
+++ b/www/assets/js/components/SearchFilterDrawer.tsx
@@ -84,7 +84,9 @@ export default function SearchFilterDrawer(props: Props) {
           tabIndex={0}
         >
           Filter
-          <i className="material-icons" aria-hidden="true">arrow_drop_down</i>
+          <i className="material-icons" aria-hidden="true">
+            arrow_drop_down
+          </i>
         </div>
       </div>
       <div className="layout-buttons layout-buttons-mobile">

--- a/www/assets/js/components/SearchFilterDrawer.tsx
+++ b/www/assets/js/components/SearchFilterDrawer.tsx
@@ -93,22 +93,20 @@ export default function SearchFilterDrawer(props: Props) {
         <button
           onClick={() => updateUI(null)}
           className="layout-button-left"
-          aria-label="search results with thumbnails"
+          type="button"
+          aria-label="show detailed results"
         >
-          <img
-            src="/images/icons/list_ui_icon.png"
-            alt="search results with thumbnails"
-            aria-hidden="true"
-          />
+          <img src="/images/icons/list_ui_icon.png" alt="" aria-hidden="true" />
         </button>
         <button
           onClick={() => updateUI(SEARCH_COMPACT_UI)}
           className="layout-button-right"
-          aria-label="compact search results"
+          type="button"
+          aria-label="show compact results"
         >
           <img
             src="/images/icons/compact_ui_icon.png"
-            alt="compact search results"
+            alt=""
             aria-hidden="true"
           />
         </button>

--- a/www/assets/js/components/SearchFilterDrawer.tsx
+++ b/www/assets/js/components/SearchFilterDrawer.tsx
@@ -57,8 +57,11 @@ export default function SearchFilterDrawer(props: Props) {
           className="bg-transparent border-0"
           onClick={closeDrawer}
           type="button"
+          aria-label="close search filters"
         >
-          <span className="material-icons">close</span>
+          <span className="material-icons" aria-hidden="true">
+            close
+          </span>
         </button>
       </div>
       <div className="apply-filters">

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -282,6 +282,7 @@ export default function SearchPage(props: SearchPageProps) {
                     className={`nav-link search-nav ${
                       isResourceSearch(activeFacets) ? "" : "active"
                     }`}
+                    type="button"
                     onClick={toggleResourceSearch(false)}
                   >
                     Courses
@@ -292,6 +293,7 @@ export default function SearchPage(props: SearchPageProps) {
                     className={`nav-link search-nav ${
                       isResourceSearch(activeFacets) ? "active" : ""
                     }`}
+                    type="button"
                     onClick={toggleResourceSearch(true)}
                   >
                     Resources

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -327,19 +327,23 @@ export default function SearchPage(props: SearchPageProps) {
                   <button
                     onClick={() => updateUI(null)}
                     className="layout-button-left"
+                    aria-label="search results with thumbnails"
                   >
                     <img
                       src="/images/icons/list_ui_icon.png"
                       alt="search results with thumbnails"
+                      aria-hidden="true"
                     />
                   </button>
                   <button
                     onClick={() => updateUI(SEARCH_COMPACT_UI)}
                     className="layout-button-right"
+                    aria-label="compact search results"
                   >
                     <img
                       src="/images/icons/compact_ui_icon.png"
                       alt="compact search results"
+                      aria-hidden="true"
                     />
                   </button>
                 </div>

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -327,22 +327,24 @@ export default function SearchPage(props: SearchPageProps) {
                   <button
                     onClick={() => updateUI(null)}
                     className="layout-button-left"
-                    aria-label="search results with thumbnails"
+                    type="button"
+                    aria-label="show detailed results"
                   >
                     <img
                       src="/images/icons/list_ui_icon.png"
-                      alt="search results with thumbnails"
+                      alt=""
                       aria-hidden="true"
                     />
                   </button>
                   <button
                     onClick={() => updateUI(SEARCH_COMPACT_UI)}
                     className="layout-button-right"
-                    aria-label="compact search results"
+                    type="button"
+                    aria-label="show compact results"
                   >
                     <img
                       src="/images/icons/compact_ui_icon.png"
-                      alt="compact search results"
+                      alt=""
                       aria-hidden="true"
                     />
                   </button>


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1222

# Description (What does it do?)

This PR adds aria attributes to interactive elements in the search page.

The most noticeable change is the ability to navigate into the filter section using tabs.

The objective of this PR is to ensure:
- Nothing is unnecessarily repeated during assistive speech
- Nothing unnecessary is spoken during assistive speech
- Decorative icons are not spoken
- And that interactive elements can be navigated by using tabs

# Screenshots (if appropriate):

There are no visual changes. In the following recording, you can see me using MacOS's VoiceOver assistant on the page.

The recording is in the desktop view, but the accessibility functionality should work in a similar way on the mobile view.

https://github.com/mitodl/ocw-hugo-themes/assets/71316217/c978723d-4432-457f-9b79-c48c57162eed


# How can this be tested?
1. Download content for the [www site](https://github.mit.edu/ocw-content-rc/ocw-www) and place it inside your local content directory.
2. Navigate your local `ocw-hugo-themes` directory.
3. Checkout branch `hussaintaj/1222`.
4. Run
    ```
    yarn start www
    ```
5. Open Chrome with the following command (macOS).
    ```
    open -a "Google Chrome" --args --disable-web-security --user-data-dir=/tmp/chrome
    ```
    > This will open Chrome with web security disabled. This is required to allow CORS requests to open-discussions.
6. Open https://localhost:3000/search.
7. Ensure that interactable UI has proper accessibility labels. In particular:
      - Ensure no decorative icon is spoken out loud
      - Ensure no label is repeated
      - Ensure the filter UI can be navigated using tabs
    > There are some semantic issues with the code. But we are not concerned with those in the scope of this fix.

