### PR TITLE
Chore: Course Image Thumbnail Cleanup

### DIFF
--- a/test-sites/ocw-ci-test-course/data/course.json
+++ b/test-sites/ocw-ci-test-course/data/course.json
@@ -42,10 +42,6 @@
   ],
   "extra_course_numbers": "456",
   "primary_course_number": "123",
-  "course_image_thumbnail": {
-    "content": "5388b0c3-c599-4c42-8a3c-f89beed7c154",
-    "website": "ocw-ci-test-course"
-  },
   "learning_resource_types": [
     "Activity Assignments",
     "Exams with Solutions"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3132

### Description (What does it do?)
As we removed the `course_image_thumbnail` field in `ocw-hugo-projects` (https://github.com/mitodl/ocw-hugo-projects/pull/297), this PR cleans up the field from test course.

### How can this be tested?
There isn't any specific way to test this. While it is a part of the test course, there is no test against `course_image_thumbnail`. You can check the logs of the checks passed on the tests in this PR.
