### PR TITLE
fix: Resource titles breaking in resource lists and resource pages

### DIFF
--- a/course-v2/assets/css/course-resources.scss
+++ b/course-v2/assets/css/course-resources.scss
@@ -155,18 +155,20 @@ h4 {
 
   .resource-list-title {
     text-decoration: none;
-    word-break: break-all;
   }
   .resource-thumbnail {
     text-decoration: none;
   }
 
   .resource-list-item-details {
-    word-break: break-all;
     padding-top: 2px;
     padding-left: 10px;
     margin-bottom: auto;
     margin-top: auto;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    hyphens: auto;
   }
 
   .row {


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3022

# Description (What does it do?)
Currently, the words break take places on arbitrary positions of a word. This is because we are currently using `word-break: break-all;`

Eg. 
`This is internationalization` may come off as:
`This is int`
`ernationalization` (Depending on the screen size/space available)
And we do not want this random breaking of words.

This PR allows to break words as whole, and also allows hyphenation.
For example:
`This is internationalization` may become:
`This is international-`
`ization`,
OR it may become:
`This is inter-`
`nationalization`
The exact behavior is dependent on the space available for text, and the algorithm the utilized browser has. Setting `lang="en"` allows us to use this behavior, and we already have that in our HTML pages.

However, this is also to note that for capitalized words, we do not get this hyphenated behavior.
Example:
`This is Internationalization`
this would become:
`This is`
`Internalization`
because browser contexts deliberately do this for words that could be proper nouns.

# Screenshots (if appropriate):
**Before:**
<img width="449" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/9f202757-dc6c-4c46-a67e-621134e02a1e">

**Now:**
<img width="495" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/d6f9fb0a-b261-4bff-97b4-674533772efb">

**Before:**
<img width="301" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/dea48356-be26-4774-ac0f-bb85c8283f6d">

**Now:**
<img width="283" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/80330934-2889-47ca-8e71-1ff09a3137b1">



# How can this be tested?
1. Checkout to this branch
2. `yarn start course 6.0002-fall-2016`
3. Go to downloads and inspect element an existing title to add a long, one word title to a resource. It should not break the div box.
4. Try different combinations of words, eg. if you use `This is internationalization` for a resource title and decrease the screen size to very small, you will notice hyphenation. But if you write `This is Internationalization`, you will just notice the line breaking before` Internationalization`.
5. Check above for a) resource lists b) resource pages
