### PR TITLE
feat: improve navbar and topics accessibility

### DIFF
--- a/course-v2/assets/css/course-nav.scss
+++ b/course-v2/assets/css/course-nav.scss
@@ -35,6 +35,12 @@ nav {
   width: 100%;
 }
 
+.course-nav-section-toggle {
+  border: none;
+  padding: 0;
+  background: none;
+}
+
 .course-nav-section-toggle > i:after {
   content: "keyboard_arrow_down";
 }

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -91,15 +91,20 @@
         document.addEventListener("DOMContentLoaded", () => {
           const drawer = $(`#${DESKTOP_COURSE_DRAWER_ID}`)
           const mainSection = $(`#${MAIN_COURSE_SECTION_ID}`)
-          
 
           drawer.on("shown.bs.collapse", (event) => {
+            if (event.target.id !== DESKTOP_COURSE_DRAWER_ID) {
+              return;
+            }
             mainSection.addClass("col-lg-9")
             mainSection.removeClass("col-12")
             setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_OPENED)
           })
       
           drawer.on("hidden.bs.collapse", (event) => {
+            if (event.target.id !== DESKTOP_COURSE_DRAWER_ID) {
+              return;
+            }
             mainSection.addClass("col-12")
             mainSection.removeClass("col-lg-9")
             setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_CLOSED)

--- a/course-v2/layouts/partials/nav.html
+++ b/course-v2/layouts/partials/nav.html
@@ -1,6 +1,6 @@
 {{ $menu := index .context.Site.Menus "leftnav" }}
 {{ $device := .device }}
-<nav class="course-nav" aria-label="Main menu">
+<nav class="course-nav" aria-label="Course materials">
   <ul class="w-100 m-auto list-unstyled">
     {{ range $menu }}
       {{ partial "nav_item.html" (dict "menuItem" . "device" $device) }}

--- a/course-v2/layouts/partials/nav.html
+++ b/course-v2/layouts/partials/nav.html
@@ -1,6 +1,6 @@
 {{ $menu := index .context.Site.Menus "leftnav" }}
 {{ $device := .device }}
-<nav class="course-nav">
+<nav class="course-nav" aria-label="Main menu">
   <ul class="w-100 m-auto list-unstyled">
     {{ range $menu }}
       {{ partial "nav_item.html" (dict "menuItem" . "device" $device) }}

--- a/course-v2/layouts/partials/nav_item.html
+++ b/course-v2/layouts/partials/nav_item.html
@@ -23,7 +23,7 @@
       data-uuid="{{ .menuItem.Identifier }}"
       aria-controls="nav-container_{{ $device }}_{{ .menuItem.Identifier }}"
       aria-expanded="false"
-      aria-label="Submenu for {{.menuItem.Name}}"
+      aria-label="Subsections for {{.menuItem.Name}}"
     >
       <i class="material-icons md-18" aria-hidden="true"></i>
     </button>

--- a/course-v2/layouts/partials/nav_item.html
+++ b/course-v2/layouts/partials/nav_item.html
@@ -14,25 +14,31 @@
       </a>
     </span>
     {{ if .menuItem.HasChildren }}
-    <a class="course-nav-section-toggle"
-      href="#nav-container_{{ $device }}_{{ .menuItem.Identifier }}"
+    <button
+      class="course-nav-section-toggle"
+      type="button"
+      id="nav-button_{{ $device }}_{{ .menuItem.Identifier }}"
       data-toggle="collapse"
+      data-target="#nav-container_{{ $device }}_{{ .menuItem.Identifier }}"
+      data-uuid="{{ .menuItem.Identifier }}"
       aria-controls="nav-container_{{ $device }}_{{ .menuItem.Identifier }}"
-      aria-expanded=""
-      data-uuid="{{ .menuItem.Identifier }}">
-      <i class="material-icons md-18"></i>
-    </a>
+      aria-expanded="false"
+      aria-label="Submenu for {{.menuItem.Name}}"
+    >
+      <i class="material-icons md-18" aria-hidden="true"></i>
+    </button>
     {{ end }}
   </div>
   {{ if or (not $hasParent) $hasChildren }}
   <span class="medium-and-below-only"><hr/></span>
   {{ end }}
-  <div class="collapse"
-    id="nav-container_{{ $device }}_{{ .menuItem.Identifier }}">
-    <ul class="course-nav-child-nav m-auto">
-      {{ range .menuItem.Children }}
-        {{ partial "nav_item.html" (dict "menuItem" . "parentId" $id "device" $device) }}
-      {{ end }}
-    </ul>
-  </div>
+  <ul
+    class="course-nav-child-nav m-auto collapse"
+    id="nav-container_{{ $device }}_{{ .menuItem.Identifier }}"
+    aria-labelledby="nav-button_{{ $device }}_{{ .menuItem.Identifier }}"
+  >
+    {{ range .menuItem.Children }}
+      {{ partial "nav_item.html" (dict "menuItem" . "parentId" $id "device" $device) }}
+    {{ end }}
+  </ul>
 </li>

--- a/course-v2/layouts/partials/topic.html
+++ b/course-v2/layouts/partials/topic.html
@@ -2,59 +2,76 @@
 {{ $device := .device | default "desktop" }}
 {{ $context := .context }}
 {{ $subtopics := slice }}
+{{ $topicTitle := title .topic }}
 {{ if not (eq .subtopics nil) }}
 {{ $subtopics = .subtopics }}
 {{ end }}
 {{ $scratch := newScratch }}
 <div class="position-relative pt-1 pb-1{{ if gt (len $subtopics) 0 }} pl-4 ml-n2 {{ end }}">
   {{ if gt (len $subtopics) 0 }}
-  <a class="topic-toggle"
-    href="#subtopic-container_{{ $device }}_{{ $index }}"
+  <button
+    type="button"
+    class="topic-toggle border-0 bg-transparent pl-0"
+    data-target="#subtopic-container_{{ $device }}_{{ $index }}"
     data-toggle="collapse"
     aria-controls="subtopic-container_{{ $device }}_{{ $index }}"
-    aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}">
+    aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}"
+    aria-label="{{ $topicTitle }} subtopics"
+  >
     <i aria-hidden="true" class="material-icons"></i>
