### PR TITLE
Render content (body) instead of description

### DIFF
--- a/base-theme/layouts/partials/course_list.html
+++ b/base-theme/layouts/partials/course_list.html
@@ -3,6 +3,6 @@
   {{ $course_list.Title }}
 </h1>
 <div class="mb-3 col-12 col-lg-8 pb-2">
-  {{ $course_list.Description | $.RenderString }}
+  {{ $course_list.Content }}
 </div>
 <div class="course-collection-container" data-collectionid="{{- $course_list.Params.uid -}}"></div>

--- a/course-v2/layouts/lists/single.html
+++ b/course-v2/layouts/lists/single.html
@@ -6,7 +6,7 @@
 
   {{ partial "course_content.html" . }}
   <div class="mb-5">
-    <div class="mb-3">
+    <div class="mb-3 collection-description">
       {{ $bundle.Description | .RenderString }}
     </div>
     <span>

--- a/course-v2/layouts/lists/single.html
+++ b/course-v2/layouts/lists/single.html
@@ -6,7 +6,7 @@
 
   {{ partial "course_content.html" . }}
   <div class="mb-5">
-    <div class="mb-3 collection-description">
+    <div class="mb-3">
       {{ $bundle.Description | .RenderString }}
     </div>
     <span>

--- a/www/assets/css/course-collection.scss
+++ b/www/assets/css/course-collection.scss
@@ -41,7 +41,7 @@ h1.course-list-title {
     padding: 15px;
   }
 
-  .collection-description {
+  .collection-content {
     padding: 15px;
   }
 

--- a/www/layouts/collections/single.html
+++ b/www/layouts/collections/single.html
@@ -9,8 +9,8 @@
     <h1>
       {{ $collection.Title }}
     </h1>
-    <div class="mb-3 collection-description">
-      {{ $collection.Description | .RenderString }}
+    <div class="mb-3 collection-content">
+      {{ $collection.Content }}
     </div>
     {{ $collectionFeaturedList := index $collection.Params "featured-courses"}}
     {{ if (not (isset $collectionFeaturedList -1)) }}


### PR DESCRIPTION
### What are the relevant tickets?
Partial solution to https://github.com/mitodl/hq/issues/3855

### Description (What does it do?)
Renders content (body) instead of description in course list and course collections.
Doing this will allow us to have only plain `description` as page SEO for the contents, and formatted content that is rendered.

This is pertaining to the changes in: https://github.com/mitodl/ocw-hugo-projects/pull/294/

### How can this be tested?
I have also updated `ocw-www` starter configuration, and copied the data from `description` to `body` for `ocw-content-rc`.

This means you can also check the course collection here:
https://ocw-hugo-themes-www-pr-1397--ocw-next.netlify.app/collections/energy/
And inspect element to find `div class="mb-3 collection-content"` that renders the content.

Although a local test may be to get a fresh copy of `ocw-www` by deleting previous, and get fresh one  using `yarn start www`. And then stop the server.

And then modify any course collection and course list from their respective markdown files under `content` directory, modify a description to a test description, while letting the content body stay as it is.
Run `yarn start www`. See the course list and course collection. Make sure the description is not rendered, however it is used in meta tags. And make sure the content body is rendered. Importantly, make sure videos are rendered. You could also do it via RC --> add video in ocw-www (RC), publish, get a fresh copy of www, and see if renders locally fine.

you can directly look for the meta tag using inspect element:
`<meta name="description" content="Test africana studies">
`
And this is a sample course list URL:
`http://localhost:3000/course-lists/energy-minor-core-courses-5/
`
