### PR TITLE
Updated course card links to have trailing "/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ at the RC instances and temporarily disable CORS in your browser.
 
 ### CORS
 
-The search page at `/search` uses the `open-discussions` search API to source
+The search page at `/search/` uses the `open-discussions` search API to source
 results. Running this locally and populating it with results can be tedious,
 so it's often easier to just point your local website at an already running
 version of the search API. In order for this to work properly, you will need

--- a/base-offline/layouts/partials/get_search_url.html
+++ b/base-offline/layouts/partials/get_search_url.html
@@ -1,2 +1,2 @@
 {{ $baseUrl := partial "static_api_base_url.html" }}
-{{ return print (strings.TrimSuffix "/" $baseUrl) "/search?" (querify (index site.Data.search_query_keys .key) .value) }}
+{{ return print (strings.TrimSuffix "/" $baseUrl) "/search/?" (querify (index site.Data.search_query_keys .key) .value) }}

--- a/base-theme/layouts/partials/course_carousel_card.html
+++ b/base-theme/layouts/partials/course_carousel_card.html
@@ -7,6 +7,11 @@
 {{ $firstThreeCourseTopics := partial "course_cards_topics_list.html" $courseTopics | default slice }}
 {{ $isMobile := (eq .itemsInCarousel 1) }}
 
+{{ $urlPath := .urlPath }}
+{{ if not (strings.HasSuffix $urlPath "/") }}
+  {{ $urlPath = printf "%s/" $urlPath }}
+{{ end }}
+
 {{ $modulo := (mod .index .itemsInCarousel) }}
 {{ $group := (div .index .itemsInCarousel) }}
 {{ if eq $modulo 0 }}
@@ -14,7 +19,7 @@
 {{ end }}
 <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 .itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
   <div class="course-card card bg-white">
-    <a href="{{ partial "site_root_url.html" .urlPath }}" aria-hidden="true" tabindex="-1">
+    <a href="{{ partial "site_root_url.html" $urlPath }}" aria-hidden="true" tabindex="-1">
       <img src="{{ partial "resource_url.html" (dict "context" . "url" $courseImageSrc) }}" alt=""/>
     </a>
     <div class="course-card-content pt-1 px-3 pb-3">
@@ -23,7 +28,7 @@
       </div>
       <div class="course-card-title pt-1">
         <div class="h5">
-          <a href="{{ partial "site_root_url.html" .urlPath }}">{{ $courseTitle }}</a>
+          <a href="{{ partial "site_root_url.html" $urlPath }}">{{ $courseTitle }}</a>
         </div>
       </div>
       {{ with $courseInstructors }}

--- a/base-theme/layouts/partials/extraheader.html
+++ b/base-theme/layouts/partials/extraheader.html
@@ -1,7 +1,7 @@
 {{ define "extraheader" }}
   {{ $renderSearchIcon := index .Params "renderSearchIcon" | default true}}
   {{ if $renderSearchIcon}}
-    <a class="nav-link search-icon text-white pr-6" href="/search">
+    <a class="nav-link search-icon text-white pr-6" href="/search/">
       <i class="material-icons">search</i>
     </a>
   {{end}}

--- a/base-theme/layouts/partials/get_search_url.html
+++ b/base-theme/layouts/partials/get_search_url.html
@@ -1,1 +1,1 @@
-{{ return print "/search?" (querify (index site.Data.search_query_keys .key) .value) }}
+{{ return print "/search/?" (querify (index site.Data.search_query_keys .key) .value) }}

--- a/tests-e2e/ocw-ci-test-course/homepage.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/homepage.spec.ts
@@ -59,7 +59,7 @@ test.describe("Course info", () => {
       })
       const urls = hrefs.map(href => new URL(href))
       expect(urls.map(url => url.search)).toEqual(expected.searchParams)
-      expect(urls.every(url => url.pathname === "/search")).toBe(true)
+      expect(urls.every(url => url.pathname === "/search/")).toBe(true)
     })
   })
 })

--- a/www/layouts/educator/section.html
+++ b/www/layouts/educator/section.html
@@ -147,7 +147,7 @@
               <p class="text">
                 <b>How would you like to discover OER for your teaching context?</b>
               </p>
-              <p class="text"><a href="/search">Browse</a> OER by topic or departments</p>
+              <p class="text"><a href="/search/">Browse</a> OER by topic or departments</p>
               <p class="text">
                 Find lecture videos on
                 <a href="https://www.youtube.com/c/mitocw" target="_blank">OCW’s YouTube channel</a>

--- a/www/layouts/home.html
+++ b/www/layouts/home.html
@@ -21,7 +21,7 @@
         Discover courses, materials, &amp; teaching resources
       </div>
       <div class="w-100 d-flex align-items-center search-box-wrapper">
-        <form action="/search" method="GET" class="home-search-box">
+        <form action="/search/" method="GET" class="home-search-box">
           <div class="d-flex flex-column flex-md-row p-2 p-md-0">
             <input
               class="w-100"
@@ -36,14 +36,14 @@
               <button type="submit" class="submit w-50 mr-2 btn font-weight-bold px-3 btn-primary">
                 Search
               </button>
-              <a class="btn explore font-weight-bold w-50 ml-2 px-3 btn-primary justify-content-center" href="/search">
+              <a class="btn explore font-weight-bold w-50 ml-2 px-3 btn-primary justify-content-center" href="/search/">
                 Explore
               </a>
             </div>
           </div>
         </form>
         <span class="or font-weight-bold md-and-above-only">OR</span>
-        <a class="btn explore font-weight-bold px-3 btn-primary md-and-above-only" href="/search">
+        <a class="btn explore font-weight-bold px-3 btn-primary md-and-above-only" href="/search/">
           Explore
         </a>
       </div>

--- a/www/layouts/partials/extra_metadata.html
+++ b/www/layouts/partials/extra_metadata.html
@@ -1,3 +1,3 @@
 
 {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-<meta property="og:image" content="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png" />
+<meta property="og:image" content="https://{{- $sitemapDomain -}}{{- partial "get_asset_webpack_url.html" "images/ocw_logo_white_on_black.png" -}}" />

--- a/www/layouts/partials/extra_metadata.html
+++ b/www/layouts/partials/extra_metadata.html
@@ -1,3 +1,3 @@
 
 {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-<meta property="og:image" content="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png" data-rh="true" />
+<meta property="og:image" content="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png" />

--- a/www/layouts/partials/extra_metadata.html
+++ b/www/layouts/partials/extra_metadata.html
@@ -1,3 +1,3 @@
 
 {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-<meta property="og:image" content="https://{{- $sitemapDomain -}}{{- partial "get_asset_webpack_url.html" "images/ocw_logo_white_on_black.png" -}}" />
+<meta property="og:image" content="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png" data-rh="true" />


### PR DESCRIPTION
### What are the relevant tickets?
fixes https://github.com/mitodl/ocw-hugo-themes/issues/1210

### Description (What does it do?)
Add trailing slash "/" to search and course links.

### Screenshots (if appropriate):

### How can this be tested?
- Inspect the course link in card at homepage, it should have trailing "/".