-  </a>
+  </button>
   {{ end }}
   <span class="topic-text-wrapper">
-    {{ $topicTitle := title .topic }}
     {{ $topicUrl := partial "get_search_url.html" (dict "key" "topic" "value" $topicTitle) }}
     {{- partial "link.html" (dict "href" $topicUrl "class" "text-black course-info-topic" "text" $topicTitle "stripLinkOffline" true) -}}
   </span>
 </div>
 {{ if gt (len $subtopics) 0 }}
-<div class="pl-4 subtopic-container collapse{{if eq $index 0 }} show{{ end }}" id="subtopic-container_{{ $device }}_{{ $index }}">
+<ul
+  class="pl-4 subtopic-container collapse{{if eq $index 0 }} show{{ end }} list-unstyled"
+  id="subtopic-container_{{ $device }}_{{ $index }}"
+  aria-label="Subtopics"
+>
   {{ $scratch.Set "index" 0 }}
   {{ range $subtopic, $specialities := $subtopics }}
   {{ $subtopicIndex := $scratch.Get "index" }}
-  <div class="position-relative pt-1 pb-1 {{ if gt (len ($specialities | default slice)) 0 }} pl-4 {{ else }} pl-2 {{ end }}">
-    {{ if gt (len ($specialities | default slice)) 0 }}
-    <a class="topic-toggle"
-      href="#speciality-container_{{ $device }}_{{ $index }}_{{ $subtopicIndex }}"
-      data-toggle="collapse"
-      aria-controls="speciality-container_{{ $device }}_{{ $index }}_{{ $subtopicIndex }}"
-      aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}">
-      <i aria-hidden="true" class="material-icons"></i>
-    </a>
-    {{ end }}
-    <span class="topic-text-wrapper">
-      {{ $subTopicTitle := title $subtopic }}
-      {{ $subTopicUrl := partial "get_search_url.html" (dict "key" "topic" "value" $subTopicTitle) }}
-      {{- partial "link.html" (dict "href" $subTopicUrl "class" "text-black course-info-topic" "text" $subTopicTitle "stripLinkOffline" true) -}}
-    </span>
-  </div>
-  <div class="collapse{{if eq $index 0 }} show{{ end }}" id="speciality-container_{{ $device }}_{{ $index }}_{{ $subtopicIndex }}">
-    {{ range $speciality, $ignore := $specialities }}
-    <div class="pt-1 pb-1 pl-5">
+  <li>
+    <div class="position-relative pt-1 pb-1 {{ if gt (len ($specialities | default slice)) 0 }} pl-4 {{ else }} pl-2 {{ end }}">
+      {{ if gt (len ($specialities | default slice)) 0 }}
+      <button
+        class="topic-toggle border-0 bg-transparent pl-0"
+        data-target="#speciality-container_{{ $device }}_{{ $index }}_{{ $subtopicIndex }}"
+        data-toggle="collapse"
+        aria-controls="speciality-container_{{ $device }}_{{ $index }}_{{ $subtopicIndex }}"
+        aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}"
+        aria-label="{{ $subtopic }} specialties"
+      >
+        <i aria-hidden="true" class="material-icons"></i>
+      </button>
+      {{ end }}
       <span class="topic-text-wrapper">
