### PR TITLE
fix mobile layout responsiveness for video resources

### DIFF
--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -14,6 +14,7 @@
       width: 100%;
       align-items: center;
       cursor: pointer;
+
       @include media-breakpoint-down(xs) {
         padding: 0px;
       }
@@ -45,9 +46,12 @@
 
       .right-col {
         position: relative;
-        // margin-left: 10px;
+        margin-left: 10px;
         width: 100%;
 
+        @include media-breakpoint-down(xs) {
+          margin-left: 0px;
+        }
         .video-title {
           margin: 0px !important;
           padding: 5px 10px !important;

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -52,7 +52,7 @@
         width: 100%;
 
         @include media-breakpoint-down(xs) {
-          margin-left: 0px;
+          margin: 0px;
         }
         .video-title {
           // margin: 0px !important;

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -55,10 +55,18 @@
           margin-left: 0px;
         }
         .video-title {
-          margin: 0px !important;
-          padding: 5px 10px !important;
+          // margin: 0px !important;
+          margin: 5px 10px !important;
           font-size: 0.7975rem !important;
           line-height: 1rem !important;
+          overflow: hidden;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+
+          @include media-breakpoint-down(xs) {
+            -webkit-line-clamp: 4;
+          }
           // position: absolute;
           // top: 50%;
           // transform: translateY(-50%);

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -27,6 +27,8 @@
 
         img.thumbnail {
           border-radius: 5px;
+          width: 100%;
+          max-width: 150px;
 
           @include media-breakpoint-down(md) {
             border-radius: 0px;

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -23,7 +23,6 @@
         justify-content: center;
         align-items: center;
         position: relative;
-        // margin-right: 10px;
 
         img.thumbnail {
           border-radius: 5px;
@@ -55,21 +54,17 @@
           margin: 0px;
         }
         .video-title {
-          // margin: 0px !important;
-          margin: 5px 10px !important;
-          font-size: 0.7975rem !important;
-          line-height: 1rem !important;
+          margin: 5px 10px;
           overflow: hidden;
           display: -webkit-box;
           -webkit-line-clamp: 2;
           -webkit-box-orient: vertical;
 
           @include media-breakpoint-down(xs) {
+            font-size: 0.7975rem !important;
+            line-height: 1rem !important;
             -webkit-line-clamp: 4;
           }
-          // position: absolute;
-          // top: 50%;
-          // transform: translateY(-50%);
         }
       }
     }

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -12,14 +12,17 @@
       margin: 0;
       text-align: left;
       width: 100%;
+      align-items: center;
       cursor: pointer;
-
+      @include media-breakpoint-down(xs) {
+        padding: 0px;
+      }
       .left-col {
         display: flex;
         justify-content: center;
         align-items: center;
         position: relative;
-        margin-right: 10px;
+        // margin-right: 10px;
 
         img.thumbnail {
           border-radius: 5px;
@@ -42,13 +45,17 @@
 
       .right-col {
         position: relative;
-        margin-left: 10px;
+        // margin-left: 10px;
         width: 100%;
 
         .video-title {
-          position: absolute;
-          top: 50%;
-          transform: translateY(-50%);
+          margin: 0px !important;
+          padding: 5px 10px !important;
+          font-size: 0.7975rem !important;
+          line-height: 1rem !important;
+          // position: absolute;
+          // top: 50%;
+          // transform: translateY(-50%);
         }
       }
     }

--- a/course-v2/layouts/partials/video-gallery-item.html
+++ b/course-v2/layouts/partials/video-gallery-item.html
@@ -8,7 +8,7 @@
         <img class="youtube-logo-overlay" src="/static_shared/images/youtube.svg" alt="YouTube" />
         {{- end -}}
       </div>
-      <div class="right-col py-5">
+      <div class="right-col">
         <h5 class="video-title">{{ .Params.title }}</h5>
       </div>
     </div>

--- a/course-v2/layouts/partials/video-gallery-item.html
+++ b/course-v2/layouts/partials/video-gallery-item.html
@@ -9,7 +9,7 @@
         {{- end -}}
       </div>
       <div class="right-col">
-        <h5 class="video-title">{{ .Params.title }} </h5>
+        <h5 class="video-title">{{ .Params.title }}</h5>
       </div>
     </div>
   </a>

--- a/course-v2/layouts/partials/video-gallery-item.html
+++ b/course-v2/layouts/partials/video-gallery-item.html
@@ -9,7 +9,7 @@
         {{- end -}}
       </div>
       <div class="right-col">
-        <h5 class="video-title">{{ .Params.title }}</h5>
+        <h5 class="video-title">{{ .Params.title }} </h5>
       </div>
     </div>
   </a>


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/2408

# Description (What does it do?)
1. Fixes mobile layout responsiveness for video resources (titles going out of `div` boxes if they're bigger in length)
2. It also adds ellipsis -- 2 lines limit for Desktop view, 4 lines limit for Mobile view (`xs` screen only)
3. Also gives `max-width` of `150px` to img thumbnails. Now for larger thumbnails, the `div` container will not grow bigger.

# Screenshots (if appropriate):
<img width="875" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/3c40a370-5deb-4536-9495-e5297539b2f1">
<img width="484" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/4c0e9f35-69c3-44f6-a7b6-8fbefaf21918">

# How to test it
1. Checkout to this branch. 
2. Use any course (just run `yarn start course`). 
4. Go to Video Lectures. 
5. Try to break responsiveness of the video `div` containers eg. try different combination of long names, or very short names, or different size images for thumbnail. Experiment a little, make sure nothing breaks for all screens.  
Also, we've kept the `font-size`, and `line-height` same as before for screens larger than mobile (`xs`). Confirm that it works as expected.

