### PR TITLE
Fix course publishing from studio without metadata (#1274)

### DIFF
--- a/course-v2/layouts/partials/course_banner.html
+++ b/course-v2/layouts/partials/course_banner.html
@@ -3,7 +3,7 @@
 <div id="course-banner" class="p-0">
   <div class="max-content-width course-banner-content m-auto py-3">
     {{ $courseData := .Site.Data.course }}
-    <span class="course-number-term-detail">{{ $courseData.primary_course_number }} | {{ $courseData.term }} {{ $courseData.year }} | {{ delimit $courseData.level ", " }}</span>
+    <span class="course-number-term-detail">{{ $courseData.primary_course_number }} | {{ $courseData.term }} {{ $courseData.year }}{{if $courseData.level }} | {{ delimit $courseData.level ", " }}{{ end }}</span>
     <br>
     <h1>
       <a


### PR DESCRIPTION
# What are the relevant tickets?
Closes [https://github.com/mitodl/ocw-studio/issues/1996](https://github.com/mitodl/ocw-studio/issues/1996)

# Description (What does it do?)
Allows to publish course without visiting metadata section

# Screenshots (if appropriate):
<img width="1440" alt="Screenshot 2023-10-20 at 2 35 51 PM" src="https://github.com/mitodl/ocw-studio/assets/88967643/0189d6ca-5594-47cf-b9cc-2bfd6912402a">

# How can this be tested?
Steps are mentioned in this Studio [PR](https://github.com/mitodl/ocw-studio/pull/2183)

<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
