### PR TITLE
fix long single word resource title going out of div

### DIFF
--- a/course-v2/assets/css/course-resources.scss
+++ b/course-v2/assets/css/course-resources.scss
@@ -155,16 +155,14 @@ h4 {
 
   .resource-list-title {
     text-decoration: none;
+    word-break: break-all;
   }
   .resource-thumbnail {
     text-decoration: none;
   }
 
-  // .resource-list-title:hover {
-  //   text-decoration: underline;
-  // }
-
   .resource-list-item-details {
+    word-break: break-all;
     padding-top: 2px;
     padding-left: 10px;
     margin-bottom: auto;


### PR DESCRIPTION
# What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/1681

# Description (What does it do?)
I noticed that if we have a have a single worded long title, it breaks the `div`.

You can notice this behavior here: https://ocw.mit.edu/courses/3-091-introduction-to-solid-state-chemistry-fall-2018/download/
If you go under readings, and inspect element to something like 300 width you will see it goes out of the div. So basically if the text is longer than that, then it will be apparent for bigger screens too.

# Screenshots (if appropriate):
Problem:
<img width="368" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/d3dde95c-327c-4f78-8ea5-6f0662523ccf">

Fix:
<img width="330" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/c920fb38-de4b-433f-8aba-bdb164e3b828">

# How to test
1. checkout to this branch
2. yarn start course 6.0002-fall-2016
3. go to downloads and inspect element an existing title to add a long, one word title to a resource. It should not break the `div` box.