### PR TITLE
Fix resource list top border styling

### DIFF
--- a/course-v2/assets/css/course-resources.scss
+++ b/course-v2/assets/css/course-resources.scss
@@ -193,7 +193,7 @@ h4 {
   transition: background-color 0.05s ease;
 }
 
-.resource-item:first-of-type {
+.resource-item:first-child {
   border-top: 1px solid #dee2e6;
 }
 

--- a/course-v2/assets/css/course-resources.scss
+++ b/course-v2/assets/css/course-resources.scss
@@ -193,7 +193,7 @@ h4 {
   transition: background-color 0.05s ease;
 }
 
-.resource-item:first-child {
+.resource-item:first-of-type {
   border-top: 1px solid #dee2e6;
 }
 

--- a/course-v2/layouts/lists/single.html
+++ b/course-v2/layouts/lists/single.html
@@ -9,10 +9,12 @@
     <div class="mb-3 collection-description">
       {{ $bundle.Description | .RenderString }}
     </div>
+    <span>
       {{ range $id := $uids }}
         {{ $page := where $.Site.Pages "Params.uid" $id }}
         {{ $resources = $resources |  append (index $page 0) }}
       {{ end }}
       {{- partial "resource_list.html" (dict "resources" $resources "sort" false) -}}
+    </span> 
   </div>
 {{ end }}


### PR DESCRIPTION
### What are the relevant tickets?
No ticket

### Description (What does it do?)
Fixes `border-top` styling not being applied to resource lists.
For example:
https://ocw.mit.edu/courses/21a-505j-the-anthropology-of-sound-spring-2022/lists/lecture-slides/
https://draft.ocw.mit.edu/courses/3-020-thermodynamics-of-materials-spring-2021/lists/problem-sets/

It should be like the lists here:
https://ocw.mit.edu/courses/res-18-010-a-2020-vision-of-linear-algebra-spring-2020/download/

### Screenshots (Before & After):
<img width="1106" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/c62b61cf-f97e-41ae-89f4-6b1901dd0511">

<img width="1125" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/86792631-03ce-4de8-8407-2662e907d4c6">


### How can this be tested?
1. Checkout to this branch
2. Run `yarn start course 21A.505J-spring-2022`
3. Go to http://localhost:3000/ and lecture slides from left menu
4. See the top-border is being applied to first element
5. Go to download course from http://localhost:3000/, see the borders are being applied on lists there
Another good example of a course is `18.06sc-fall-2011`. Run it locally, go to Download Course. From there see the lists that have "See all" option, click it, and see the lists still have consistent styling.

For offline course theme, run:
`yarn build ~/path/ocw-content-rc/3.020-spring-2021/ ~/path/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`
And then open `index.html` from `dist` directory of the course.