### PR TITLE
config(renovate): exclude hugo-bin-extended from auto-merge (#1357)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>mitodl/.github:renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["hugo-bin-extended"],
+      "automerge": false,
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/1296

### Description (What does it do?)

Merges new renovate config (i.e. https://github.com/mitodl/ocw-hugo-themes/pull/1357) into main. 



### How can this be tested?

See the list of checks on this branch/PR. Renovate should have run a validation job against the updates.

