### PR TITLE
Remove broken link from Educator page

### DIFF
--- a/www/layouts/educator/section.html
+++ b/www/layouts/educator/section.html
@@ -197,13 +197,6 @@
                 <a href="/contact/">Ask a question</a> about reusing OER
                 from OCW in my teaching context
               </p>
-              <p class="text">
-                <a
-                  href="https://jwel.mit.edu/assets/video/getting-started-open-educational-resources-oer"
-                  target="_blank"
-                  >Review the basics of teaching with OER</a
-                >
-              </p>
             </div>
           </div>
           <div class="col-lg-6">


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4757.

### Description (What does it do?)
This PR removes a broken link from the Educator page, as indicated in the issue description.

### How can this be tested?
Run `yarn start www`, and then navigate to `http://localhost:3000/educator/`. Verify that the link with the text `Review the basics of teaching with OER` under the heading `How can we help you use OER from MIT OpenCourseWare?` has been removed.