### PR TITLE
fixed section rendering for the pages

### DIFF
--- a/course-v2/layouts/pages/section.html
+++ b/course-v2/layouts/pages/section.html
@@ -1,10 +1,10 @@
 {{ define "main" }}
 {{ partial "course_content.html" . }}
   {{ range .Pages }}
-  <div class="mb-2">
-    <article class="content pt-3 mt-1">
-      {{- .Content -}}
-    </article>
-  </div>  
+    <div class="mb-2">
+      <article class="content pt-3 mt-1">
+        {{- .Content -}}
+      </article>
+    </div>  
   {{ end }}
 {{ end }}

--- a/course-v2/layouts/pages/section.html
+++ b/course-v2/layouts/pages/section.html
@@ -1,3 +1,10 @@
 {{ define "main" }}
 {{ partial "course_content.html" . }}
+  {{ range .Pages }}
+  <div class="mb-2">
+    <article class="content pt-3 mt-1">
+      {{- .Content -}}
+    </article>
+  </div>  
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4645

### Description (What does it do?)
This fixes rendering of sections for pages in theme

### How can this be tested?
2. in local Hugo themes repo, switch to `main` branch
3. start course with the following command: `yarn start course 3.a04-fall-2008`. This should pull course from rc
4. Access course on `http://localhost:3000/pages/forging/`
5. Identify that it shows only a few of images and incomplete page after `Anvil` heading.
<img width="1086" alt="Screenshot 2024-06-26 at 4 49 02 PM" src="https://github.com/mitodl/ocw-hugo-themes/assets/71461724/6a3f157a-bd65-4686-93d8-547b91a70bfe">

6. Switch to `umar/4645-broken-image-galleries-in-legacy-courses` branch in themes repo.
7. refresh page in browser. This should complete page rendering and multiple renderings along with images should appear
<img width="693" alt="Screenshot 2024-06-26 at 4 51 33 PM" src="https://github.com/mitodl/ocw-hugo-themes/assets/71461724/39f1ba2a-0d36-4278-9252-3ef9686c4f68">
