### PR TITLE
add a macos test comment

### DIFF
--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -41,7 +41,7 @@ test("Verify that the 'Download video' and 'Download transcript' links are keybo
    * ALERT MAC USERS
    * =================
    * This test will only pass if MacOS System setting "Keyboard navigation" is
-   * enabled. This setting is **disablled** by default.
+   * enabled. This setting is **disabled** by default.
    *
    * See https://github.com/mitodl/ocw-hugo-themes/issues/1283#issuecomment-1833883368
    * for more context.

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -33,9 +33,19 @@ test("that the Download Button works for multiple embed videos in a page", async
     await videoElement.downloadButton().click()
   }
 })
+
 test("Verify that the 'Download video' and 'Download transcript' links are keyboard navigable and have the correct download URLs", async ({
   page
 }) => {
+  /**
+   * ALERT MAC USERS
+   * =================
+   * This test will only pass if MacOS System setting "Keyboard navigation" is
+   * enabled. This setting is **disablled** by default.
+   *
+   * See https://github.com/mitodl/ocw-hugo-themes/issues/1283#issuecomment-1833883368
+   * for more context.
+   */
   const coursePage = new CoursePage(page, "course")
   await coursePage.goto("resources/ocw_test_course_mit8_01f16_l01v01_360p")
   const downloadLinks = [


### PR DESCRIPTION
# What are the relevant tickets?
None; came up while testing #1289 

# Description (What does it do?)
Adds a comment about fun MacOS behavior.

# How can this be tested?
If you want to test this, run `yarn test:e2e` on MacOS with and without keyboard navigation enabled in System Settings. (`System Settings --> Keyboard --> Keyboard Navigation`)