### PR TITLE
use git package; remove hardcoded baseurl

### DIFF
--- a/base-theme/assets/types/global.d.ts
+++ b/base-theme/assets/types/global.d.ts
@@ -12,6 +12,7 @@ declare global {
   namespace NodeJS {
     interface ProcessEnv {
       SEARCH_API_URL: string
+      MIT_OPEN_BASEURL: string
     }
   }
 }

--- a/base-theme/assets/types/mit-open-login-button.d.ts
+++ b/base-theme/assets/types/mit-open-login-button.d.ts
@@ -1,1 +1,1 @@
-declare module 'mit-open-login-button'
+declare module "mit-open-login-button"

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -173,7 +173,8 @@ const config: webpack.Configuration = {
       Popper:          "popper.js/dist/umd/popper"
     }),
     new webpack.DefinePlugin({
-      RELEASE_VERSION: JSON.stringify(packageJson.version)
+      RELEASE_VERSION:  JSON.stringify(packageJson.version),
+      MIT_OPEN_BASEURL: JSON.stringify(packageJson.version)
     })
   ].concat(
     process.env.WEBPACK_ANALYZE === "true" ?

--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -31,8 +31,20 @@ $(function() {
   checkAnswer()
   showSolution()
   initCourseDrawersClosingViaSwiping()
-  initLoginButton("login-button-mobile", "http://od.odl.local:8063/", "Login", "btn blue-btn text-white btn-link link-button py-2 px-3 my-0", "text-white")
-  initLoginButton("login-button-desktop", "http://od.odl.local:8063/", "Login", "btn blue-btn text-white btn-link link-button py-2 px-3 my-0", "text-white px-3")
+  initLoginButton(
+    "login-button-mobile",
+    process.env.MIT_OPEN_BASEURL,
+    "Login",
+    "btn blue-btn text-white btn-link link-button py-2 px-3 my-0",
+    "text-white"
+  )
+  initLoginButton(
+    "login-button-desktop",
+    process.env.MIT_OPEN_BASEURL,
+    "Login",
+    "btn blue-btn text-white btn-link link-button py-2 px-3 my-0",
+    "text-white px-3"
+  )
 })
 
 let videoJSLoaded = false

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "lodash.uppercase": "^4.3.0",
     "mathjax": "^3.2.2",
     "mini-css-extract-plugin": "^2.6.1",
-    "mit-open-login-button": "/home/gumaerc/Code/mit-open-login-button",
+    "mit-open-login-button": "https://github.com/mitodl/mit-open-login-button.git",
     "nanogallery2": "^2.4.2",
     "npm-run-all": "^4.1.5",
     "offcanvas-bootstrap": "^2.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9536,7 +9536,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"history@npm:^4.9 || ^5.0.0, history@npm:^5.3.0":
+"history@npm:^5.0.0, history@npm:^5.3.0":
   version: 5.3.0
   resolution: "history@npm:5.3.0"
   dependencies:
@@ -12900,9 +12900,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mit-open-login-button@file:/home/gumaerc/Code/mit-open-login-button::locator=ocw-hugo-themes%40workspace%3A.":
+"mit-open-login-button@https://github.com/mitodl/mit-open-login-button.git#cg/fix-api-path":
   version: 0.0.1
-  resolution: "mit-open-login-button@file:/home/gumaerc/Code/mit-open-login-button#/home/gumaerc/Code/mit-open-login-button::hash=30f8a0&locator=ocw-hugo-themes%40workspace%3A."
+  resolution: "mit-open-login-button@https://github.com/mitodl/mit-open-login-button.git#commit=49f1e18fd98a0deaf5572b2b57e70f1b8786157e"
   dependencies:
     "@typescript-eslint/eslint-plugin": ^6.19.1
     eslint: ^8.56.0
@@ -12912,7 +12912,7 @@ __metadata:
     eslint-plugin-react: ^7.33.2
     eslint-plugin-react-hooks: ^4.6.0
     typescript: ^5.3.3
-  checksum: 09a4b3d671e196d6e4032b345145c42ddda4e7a97539aa4d961ce67bebe339ac7514a75267e180fe28f0caaf111ba4dc27e92b2621dbb70a219d0fb569330b25
+  checksum: 700d0160807684e0239da4d0922aa6302f0e72378651f1cd63277b3a470d95704677374411f72e3a8179e17e7864c8390e9bf78933b4bd4d85cddc10cde8cb3e
   languageName: node
   linkType: hard
 
@@ -13780,7 +13780,7 @@ __metadata:
     lodash.uppercase: ^4.3.0
     mathjax: ^3.2.2
     mini-css-extract-plugin: ^2.6.1
-    mit-open-login-button: /home/gumaerc/Code/mit-open-login-button
+    mit-open-login-button: "https://github.com/mitodl/mit-open-login-button.git#cg/fix-api-path"
     nanogallery2: ^2.4.2
     npm-run-all: ^4.1.5
     offcanvas-bootstrap: ^2.5.2


### PR DESCRIPTION
This PR makes a few small changes to `cg/add-mit-open-login-button`:

- Removes hard-coded MIT Open baseurl
- Installs `mit-open-login-button` from git rather than local.
    - Local might still be easier and useful for development, but git is definitely easier for sharing with others. 