-        {{ $specialityTitle := title $speciality }}
-        {{ $specialityUrl := partial "get_search_url.html" (dict "key" "topic" "value" $specialityTitle) }}
-        {{- partial "link.html" (dict "href" $specialityUrl "class" "text-black course-info-topic" "text" $specialityTitle "stripLinkOffline" true) -}}
+        {{ $subTopicTitle := title $subtopic }}
+        {{ $subTopicUrl := partial "get_search_url.html" (dict "key" "topic" "value" $subTopicTitle) }}
+        {{- partial "link.html" (dict "href" $subTopicUrl "class" "text-black course-info-topic" "text" $subTopicTitle "stripLinkOffline" true) -}}
       </span>
     </div>
-    {{ end }}
-  </div>
-  {{ $scratch.Set "index" (add 1 ($scratch.Get "index")) }}
+    <ul
+      class="collapse{{if eq $index 0 }} show{{ end }} list-unstyled"
+      id="speciality-container_{{ $device }}_{{ $index }}_{{ $subtopicIndex }}"
+      aria-label="Specialties"
+    >
+      {{ range $speciality, $ignore := $specialities }}
+      <li class="pt-1 pb-1 pl-5">
+        <span class="topic-text-wrapper">
+          {{ $specialityTitle := title $speciality }}
+          {{ $specialityUrl := partial "get_search_url.html" (dict "key" "topic" "value" $specialityTitle) }}
+          {{- partial "link.html" (dict "href" $specialityUrl "class" "text-black course-info-topic" "text" $specialityTitle "stripLinkOffline" true) -}}
+        </span>
+      </li>
+      {{ end }}
+    </ul>
+    {{ $scratch.Set "index" (add 1 ($scratch.Get "index")) }}
+  </li>
   {{ end }}
-</div>
+</ul>
 {{ end }}

--- a/tests-e2e/ocw-ci-test-course/course-info.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/course-info.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from "@playwright/test"
 import { CoursePage } from "../util"
 
