### PR TITLE
added text parsing to omit html tags in length checking

### DIFF
--- a/course-v2/layouts/partials/course_description.html
+++ b/course-v2/layouts/partials/course_description.html
@@ -1,6 +1,7 @@
 {{ $courseData := .context.Site.Data.course }}
 {{ $shouldCollapseDescription := false }}
 {{ with $courseData.course_description }}
+  <!-- This matches the text inside the square brackets and keeps it, removing the actual link part. -->
   {{ $plainDescription := . | replaceRE `\[(.*?)\]\(.*?\)` `$1` }}
   {{ $shouldCollapseDescription = gt (len $plainDescription) 320 }}
 {{ end }}

--- a/course-v2/layouts/partials/course_description.html
+++ b/course-v2/layouts/partials/course_description.html
@@ -1,7 +1,7 @@
 {{ $courseData := .context.Site.Data.course }}
 {{ $shouldCollapseDescription := false }}
 {{ with $courseData.course_description }}
-  {{ $plainDescription := plainify . }}
+  {{ $plainDescription := . | replaceRE `\[(.*?)\]\(.*?\)` `$1` }}
   {{ $shouldCollapseDescription = gt (len $plainDescription) 320 }}
 {{ end }}
 <div id="course-description">

--- a/course-v2/layouts/partials/course_description.html
+++ b/course-v2/layouts/partials/course_description.html
@@ -1,7 +1,8 @@
 {{ $courseData := .context.Site.Data.course }}
 {{ $shouldCollapseDescription := false }}
 {{ with $courseData.course_description }}
-  {{ $shouldCollapseDescription = gt (len .) 320 }}
+  {{ $plainDescription := plainify . }}
+  {{ $shouldCollapseDescription = gt (len $plainDescription) 320 }}
 {{ end }}
 <div id="course-description">
   <h4 class="course-detail-title">


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4074

### Description
The description includes html tags as well. The cutoff to show expand/collapse button is `320`.  The length of text characters shown in the image below is `243` but the actual length of raw text including the html `<a>` is `351`. Due to this difference the expand/collapse button is shown here.

![image](https://github.com/mitodl/ocw-hugo-themes/assets/71461724/37bf158a-76fa-416a-a716-b54fb7b0a5cd)

**Raw text**
`6.00 Intro to CS and Programming has been retired from OCW. You can access the archived course on <a href=\"https://dspace.mit.edu/handle/1721.1/150580\" target=\"_blank\" rel=\"noopener\">DSpace – MIT’s digital repository</a>. Please see the list of&nbsp;<a href=\"https://ocw.mit.edu/collections/introductory-programming/\" target=\"_blank\" rel=\"noopener\">introductory programming courses</a> and other programming courses from recent years.`

The length should be calculated without html and only of plain text. Thus text parsing is added.

### How can this be tested?
1. Create a course on `RC` and add course description shared above.
2. in local `Hugo themes` repo, switch to `main` branch
3. start course with the following command: `yarn start course <course-on-rc>`. This should pull course from rc
4. Access course on `localhost:3000` and Identify `show more/show less` button appearing but not working properly.
5. Then switch to `umar/4074-expand-collapse-text-button-showed-on-small-text` branch in `themes` repo.
6. refresh course in browser. The button should not appear for the length.
7. Additionally, you could try adding text of different lengths and including/excluding html tags to verify that it works in all cases

