### PR TITLE
Updating Ex-Officio FAC Committee order and heading size

### DIFF
--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -569,12 +569,12 @@
           Senior Associate Dean for Open Learning, Professor of History
         </div>
         <div class="pb-4">
-          <h4>Curt Newton</h4>
-          Director, MIT OpenCourseWare
-        </div>
-        <div class="pb-4">
           <h4>Eric Grimson</h4>
           Vice President for Open Learning, MIT Chancellor for Academic Advancement
+        </div>
+        <div class="pb-4">
+          <h4>Curt Newton</h4>
+          Director, MIT OpenCourseWare
         </div>
         <div class="pb-4">
           <h4>Anjali Sastry</h4>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3930.

### Description (What does it do?)
This PR updates the Ex-Officio Faculty Advisory Committee order and font size of the header.

### How can this be tested?
Run `yarn start www`, and then navigate to http://localhost:3000/about. Verify that the Faculty Advisory Committee Ex-Officio section has been updated properly, corresponding to the list linked in the issue, and that the header font size is slightly larger than before.

