### PR TITLE
Update 404 page to match deployed version

### DIFF
--- a/www/layouts/404.html
+++ b/www/layouts/404.html
@@ -1,123 +1,124 @@
-<style>
-  body {
-    font-family: "Helvetica";
-    font-size: 16px;
-    margin: 0;
-    text-align: left;
-    font-weight: 400;
-    line-height: 1.5;
-    color: #212529;
-    background-color: #ffff;
-  }
-
-  .page-single {
-    max-width: 100%;
-    margin: 0 auto;
-  }
-
-  .title-text {
-    width: 100%;
-    font-weight: 600;
-    line-height: 1.2;
-  }
-
-  .message-container {
-    max-width: 1280px;
-    padding-left: 15px;
-    padding-right: 15px;
-    margin-left: 4rem;
-    margin-right: 4rem;
-    margin-top: 2rem;
-  }
-
-  .container {
-    display: flex;
-    flex-flow: column;
-    justify-content: space-between;
-    margin-right: 10px;
-  }
-
-  h3 {
-    margin-top: 0;
-    font-size: 1.5rem;
-    margin-bottom: 8px;
-  }
-
-  p {
-    margin-top: 0;
-  }
-
-  a {
-    color: black;
-  }
-
-  @media (min-width: 1200px) {
-    .title-text {
-      max-width: 100%;
-      font-size: 3rem;
-    }
-  }
-
-  @media (min-width: 992px) {
-    .page-title {
-      padding: 3.5rem 5rem;
-    }
-
-    .title-text {
-      max-width: 1447px;
-      font-size: 3rem;
-    }
-  }
-
-  @media (max-width: 1200px) {
-    .title-text {
-      font-size: calc(1.375rem + 1.5vw)
-    }
-
-    .page-title {
-      padding: 1rem;
-    }
-
-    .message-container {
-      margin:0;
-      padding: 1rem;
-
-    }
-
-  }
-
-  ol,
-  ul,
-  dl {
-    margin: 2rem 0;
-  }
-
-  .h-100v {
-    height: 100vh;
-  }
-
-  h2 {
-    margin-top: 5rem;
-  }
-
-  .page-title {
-    color: #ffff;
-    background-color: #126f9a;
-  }
-
-  .max-content-width {
-    padding: 0 3rem;
-    max-width: 100%;
-  }
-
-  .navbar-nav.max-content-width {
-    padding: 0 1rem 0 0;
-  }
-</style>
-<html lang="{{ $.Site.Language.Lang }}">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">  
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <style>
+      body {
+        font-family: "Helvetica";
+        font-size: 16px;
+        margin: 0;
+        text-align: left;
+        font-weight: 400;
+        line-height: 1.5;
+        color: #212529;
+        background-color: #ffff;
+      }
+
+      .page-single {
+        max-width: 100%;
+        margin: 0 auto;
+      }
+
+      .title-text {
+        width: 100%;
+        font-weight: 600;
+        line-height: 1.2;
+      }
+
+      .message-container {
+        max-width: 1280px;
+        padding-left: 15px;
+        padding-right: 15px;
+        margin-left: 4rem;
+        margin-right: 4rem;
+        margin-top: 2rem;
+      }
+
+      .container {
+        display: flex;
+        flex-flow: column;
+        justify-content: space-between;
+        margin-right: 10px;
+      }
+
+      h3 {
+        margin-top: 0;
+        font-size: 1.5rem;
+        margin-bottom: 8px;
+      }
+
+      p {
+        margin-top: 0;
+      }
+
+      a {
+        color: black;
+      }
+
+      @media (min-width: 1200px) {
+        .title-text {
+          max-width: 100%;
+          font-size: 3rem;
+        }
+      }
+
+      @media (min-width: 992px) {
+        .page-title {
+          padding: 3.5rem 5rem;
+        }
+
+        .title-text {
+          max-width: 1447px;
+          font-size: 3rem;
+        }
+      }
+
+      @media (max-width: 1200px) {
+        .title-text {
+          font-size: calc(1.375rem + 1.5vw)
+        }
+
+        .page-title {
+          padding: 1rem;
+        }
+
+        .message-container {
+          margin:0;
+          padding: 1rem;
+
+        }
+
+      }
+
+      ol,
+      ul,
+      dl {
+        margin: 2rem 0;
+      }
+
+      .h-100v {
+        height: 100vh;
+      }
+
+      h2 {
+        margin-top: 5rem;
+      }
+
+      .page-title {
+        color: #ffff;
+        background-color: #126f9a;
+      }
+
+      .max-content-width {
+        padding: 0 3rem;
+        max-width: 100%;
+      }
+
+      .navbar-nav.max-content-width {
+        padding: 0 1rem 0 0;
+      }
+    </style>
   </head>
   <body>
     <div
@@ -137,8 +138,15 @@
           <h3>Sorry, the page you requested was not found.</h3>
           <br />
           <p>
-            You might want to try <a href="/search/">searching</a> for another
-            page, or you can <a href="/contact/">contact us</a> and let us know
+            If you are trying to access OCW content from a saved bookmark or from a link from another website:
+            <ul>
+              <li>The OCW content may have been updated to a new version, which you can find by
+                <a href="/search/">searching</a> for the course number or title.</li>
+              <li>The OCW content may have been retired by request of MIT departments and faculty.
+                Retired and prior versions no longer on the live OCW website can be found in our
+                <a href="https://dspace.mit.edu/handle/1721.1/33971">DSpace archive</a>.</li>
+            </ul>
+            If you still can't find what you're seeking, please <a href="/contact/">contact us</a> for help.
           </p>
         </div>
       </div>


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1273.

# Description (What does it do?)
Updates the 404 page template in this repository to match the currently-deployed version in the `ol-infrastructure` repository.

# How can this be tested?
Run `yarn start www` and then navigate to a page that does not exist, such as `http://localhost:3000/notapage`. Verify that everything looks correct and matches what the deployed version looks like at `https://ocw.mit.edu/notapage`.

# Additional Context
This is the first step in making the 404 page in this repository actually be the source of the deployed 404 page. The next steps are described in these issues: https://github.com/mitodl/ol-infrastructure/issues/1889 and https://github.com/mitodl/ol-infrastructure/issues/1890.