### PR TITLE
Add back content class in course content

### DIFF
--- a/course-v2/layouts/partials/course_content.html
+++ b/course-v2/layouts/partials/course_content.html
@@ -1,6 +1,6 @@
 <div class="mb-2">
   {{ partial "content_header_v2.html" . }}
-  <article>
+  <article class="content pt-3 mt-1">
     <main id="course-content-section">{{- .Content -}}</main>
   </article>
 </div>


### PR DESCRIPTION
### What are the relevant tickets?
No ticket

### Description (What does it do?)
I had removed `content` class from course_content.html in https://github.com/mitodl/ocw-hugo-themes/pull/1369 because I thought it didn't serve any purpose. Moreover, `content pt-3 mt-1` was causing paddings and margins to be inconsistent with other OCW pages (like regular pages, and embed video pages).

But it appears it was keeping the page fixed to a certain width - images were not allowed to be overflowed. Other than that, it was also responsible for giving anchor texts blue color. Example: https://live-qa.ocw.mit.edu/courses/ht-test-site-2024/pages/embeds-and-links/

I think more R&D is required for this, and for the time being it's okay to add back that change.

### How can this be tested?
`yarn start course ht-test-2024`
Go to different links from the left menu, see everything works as expected.


