### PR TITLE
Make multiple choice quiz buttons keyboard-interactive

### DIFF
--- a/course-v2/layouts/partials/quiz_multiple_choice_solution.html
+++ b/course-v2/layouts/partials/quiz_multiple_choice_solution.html
@@ -4,7 +4,7 @@
   </button>
   {{if .solution }}
   	&emsp;
-  	<button class="btn btn-outline-primary multiple-choice-show-button ">
+  	<button class="btn btn-outline-primary multiple-choice-show-button">
   		Show Solution
     </button>
   {{end}}


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1252.

# Description (What does it do?)
This PR makes the `Show Solution`/`Hide Solution` and `Check` buttons in multiple-choice quizzes keyboard-interactive, which is needed for improved accessibility.

# How can this be tested?
1. Spin up a course with a multiple-choice quiz, for example `yarn start course 15.071-spring-2017`.
2. Navigate to a page with a multiple-choice quiz, such as `http://localhost:3000/pages/logistic-regression/the-framingham-heart-study-evaluating-risk-factors-to-save-lives/quick-question-225/`.
3. Verify that the `Check` and `Show Solution` buttons are keyboard-interactive. For the `Check` button, this means selecting one of the quiz options and then using the keyboard to push the `Check` button. For the `Show Solution` button, this does not require one of the options to be selected first.