+const DESKTOP_COURSE_DRAWER_ID = "desktop-course-drawer"
+const MAIN_COURSE_SECTION_ID = "main-course-section"
+
 test("Course info section can be toggled", async ({ page }) => {
   const course = new CoursePage(page, "course")
   await course.goto("/pages/section-1")
@@ -13,4 +16,22 @@ test("Course info section can be toggled", async ({ page }) => {
   await expect(heading).toBeHidden()
   await button.click()
   await expect(heading).toBeVisible()
+})
+
+test("Toggling topics does not affect drawer layout", async ({page}) => {
+  const course = new CoursePage(page, "course")
+  await course.goto("/pages/section-1")
+
+  const heading = await page.getByRole("heading", { name: "Course Info" })
+  const topicCollapseButton = await page.getByRole('button', { name: 'Engineering subtopics' })
+
+  await expect(heading).toBeVisible()
+  await expect(topicCollapseButton).toHaveAttribute("aria-expanded", "true")
+  
+  await topicCollapseButton.click()
+  const mainSection = await page.locator(`#${MAIN_COURSE_SECTION_ID}`)
+  const drawer = await page.locator(`#${DESKTOP_COURSE_DRAWER_ID}`)
+
+  await expect(mainSection).toHaveClass(/.*col-lg-9.*/)
+  await expect(drawer).toHaveClass(/.*col-3.*/)  
 })

--- a/tests-e2e/ocw-ci-test-course/course-info.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/course-info.spec.ts
@@ -18,20 +18,22 @@ test("Course info section can be toggled", async ({ page }) => {
   await expect(heading).toBeVisible()
 })
 
-test("Toggling topics does not affect drawer layout", async ({page}) => {
+test("Toggling topics does not affect drawer layout", async ({ page }) => {
   const course = new CoursePage(page, "course")
   await course.goto("/pages/section-1")
 
   const heading = await page.getByRole("heading", { name: "Course Info" })
-  const topicCollapseButton = await page.getByRole('button', { name: 'Engineering subtopics' })
+  const topicCollapseButton = await page.getByRole("button", {
+    name: "Engineering subtopics"
+  })
 
   await expect(heading).toBeVisible()
   await expect(topicCollapseButton).toHaveAttribute("aria-expanded", "true")
-  
+
   await topicCollapseButton.click()
   const mainSection = await page.locator(`#${MAIN_COURSE_SECTION_ID}`)
   const drawer = await page.locator(`#${DESKTOP_COURSE_DRAWER_ID}`)
 
   await expect(mainSection).toHaveClass(/.*col-lg-9.*/)
-  await expect(drawer).toHaveClass(/.*col-3.*/)  
+  await expect(drawer).toHaveClass(/.*col-3.*/)
 })


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1220
Fixes https://github.com/mitodl/ocw-hugo-themes/issues/1237

# Description (What does it do?)

This PR improves the accessibility of the sidebars. In general, this PR:

* Converts relevant `<a>` tags to `<button>`s.
* Adds some extra semantic labels for the navbar.
* Makes the HTML more semantic by using `<ul>` for topics in the course info bar.
* Fixes the layout shift issue when topics were toggled.


# Screenshots (if appropriate):


https://github.com/mitodl/ocw-hugo-themes/assets/71316217/fa9893a5-6d74-4cd3-b644-56c4a8c49144


# How can this be tested?

1. Download content for the course [6.01sc-spring-2011](https://github.mit.edu/ocw-content-rc/6.01sc-spring-2011), and place it inside your local content directory. This step is optional if you have your setup configured to fetch remote content.
2. Navigate your local `ocw-hugo-themes` directory.
3. Checkout branch `hussaintaj/1220/expandables`.
4. Run
    ```
    yarn start course 6.01sc-spring-2011
    ```
5. Open https://localhost:3000/.
6. In the course info sidebar, on the right, toggle the collapsible topics/subtopics.
    **Expected Behavior**: No unexpected layout shifts occur.
7. Open your screen reading assistant (VoiceOver on Mac). Let it read the screen. (On Mac, you can use Ctrl + Option + A to start reading from the cursor position). Listen to the UI navbar on the left, and the topics section of the course info bar on the right. Expand items and listen to what the reader says when the items are expanded. Refer to the recording for more details.
    **Expected Behavior**: The voice assistant's speech is comprehensible.
    **Expected Behavior**: No decorative icon is spoken out loud.
    **Expected Behavior**: Accessibility works the same on mobile screen.
8. Repeat step 7 but this time build the course for offline use and run it from disk.
    ```
    yarn build /absolute/path/6.01sc-spring-2011 /absolute/path/ocw-hugo-projects/ocw-course-v2/config-offline.yaml
    ```

# Additional Context
Best read up on the source of it all https://github.com/mitodl/hq/issues/1918. In particular, this comment: https://github.com/mitodl/hq/issues/1918#issuecomment-1701002386
