### PR TITLE
Markdownify quiz choice

### DIFF
--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -141,7 +141,7 @@ div[class^="reveal"],
   margin: 11px 0;
 
   label {
-    margin: 0 5px 0 0;
+    margin: 0;
   }
 }
 

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -146,7 +146,10 @@ div[class^="reveal"],
 pre {
   padding: 10px;
   border: 1px solid $medium-gray;
-  display: inline-flex;
+}
+
+.multiple-choice-question .multiple-choice-div pre {
+  display: inline-flex !important;
 }
 
 .collapse-btn-section {

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -146,6 +146,7 @@ div[class^="reveal"],
 pre {
   padding: 10px;
   border: 1px solid $medium-gray;
+  display: inline-flex;
 }
 
 .collapse-btn-section {

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -126,21 +126,23 @@ div[class^="reveal"],
 }
 
 .correctness-icon {
-  position: relative;
-  top: 6px;
+  margin-left: 4px;
 }
 
 .multiple-choice-radio {
-  margin-top: 11px;
-  margin-bottom: 11px;
+  margin-right: 5px;
 }
 
 .multiple_choice_buttons {
   margin: 10px;
 }
 
-.multiple-choice-div label {
-  margin-bottom: 0px;
+.multiple-choice-div {
+  margin: 11px 0;
+
+  label {
+    margin: 0 5px 0 0;
+  }
 }
 
 pre {
@@ -149,7 +151,7 @@ pre {
 }
 
 .multiple-choice-question .multiple-choice-div pre {
-  display: inline-flex !important;
+  margin: 0;
 }
 
 .collapse-btn-section {

--- a/course-v2/layouts/partials/quiz_multiple_choice_choice.html
+++ b/course-v2/layouts/partials/quiz_multiple_choice_choice.html
@@ -1,16 +1,16 @@
 <div class="multiple-choice-div">
 	<label class="d-flex align-items-center">
 		<input type='radio' name={{ .questionId }} class="multiple-choice-radio">
-		{{ .choiceText | markdownify }}
-		
-		{{ if eq .correct "true" }}
-		<span class="toggle material-icons correctness-icon correctness-icon-correct">
-			check
-		</span>
-		{{ else }}
-		<span class="toggle material-icons correctness-icon correctness-icon-wrong">
-			close
-		</span>
-		{{ end }}
+			{{ .choiceText | markdownify }}
+			
+			{{ if eq .correct "true" }}
+				<span class="toggle material-icons correctness-icon correctness-icon-correct">
+					check
+				</span>
+			{{ else }}
+				<span class="toggle material-icons correctness-icon correctness-icon-wrong">
+					close
+				</span>
+			{{ end }}
 	</label>
 </div>

--- a/course-v2/layouts/partials/quiz_multiple_choice_choice.html
+++ b/course-v2/layouts/partials/quiz_multiple_choice_choice.html
@@ -1,16 +1,16 @@
 <div class="multiple-choice-div">
 	<label class="d-flex align-items-center">
 		<input type='radio' name={{ .questionId }} class="multiple-choice-radio">
-			{{ .choiceText | markdownify }}
-			
-			{{ if eq .correct "true" }}
-				<span class="toggle material-icons correctness-icon correctness-icon-correct">
-					check
-				</span>
-			{{ else }}
-				<span class="toggle material-icons correctness-icon correctness-icon-wrong">
-					close
-				</span>
-			{{ end }}
+		{{ .choiceText | markdownify }}
+		
+		{{ if eq .correct "true" }}
+			<span class="toggle material-icons correctness-icon correctness-icon-correct">
+				check
+			</span>
+		{{ else }}
+			<span class="toggle material-icons correctness-icon correctness-icon-wrong">
+				close
+			</span>
+		{{ end }}
 	</label>
 </div>

--- a/course-v2/layouts/partials/quiz_multiple_choice_choice.html
+++ b/course-v2/layouts/partials/quiz_multiple_choice_choice.html
@@ -1,8 +1,8 @@
 <div class="multiple-choice-div">
 	<label class="d-flex align-items-center">
 		<input type='radio' name={{ .questionId }} class="multiple-choice-radio">
-		{{ .choiceText | markdownify }}
-		
+        {{ page.RenderString .choiceText }}
+
 		{{ if eq .correct "true" }}
 			<span class="toggle material-icons correctness-icon correctness-icon-correct">
 				check

--- a/course-v2/layouts/partials/quiz_multiple_choice_choice.html
+++ b/course-v2/layouts/partials/quiz_multiple_choice_choice.html
@@ -1,6 +1,7 @@
 <div class="multiple-choice-div">
 	<label>
-		<input type='radio' name={{ .questionId }} class="multiple-choice-radio">{{.choiceText}}
+		<input type='radio' name={{ .questionId }} class="multiple-choice-radio">
+		{{.choiceText | markdownify}}
 	</label>
 	{{ if eq .correct "true" }}
 		<span class="toggle material-icons correctness-icon correctness-icon-correct">

--- a/course-v2/layouts/partials/quiz_multiple_choice_choice.html
+++ b/course-v2/layouts/partials/quiz_multiple_choice_choice.html
@@ -1,15 +1,16 @@
 <div class="multiple-choice-div">
-	<label>
+	<label class="d-flex align-items-center">
 		<input type='radio' name={{ .questionId }} class="multiple-choice-radio">
-		{{.choiceText | markdownify}}
-	</label>
-	{{ if eq .correct "true" }}
+		{{ .choiceText | markdownify }}
+		
+		{{ if eq .correct "true" }}
 		<span class="toggle material-icons correctness-icon correctness-icon-correct">
 			check
 		</span>
-  {{ else }}
-  	<span class="toggle material-icons  correctness-icon correctness-icon-wrong">
+		{{ else }}
+		<span class="toggle material-icons correctness-icon correctness-icon-wrong">
 			close
 		</span>
-	{{end}}
+		{{ end }}
+	</label>
 </div>


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/3661

### Description (What does it do?)
Adds `.RenderString` in `quiz_choice` to allow markdown rendering. The CSS changes were added to align everything centrally - the uneven spacing was specifically apparent with `code` blocks in MCQ options.

### Screenshots (if appropriate):
<img width="865" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/14cbbb6a-37ee-403b-a26c-fe41481102f5">
<img width="854" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/3aa3b45a-4529-4810-b1a4-c155711a28c6">
<img width="500" alt="image" src="https://github.com/mitodl/ocw-hugo-themes/assets/109785089/e8b18aa4-d6e2-4a0b-998e-17df21735e49">


### How can this be tested?

Lecture 8 and Lecture 9 of `6.0001-fall-2016` have such contents... I'm not sure if they're available in `ocw-content-rc` right now, so you can also use this markdown:

```
### Getters and Setters

1. Which of the below is a getter method for the number of wheels?    

    ```plaintext
    ----------------------------------
    ----------- Given ------------
    ----------------------------------
    class Car(object):
        def __init__(self, w, d):
            self.wheels = w
            self.doors = d
            self.color = ""
    ----------------------------------

    (A)     def get_wheels():
                return wheels

    (B)     def get_wheels():
                return self.wheels

    (C)     def get_wheels(self):
                return wheels

    (D)     def get_wheels(self):
                return self.wheels
    ```
      
    {{< quiz_multiple_choice questionId="Q1_div" >}}{{< quiz_choices >}}{{< quiz_choice isCorrect="false" >}}  
    def get_wheels():    
    {{< /quiz_choice >}}  
    {{< quiz_choice isCorrect="false" >}}  
    def get_wheels():  
    {{< /quiz_choice >}}  
    {{< quiz_choice isCorrect="false" >}}  
    def get_wheels(self):    
    {{< /quiz_choice >}}  
    {{< quiz_choice isCorrect="true" >}}  
    def get_wheels(self):    
    {{< /quiz_choice >}}{{< /quiz_choices >}}  
    {{< quiz_solution >}}  
      
     

{{< resource uuid="c4e79feb-d329-f620-2a0b-250ea3c746aa" >}}
```

