### PR TITLE
Toggle show solution for multiple-choice quizzes

### DIFF
--- a/course-v2/assets/js/quiz_multiple_choice.js
+++ b/course-v2/assets/js/quiz_multiple_choice.js
@@ -49,11 +49,13 @@ export const showSolution = () => {
           .closest(".multiple-choice-question")
           .getElementsByClassName("correctness-icon-correct")[0]
           .classList.add("toggle-visible")
+        button.textContent = "Hide Solution"
       } else {
         button
           .closest(".multiple-choice-question")
           .getElementsByClassName("correctness-icon-correct")[0]
           .classList.remove("toggle-visible")
+        button.textContent = "Show Solution"
       }
     })
   })


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1248.

# Description (What does it do?)
Updates the text of the `Show Solution` button in multiple-choice quizzes to `Hide Solution` once the solution is shown.

# How can this be tested?
1. Spin up a course with a multiple-choice quiz, for example `yarn start course 15.071-spring-2017`.
2. Navigate to a page with a multiple-choice quiz, such as `http://localhost:3000/pages/logistic-regression/the-framingham-heart-study-evaluating-risk-factors-to-save-lives/quick-question-225/`.
3. Verify that clicking the `Show Solution` button displays the solution and the button text has been changed to `Hide Solution`. Click the `Hide Solution` button and verify that the solution is now hidden and the button text has been changed to `Show Solution`.