### PR TITLE
Update Faculty Advisory Committee

### DIFF
--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -534,10 +534,6 @@
           Associate Professor of Mathematics
         </div>
         <div class="pb-4">
-          <h4>Yasheng Huang</h4>
-          Professor of International Management, Faculty Director of Action Learning, MIT Sloan
-        </div>
-        <div class="pb-4">
           <h4>Michael Short</h4>
           Associate Professor, Department of Nuclear Science and Engineering
         </div>
@@ -545,13 +541,13 @@
           <h4>Michel DeGraff</h4>
           Professor of Linguistics, Director of MIT-Haiti Initiative
         </div>
-      </div>
-      <div class="col-12 col-lg-6">
         <div class="pb-4">
           <h4>Caitlin Mueller</h4>
           Associate Professor, Department of Architecture; Associate Professor,
           Department of Civil and Environmental Engineering
         </div>
+      </div>
+      <div class="col-12 col-lg-6">
         <div class="pb-4">
           <h4>Rosalind Picard</h4>
           Professor, Program in Media Arts and Sciences; Faculty Chair, MIT


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3870.

### Description (What does it do?)
This PR updates the Faculty Advisory Committee membership on the About OCW page.

### How can this be tested?
Run `yarn start www`, and then navigate to http://localhost:3000/about. Verify that the Faculty Advisory Committee section has been updated properly.
