### PR TITLE
Video pages layout width-fix

### DIFF
--- a/base-offline/layouts/partials/video.html
+++ b/base-offline/layouts/partials/video.html
@@ -15,13 +15,15 @@
   	<div class="description">
     	{{ .Content }}
   	</div>
-  	{{ partial "video_player.html" (dict "context" $context "youtubeKey" $youtubeKey "archiveUrl" $archiveUrl "downloadLink" $downloadLink "startTime" $startTime "endTime" $endTime) }}
+	<div class="video-player-wrapper">
+		{{ partial "video_player.html" (dict "context" $context "youtubeKey" $youtubeKey "archiveUrl" $archiveUrl "downloadLink" $downloadLink "startTime" $startTime "endTime" $endTime) }}
 
-  	{{ if $relatedResourses }}
-	  {{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "related-resource" "tabTitle" "Related Resources" "tabContent" $relatedResourses) }}
-  	{{ end }}
+		{{ if $relatedResourses }}
+		{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "related-resource" "tabTitle" "Related Resources" "tabContent" $relatedResourses) }}
+		{{ end }}
 
-  	{{ if and $optionalTabTitle $optionalTabContent }}
-		{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "optional-tab" "tabTitle" $optionalTabTitle "tabContent" $optionalTabContent) }}
-  	{{end}}
+		{{ if and $optionalTabTitle $optionalTabContent }}
+			{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "optional-tab" "tabTitle" $optionalTabTitle "tabContent" $optionalTabContent) }}
+		{{end}}
+	</div>
 </div>

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -342,8 +342,6 @@ article.content {
 }
 
 .course-section-title-container {
-  padding-right: 1.5rem;
-
   #course-title {
     border-bottom: 1px solid $medium-gray;
   }

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -347,10 +347,6 @@ article.content {
   #course-title {
     border-bottom: 1px solid $medium-gray;
   }
-
-  @include media-breakpoint-down(xs) {
-    padding-right: 15px;
-  }
 }
 
 .download-file {

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -342,6 +342,8 @@ article.content {
 }
 
 .course-section-title-container {
+  padding-right: 1.5rem;
+
   #course-title {
     border-bottom: 1px solid $medium-gray;
   }

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -69,6 +69,7 @@ $resource-video-thumbnail-color: #494949;
 $resource-file-thumbnail-color: #0851bb;
 
 // video
+$video-player-max-width: 100vh;
 $video-tab-content-color: rgba(51, 51, 51, 0.87);
 $video-tab-title-color: rgba(255, 255, 255, 0.87);
 $transcript-hover-background-color: #e1e1e1;

--- a/base-theme/assets/css/variables.scss
+++ b/base-theme/assets/css/variables.scss
@@ -69,7 +69,6 @@ $resource-video-thumbnail-color: #494949;
 $resource-file-thumbnail-color: #0851bb;
 
 // video
-$video-section-max-width: 100vh;
 $video-tab-content-color: rgba(51, 51, 51, 0.87);
 $video-tab-title-color: rgba(255, 255, 255, 0.87);
 $transcript-hover-background-color: #e1e1e1;

--- a/base-theme/layouts/partials/video.html
+++ b/base-theme/layouts/partials/video.html
@@ -27,18 +27,20 @@
   	<div class="description">
     	{{ .Content }}
   	</div>
-  	{{ partial "video_player.html" (dict "context" $context "youtubeKey" $youtubeKey "archiveUrl" $archiveUrl "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime "downloadLink" $downloadLink "transcriptLink" $transcriptPdfLocation)}}
-	{{ if $transcriptPdfLocation }}
-		{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "transcript" "tabTitle" "Transcript" "downloadLink" $downloadLink "transcriptLink" $transcriptPdfLocation) }}
-	{{ else }}
-		{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "" "tabTitle" "" "downloadLink" $downloadLink "transcriptLink" $transcriptPdfLocation) }}
-	{{end}}
+	<div class="video-player-wrapper">
+		{{ partial "video_player.html" (dict "context" $context "youtubeKey" $youtubeKey "archiveUrl" $archiveUrl "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime "downloadLink" $downloadLink "transcriptLink" $transcriptPdfLocation)}}
+		{{ if $transcriptPdfLocation }}
+			{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "transcript" "tabTitle" "Transcript" "downloadLink" $downloadLink "transcriptLink" $transcriptPdfLocation) }}
+		{{ else }}
+			{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "" "tabTitle" "" "downloadLink" $downloadLink "transcriptLink" $transcriptPdfLocation) }}
+		{{end}}
 
