### PR TITLE
Update Faculty Advisory Committee order and membership

### DIFF
--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -512,8 +512,8 @@
           Professor, Department of Electrical Engineering and Computer Science
         </div>
         <div class="pb-4">
-          <h4>Robert Miller</h4>
-          Distinguished Professor of Computer Science, Education Officer for Computer Science
+          <h4>Michel DeGraff</h4>
+          Professor of Linguistics, Director of MIT-Haiti Initiative
         </div>
         <div class="pb-4">
           <h4>Gloria H. Kang</h4>
@@ -530,40 +530,36 @@
           Director of Scheller Teacher Education Program
         </div>
         <div class="pb-4">
-          <h4>Yufei Zhao</h4>
-          Associate Professor of Mathematics
-        </div>
-        <div class="pb-4">
-          <h4>Michael Short</h4>
-          Associate Professor, Department of Nuclear Science and Engineering
-        </div>
-        <div class="pb-4">
-          <h4>Michel DeGraff</h4>
-          Professor of Linguistics, Director of MIT-Haiti Initiative
+          <h4>Robert Miller</h4>
+          Distinguished Professor of Computer Science, Education Officer for Computer Science
         </div>
         <div class="pb-4">
           <h4>Caitlin Mueller</h4>
           Associate Professor, Department of Architecture; Associate Professor,
           Department of Civil and Environmental Engineering
         </div>
-      </div>
-      <div class="col-12 col-lg-6">
         <div class="pb-4">
           <h4>Rosalind Picard</h4>
           Professor, Program in Media Arts and Sciences; Faculty Chair, MIT
           Mind+Hand+Heart
         </div>
+      </div>
+      <div class="col-12 col-lg-6">
         <div class="pb-4">
-          <h4>Krishna Rajagopal (Chair)</h4>
+          <h4>Krishna Rajagopal</h4>
           Professor of Physics
-        </div>
-        <div class="pb-4">
-          <h4>Jeffrey S. Ravel</h4>
-          Professor of History
         </div>
         <div class="pb-4">
           <h4>Shannon Shen</h4>
           Graduate student, Electrical Engineering and Computer Science
+        </div>
+        <div class="pb-4">
+          <h4>Michael Short (Chair)</h4>
+          Associate Professor, Department of Nuclear Science and Engineering
+        </div>
+        <div class="pb-4">
+          <h4>Yufei Zhao</h4>
+          Associate Professor of Mathematics
         </div>
         <div class="pb-4">
           <h4 class="color-highlight-red">Ex-Officio Members</h4>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3930.

### Description (What does it do?)
This PR updates the Faculty Advisory Committee order and membership on the About OCW page.

### How can this be tested?
Run `yarn start www`, and then navigate to http://localhost:3000/about. Verify that the Faculty Advisory Committee section has been updated properly, corresponding to the list linked in the issue.
