### PR TITLE
Remove RES from departments.json

### DIFF
--- a/base-theme/data/departments.json
+++ b/base-theme/data/departments.json
@@ -144,10 +144,6 @@
     "title": "Physics",
     "id": "physics"
   },
-  "RES": {
-    "title": "Supplemental Resources",
-    "id": "supplemental-resources"
-  },
   "SP": {
     "title": "Special Programs",
     "id": "special-programs"

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -161,7 +161,11 @@ pre {
 }
 
 .course-detail-section {
-  margin-bottom: 40px;
+  margin-bottom: 24px;
+}
+
+.course-detail-section:last-child {
+  margin-bottom: 0;
 }
 
 .course-detail-title {

--- a/course-v2/layouts/partials/course_info.html
+++ b/course-v2/layouts/partials/course_info.html
@@ -23,18 +23,21 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
             "showCollapse" $inPanel) }}
           </div>
         </div>
-        {{ end }} {{ with $courseData.department_numbers }}
-        <div class="mt-4">
+        {{ end }}
+        {{ with $courseData.department_numbers }}
           {{ $departments := partial "get_departments.html" . }}
-          <h5 class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
-            Departments
-          </h5>
-          <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
-            {{ partial "partial_collapse_list.html" (dict "list" $departments
-            "id" "departments" "key" "title" "klass" "course-info-department"
-            "useLinks" true) }}
-          </div>
-        </div>
+          {{ if $departments }}
+            <div class="mt-4">
+              <h5 class="{{ if $inPanel }}panel-course-info-title {{ else }} text-muted {{ end }}">
+                Departments
+              </h5>
+              <div class="course-info-content {{ if $inPanel }}panel-course-info-text{{ end }}">
+                {{ partial "partial_collapse_list.html" (dict "list" $departments
+                "id" "departments" "key" "title" "klass" "course-info-department"
+                "useLinks" true) }}
+              </div>
+            </div>
+          {{ end }}
         {{ end }} 
         {{ if $inPanel }}
         <div class="mt-4">

--- a/course-v2/layouts/partials/get_departments.html
+++ b/course-v2/layouts/partials/get_departments.html
@@ -1,9 +1,9 @@
 {{ $departments := slice }}
 {{ range . }}
-    {{ $department := index site.Data.departments . }}
-    {{ if $department }}
-        {{ $department := merge $department (dict "url" (partial "get_search_url.html" (dict "key" "department_numbers" "value" $department.title))) }}
-        {{ $departments = $departments | append $department }}
-    {{ end }}
+  {{ $department := index site.Data.departments . }}
+  {{ if $department }}
+    {{ $department := merge $department (dict "url" (partial "get_search_url.html" (dict "key" "department_numbers" "value" $department.title))) }}
+    {{ $departments = $departments | append $department }}
+  {{ end }}
 {{ end }}
 {{ return $departments }}

--- a/course-v2/layouts/partials/get_departments.html
+++ b/course-v2/layouts/partials/get_departments.html
@@ -1,7 +1,9 @@
 {{ $departments := slice }}
 {{ range . }}
-{{ $department := index site.Data.departments . }}
-{{ $department := merge $department (dict "url" (partial "get_search_url.html" (dict "key" "department_numbers" "value" $department.title))) }}
-{{ $departments = $departments | append $department }}
+    {{ $department := index site.Data.departments . }}
+    {{ if $department }}
+        {{ $department := merge $department (dict "url" (partial "get_search_url.html" (dict "key" "department_numbers" "value" $department.title))) }}
+        {{ $departments = $departments | append $department }}
+    {{ end }}
 {{ end }}
 {{ return $departments }}

--- a/course-v2/layouts/partials/title.html
+++ b/course-v2/layouts/partials/title.html
@@ -7,7 +7,7 @@
   {{- $titleArray = $titleArray | append $courseData.course_title -}}
   {{- if $courseData.department_numbers -}}
     {{ $departments := partial "get_departments.html" $courseData.department_numbers }}
-    {{- if gt (len $departments) 0 -}}
+    {{- if $departments -}}
       {{- $titleArray = $titleArray | append (index $departments 0).title -}}
     {{- end -}}
   {{- end -}}

--- a/course-v2/layouts/partials/title.html
+++ b/course-v2/layouts/partials/title.html
@@ -7,7 +7,9 @@
   {{- $titleArray = $titleArray | append $courseData.course_title -}}
   {{- if $courseData.department_numbers -}}
     {{ $departments := partial "get_departments.html" $courseData.department_numbers }}
-    {{- $titleArray = $titleArray | append (index $departments 0).title -}}
+    {{- if gt (len $departments) 0 -}}
+      {{- $titleArray = $titleArray | append (index $departments 0).title -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- $titleArray = $titleArray | append $.Site.Title -}}


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/4855

### Description (What does it do?)
This PR removes `RES` from `departments.json` and adds conditional rendering for departments.

### How can this be tested?
1. Checkout to this branch.
2. `yarn start course ibrahims-cat-course`. This course has 3 departments, including `RES`: https://live-qa.ocw.mit.edu/courses/108-ibrahims-cat-course-spring-2023/
3. Go to http://localhost:3000/ .It will show only 2 of them locally.
4. `yarn start course res.14-002-spring-2011` . This course has no department.
5. Go to localhost:3000. `Departments` heading should no longer be there.
6. You should also check for department in OG title. Go to `http://localhost:3000/` and inspect element, find the meta tag that looks like this: `<meta property="og:title" content="ibrahims-cat-course | Civil and Environmental Engineering | MIT OpenCourseWare">` 
7. Without any department, it looks like this: `<meta property="og:title" content="Abdul Latif Jameel Poverty Action Lab Executive Training: Evaluating Social Programs 2011 | MIT OpenCourseWare | Free Online Course Materials">`
8. Another place where `departments` are shown is the `Course info` panel on right, when you visit any page.
