### PR TITLE
Fix redundant backslashes in Playwright test URLs

### DIFF
--- a/tests-e2e/util/test_sites.ts
+++ b/tests-e2e/util/test_sites.ts
@@ -39,7 +39,7 @@ const siteUrl = (siteAlias: TestSiteAlias, ...relPath: string[]) => {
 
   const relDest = siteAlias === "www" ? "" : `courses/${site.name}`
   const pathName = [relDest, ...relPath].join("/")
-  return path.join(playwrightBaseUrl, pathName)
+  return new URL(path.join(playwrightBaseUrl, pathName)).href
 }
 
 export { TEST_SITES, LOCAL_OCW_PORT, siteUrl, TestSiteAlias }

--- a/tests-e2e/util/test_sites.ts
+++ b/tests-e2e/util/test_sites.ts
@@ -39,7 +39,7 @@ const siteUrl = (siteAlias: TestSiteAlias, ...relPath: string[]) => {
 
   const relDest = siteAlias === "www" ? "" : `courses/${site.name}`
   const pathName = [relDest, ...relPath].join("/")
-  return new URL(path.join(playwrightBaseUrl, pathName)).href
+  return new URL(pathName, playwrightBaseUrl).href
 }
 
 export { TEST_SITES, LOCAL_OCW_PORT, siteUrl, TestSiteAlias }

--- a/tests-e2e/util/test_sites.ts
+++ b/tests-e2e/util/test_sites.ts
@@ -1,5 +1,3 @@
-import path from "path"
-
 import { env } from "../../env"
 
 const LOCAL_OCW_PORT = 3010

--- a/tests-e2e/util/test_sites.ts
+++ b/tests-e2e/util/test_sites.ts
@@ -1,3 +1,5 @@
+import path from "path"
+
 import { env } from "../../env"
 
 const LOCAL_OCW_PORT = 3010
@@ -36,8 +38,8 @@ const siteUrl = (siteAlias: TestSiteAlias, ...relPath: string[]) => {
   const site = TEST_SITES[siteAlias]
 
   const relDest = siteAlias === "www" ? "" : `courses/${site.name}`
-  const pathname = [relDest, ...relPath].join("/")
-  return `${playwrightBaseUrl}/${pathname}`
+  const pathName = [relDest, ...relPath].join("/")
+  return path.join(playwrightBaseUrl, pathName)
 }
 
 export { TEST_SITES, LOCAL_OCW_PORT, siteUrl, TestSiteAlias }

--- a/tests-e2e/util/test_sites.ts
+++ b/tests-e2e/util/test_sites.ts
@@ -36,7 +36,9 @@ const siteUrl = (siteAlias: TestSiteAlias, ...relPath: string[]) => {
   const site = TEST_SITES[siteAlias]
 
   const relDest = siteAlias === "www" ? "" : `courses/${site.name}`
-  const pathName = [relDest, ...relPath].join("/")
+  const pathName = [relDest, ...relPath]
+    .join("/")
+    .replace(/([^:])(\/\/+)/g, "$1/")
   return new URL(pathName, playwrightBaseUrl).href
 }
 


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1289

# Description (What does it do?)
This PR alters the `siteUrl` function in our Playwright tests to strip out consecutive slashes from URL paths in URLs being requested by Playwright during testing. These consecutive slashes are filtered out both by `hugo server` and the nginx fronted Minio instance run by `ocw-studio`, so the problematic behavior that this causes is not seen locally unless you set `PLAYWRIGHT_BASE_URL` to point at a site that doesn't handle consecutive slashes. Our Fastly fronted AWS S3 buckets are an example of this. The URL is passed through from Fastly to S3 without any modification. S3 interprets double slashes as just another part of the key, as S3 does not have a true directory structure. The URL path (or "key," in AWS terminology) can include any amount of legal characters, which includes consecutive backslashes. So, where most web servers will strip these out and assume you are building a path, AWS does not strip these out and assumes that they are part of the key. This results in a 404 for the resource, because the key does not match exactly.

# How can this be tested?
1. Set the following env variables:
```
STATIC_API_BASE_URL=https://test-qa.ocw.mit.edu/
RESOURCE_BASE_URL=https://test-qa.ocw.mit.edu/
SITEMAP_DOMAIN=test-qa.ocw.mit.edu
```
2. Modify line 155 of `tests-e2e/LocalOcw.ts` and set `RESOURCE_BASE_URL:   "https://test-qa.ocw.mit.edu/"`
3. Run `yarn test:e2e`, which we will expect to fail the first time around. The purpose of doing this is to generate test site fixtures with the `test-qa.ocw.mit.edu` domain
4. In your env` now set `PLAYWRIGHT_BASE_URL:   "https://test-qa.ocw.mit.edu/"
5. Run `yarn test:e2e` again and all tests should pass

# Additional Context
The Playwright tests in `fixtures.spec.ts`, as they are, currently compare a set of static fixtures against built Hugo JSON output. When `PLAYWRIGHT_BASE_URL` is set, a Hugo build is not done locally as it is assumed that you are testing against an already built site. However, if you set `PLAYWRIGHT_BASE_URL` to an external URL and run the tests without following the steps above, all tests aside from the one in `fixtures.spec.ts` will pass. This is because the fixture test code takes into account `RESOURCE_BASE_URL` and assumes that this value was used when building the test site that it is running against. If the values are not the same, the test will fail.