### PR TITLE
config(renovate): exclude hugo-bin-extended from Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>mitodl/.github:renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["hugo-bin-extended"],
+      "automerge": false,
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-themes/issues/1296

### Description (What does it do?)

This PR updates renovate config to prevent a package's updates from being auto-merged.


### How can this be tested?

You may validate the config locally. Simply clone the repo and run:
```sh
npx --package renovate -c 'renovate-config-validator'
```

Notice the base branch of this PR. From what I've read online, once we merge this PR, renovate should run some checks on it. Source: https://github.com/renovatebot/renovate/issues/13948#issuecomment-1677034852

Once that passes, I'll create another PR merging `renovate/reconfigure` into `main`. 


