### PR TITLE
Add SP department

### DIFF
--- a/base-theme/data/departments.json
+++ b/base-theme/data/departments.json
@@ -147,5 +147,9 @@
   "RES": {
     "title": "Supplemental Resources",
     "id": "supplemental-resources"
+  },
+  "SP": {
+    "title": "Special Programs",
+    "id": "special-programs"
   }
 }


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/3793.

### Description (What does it do?)
This PR adds a new SP (Special Programs) constant to OCW departments, allowing that to be set as a possible department value for publishing and search.

### How can this be tested?
This will primarily be tested on RC; it adds a new constant value for an additional OCW department and does not impact functionality in any other way.

### Additional Context
Related PRs:
https://github.com/mitodl/ocw-hugo-projects/pull/281
https://github.com/mitodl/open-discussions/pull/4260