### PR TITLE
feat: adjust modal styles for `xs` screens

### DIFF
--- a/base-theme/assets/css/modal.scss
+++ b/base-theme/assets/css/modal.scss
@@ -4,12 +4,20 @@ $header-icon-size: 1.9rem;
 .modal {
   .modal-content {
     border-radius: 0.5rem;
+
+    @include media-breakpoint-down(xs) {
+      padding: 0 !important;
+      font-size: $font-sm;
+    }
   }
 
   .modal-title {
     font-size: $font-lg !important;
     font-weight: 400;
-    text-align: center;
+
+    @include media-breakpoint-down(xs) {
+      font-size: $font-md !important;
+    }
   }
 
   .modal-header-icon-img {


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-hugo-themes/pull/1364

### Description (What does it do?)

@mbilalmughal suggested a few improvements to the styles of the modal for small screens.

This PR updates modal styles for `xs` screens. It

- reduces the text size
- reduces padding
- aligns title text to the left

### Screenshots (if appropriate):

iPhone 12 pro vs iPad Mini (for reference)

<img height="300" alt="iPhone 12" src="https://github.com/mitodl/ocw-hugo-themes/assets/71316217/4d77a14a-b63c-47d9-93e6-1c4411ddb7de" />

<img height="300" alt="iPad Mini" src="https://github.com/mitodl/ocw-hugo-themes/assets/71316217/a013f7f9-8482-428f-959b-54f6d3d19d47" />



### How can this be tested?
1. Grab content for [this course](https://github.mit.edu/ocw-content-rc/ht-test-2024).
2. Place the content in your local content directory.
3. Navigate to your local setup of `ocw-hugo-themes`.
4. Checkout branch `hussaintaj/adjust-modal-xs-styles`.
5. Run
    ```
    yarn start course ht-test-2024
    ```
6. Click a link that opens a modal.
7. Observe the modal in a small device through the device toolbar in the developer panel.
8. Expect the mobile modal to be smaller and more compact for smaller screens.


