### PR TITLE
Remove external link icon from pages

### DIFF
--- a/base-theme/assets/css/external-link.scss
+++ b/base-theme/assets/css/external-link.scss
@@ -17,7 +17,7 @@
   }
 }
 
-.external-link::after {
+.external-link.nav-link::after {
   content: "";
   display: inline-block;
   width: 12px;

--- a/base-theme/layouts/partials/head.html
+++ b/base-theme/layouts/partials/head.html
@@ -61,7 +61,7 @@
       local('Helvetica-Light'),
       url({{ partial "webpack_url.html" (dict "context" . "url" (partial "get_asset_webpack_url.html" "fonts/Helvetica-Light.ttf")) }}) format('truetype');
   }
-  .external-link::after {
+  .external-link.nav-link::after {
     background-image: url('{{ partial "webpack_url.html" (dict "context" . "url" (partial "get_asset_webpack_url.html" "images/external_link.svg")) }}'); 
   }
   </style>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4724

### Description (What does it do?)
Removes external link icon from everywhere except nav-links. This means both course-v2 and www theme, so pages, course links, course collections, etc. 


### How can this be tested?
1. Checkout to this branch
2. Use external resources in pages. Make sure to test for both cases: tick the external resource warning, and don't tick it.
3. See that external resource icon does not appear in either for pages.
4. Everything should stay same for external resources in left navbar.
5. Functionality for external resource will also stay same within pages.

To test for www theme, you will have to rebase this branch onto `ibrahim/4245/external-resource-rendering-www` and then you can test for external resource icon in pages, course lists, course collections the same way.