-  	{{ if $relatedResourses }}
-	  {{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "related-resource" "tabTitle" "Related Resources" "tabContent" $relatedResourses) }}
-  	{{ end }}
+		{{ if $relatedResourses }}
+		{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "related-resource" "tabTitle" "Related Resources" "tabContent" $relatedResourses) }}
+		{{ end }}
 
-  	{{ if and $optionalTabTitle $optionalTabContent }}
-		{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "optional-tab" "tabTitle" $optionalTabTitle "tabContent" $optionalTabContent) }}
-  	{{end}}
+		{{ if and $optionalTabTitle $optionalTabContent }}
+			{{ partial "video_expandable_tab.html" (dict "context" $context "tabClass" "optional-tab" "tabTitle" $optionalTabTitle "tabContent" $optionalTabContent) }}
+		{{end}}
+	</div>
 </div>

--- a/base-theme/layouts/partials/video_embed.html
+++ b/base-theme/layouts/partials/video_embed.html
@@ -15,7 +15,7 @@
 {{ $downloadLink =  partial "resource_url.html" (dict "context" $context "url" $downloadLink) }}
 {{ end }}
 
-<div class="video-embed">
+<div class="video-embed video-player-wrapper">
   {{ partial "video_player.html" (dict "context" $context "youtubeKey" $youtubeKey "archiveUrl" $archiveUrl "captionsLocation" $captionsLocation "startTime" $startTime "endTime" $endTime "downloadLink" $downloadLink) }}
   {{ range where site.Pages "Params.uid" $uid }}
   {{ $resourceUrl := partial "page_url.html" (dict "context" $context "url" .Permalink) }}

--- a/course-v2/assets/css/instructor-insights.scss
+++ b/course-v2/assets/css/instructor-insights.scss
@@ -1,5 +1,8 @@
 @import "../../../base-theme/assets/css/variables.scss";
 #course-content-section {
+  margin-top: 20px;
+  padding-right: 1.5rem;
+
   p {
     margin-bottom: 1.25rem;
   }

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -75,6 +75,10 @@
   margin-bottom: 15px;
 }
 
+.video-player-wrapper {
+  max-width: $video-player-max-width;
+}
+
 .video-page {
   margin-bottom: 15px;
 

--- a/course-v2/assets/css/video.scss
+++ b/course-v2/assets/css/video.scss
@@ -72,12 +72,10 @@
 }
 
 .video-embed {
-  max-width: $video-section-max-width;
   margin-bottom: 15px;
 }
 
 .video-page {
-  max-width: $video-section-max-width;
   margin-bottom: 15px;
 
   .video-container {

--- a/course-v2/layouts/partials/course_content.html
+++ b/course-v2/layouts/partials/course_content.html
@@ -1,6 +1,6 @@
 <div class="mb-2">
   {{ partial "content_header_v2.html" . }}
-  <article class="content pt-3 mt-1">
+  <article>
     <main id="course-content-section">{{- .Content -}}</main>
   </article>
 </div>

--- a/www/layouts/collections/single.html
+++ b/www/layouts/collections/single.html
@@ -10,6 +10,7 @@
       {{ $collection.Title }}
     </h1>
     <div class="mb-3 collection-description">
+      <!-- {{ $collection.Description }} -->
       {{ $collection.Description | .RenderString }}
     </div>
     {{ $collectionFeaturedList := index $collection.Params "featured-courses"}}

--- a/www/layouts/collections/single.html
+++ b/www/layouts/collections/single.html
@@ -10,7 +10,6 @@
       {{ $collection.Title }}
     </h1>
     <div class="mb-3 collection-description">
-      <!-- {{ $collection.Description }} -->
       {{ $collection.Description | .RenderString }}
     </div>
     {{ $collectionFeaturedList := index $collection.Params "featured-courses"}}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/2921

### Description (What does it do?)
Removes `max-width: 100vh` from video pages styling to allow the content to spread over all of the `div` body.
This means, not only the text, but videos will now take up entire `div` width too.

### Screenshots
Refer to https://github.com/mitodl/ocw-hugo-themes/pull/1369#issuecomment-1993747002


### How can this be tested?
Checkout to this branch, check any course that has video lectures (the default course also does -- `yarn start course`). Check embed video pages as well. An example of embed video is in course `18.06sc-fall-2011` in the Instructor Insights page.

For offline course theme, run:
`yarn build ~/path/ocw-content-rc/18.06sc-fall-2011/ ~/path/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`
And then open `index.html` from `dist` directory of the course, and navigate to videos. Replace course-id with course of your choice.
