### PR TITLE
fix non-credit filter

### DIFF
--- a/www/assets/js/lib/constants.ts
+++ b/www/assets/js/lib/constants.ts
@@ -468,7 +468,7 @@ export const FACET_OPTIONS: Facets = {
   department_name: Object.values(departments).map(
     department => department.title
   ),
-  level:               ["Undergraduate", "Graduate", "Non Credit", "High School"],
+  level:               ["Undergraduate", "Graduate", "Non-Credit", "High School"],
   course_feature_tags: RESOURCE_TYPES,
   resource_type:       RESOURCE_TYPES
 }


### PR DESCRIPTION
### What are the relevant tickets?
None.

Selecting 'Non-Credit' at  https://ocw.mit.edu/search/ does not work. This fixes the issue

### Description (What does it do?)
We have parameter validation for the ocw search. Unfortunately, the parameter validation needs to be updated when we update the results from the api. 

### How can this be tested?
Set 
SEARCH_API_URL=https://open.mit.edu/api/v0/search/
Run `yarn start www`
Turn CORS off in your browser
Go to http://localhost:3000/search/

Verify that you can select non-credit


### Additional Context
Needing to manually update the possible parameters every time they change isn't great. 

Once ocw is migrated to the new search api and https://github.com/mitodl/mit-open/issues/269 is implemented we can get the possible parameters from the client that will be created by https://github.com/mitodl/mit-open/issues/269 
