### PR TITLE
Render external resources in www theme

### DIFF
--- a/course-v2/assets/course-v2.ts
+++ b/course-v2/assets/course-v2.ts
@@ -12,7 +12,6 @@ import {
   checkAnswer,
   showSolution
 } from "./js/quiz_multiple_choice"
-import { initExternalLinkModal } from "./js/external_link_modal"
 
 export interface OCWWindow extends Window {
   initNanogallery2: () => void
@@ -28,7 +27,6 @@ $(function() {
   checkAnswer()
   showSolution()
   initCourseDrawersClosingViaSwiping()
-  initExternalLinkModal()
 })
 
 let nanogallery2Loaded = false

--- a/www/layouts/_default/baseof.html
+++ b/www/layouts/_default/baseof.html
@@ -18,6 +18,7 @@
     {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
     <!-- Appzi: Capture Insightful Feedback -->
     {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
+    {{ partial "external_link_modal" }}
     <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
 
     <!-- End Appzi -->


### PR DESCRIPTION
### What are the relevant tickets?
Task 2: https://github.com/mitodl/hq/issues/4245

### Description (What does it do?)
Render external resources in www theme by calling the `external_link_modal` partial in `www/layouts/_default/baseof.html`.

### How can this be tested?
Testing instructions given in https://github.com/mitodl/ocw-hugo-projects/pull/296
Test both PRs together.