### PR TITLE
fix: search page (broken by ramda upgrade)

### DIFF
--- a/www/assets/js/components/Facet.tsx
+++ b/www/assets/js/components/Facet.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { contains } from "ramda"
+import { includes } from "ramda"
 import has from "lodash.has"
 
 import SearchFacetItem from "./SearchFacetItem"
@@ -49,7 +49,7 @@ function SearchFacet(props: Props) {
                   <SearchFacetItem
                     key={i}
                     facet={facet}
-                    isChecked={contains(facet.key, currentlySelected || [])}
+                    isChecked={includes(facet.key, currentlySelected || [])}
                     onUpdate={onUpdate}
                     name={name}
                   />

--- a/www/assets/js/components/FilterableFacet.tsx
+++ b/www/assets/js/components/FilterableFacet.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react"
-import { contains } from "ramda"
+import { includes } from "ramda"
 import has from "lodash.has"
 import Fuse from "fuse.js"
 
@@ -108,7 +108,7 @@ function FilterableSearchFacet(props: Props) {
               <SearchFacetItem
                 key={i}
                 facet={facet}
-                isChecked={contains(facet.key, currentlySelected || [])}
+                isChecked={includes(facet.key, currentlySelected || [])}
                 onUpdate={onUpdate}
                 name={name}
               />


### PR DESCRIPTION
### What are the relevant tickets?

PR: https://github.com/mitodl/ocw-hugo-themes/pull/1347
Ramda Release Notes: https://github.com/ramda/ramda/issues/3218

### Description (What does it do?)

https://github.com/mitodl/ocw-hugo-themes/pull/1347 auto updates ramda from 0.27 to 0.29. In 0.28, the method `contains` was removed in favor of `includes`.

### How can this be tested?
1. Navigate to your local `ocw-hugo-themes` directory.
2. Checkout the branch `hussaintaj/fix-search-ramda`.
3. Make sure your env has
    ```env
    STATIC_API_BASE_URL=https://live-qa.ocw.mit.edu/
    ```
4. Run
    ```sh
    yarn start www
    ```
5. Open [localhost:3000/search](http://localhost:3000/search) with CORS disabled.
    > I use an extension called "CORS Everywhere" in firefox.
6. Expect the search to work. Especially the filter facets.