### PR TITLE
Make multiple-choice quiz state consistent

### DIFF
--- a/course-v2/assets/js/quiz_multiple_choice.js
+++ b/course-v2/assets/js/quiz_multiple_choice.js
@@ -9,6 +9,13 @@ export const clearSolution = () => {
       ).forEach(solution => {
         solution.classList.remove("toggle-visible")
       })
+      const question = radio.closest(".multiple-choice-question")
+      question
+        .getElementsByClassName("multiple-choice-solution")[0]
+        .classList.remove("toggle-visible")
+      question.getElementsByClassName(
+        "multiple-choice-show-button"
+      )[0].textContent = "Show Solution"
     })
   }
 }


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1250.

# Description (What does it do?)
If the solution is shown on a multiple-choice quiz, this PR makes the change that selecting an option resets the state of the quiz to the "solution not shown" state. Previously, selecting an option would remove the checkmarks indicating correctness but would not hide the solution text.

# How can this be tested?
1. Spin up a course with a multiple-choice quiz, for example `yarn start course 15.071-spring-2017`.
2. Navigate to a page with a multiple-choice quiz, such as `http://localhost:3000/pages/logistic-regression/the-framingham-heart-study-evaluating-risk-factors-to-save-lives/quick-question-225/`.
3. (Optional) Select one of the quiz choices.
4. Click the `Show Solution` button. The solution should appear, and the button text should now read `Hide Solution` (feature added here: https://github.com/mitodl/ocw-hugo-themes/pull/1249)
5. Click on any quiz choice. Verify that the checkmarks disappear (this was the behavior prior to this PR) and now that the solution is hidden and the button now has the text `Show Solution` again.