### PR TITLE
Umar/4645 broken image galleries in legacy courses

### DIFF
--- a/course-v2/layouts/pages/section.html
+++ b/course-v2/layouts/pages/section.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 {{ partial "course_content.html" . }}
-  {{ if not .Params.show_section_page }}
+  {{ if .Params.show_section_pages }}
     {{ range .Pages }}
       <div class="mb-2">
         <article class="content pt-3 mt-1">

--- a/course-v2/layouts/pages/section.html
+++ b/course-v2/layouts/pages/section.html
@@ -1,10 +1,12 @@
 {{ define "main" }}
 {{ partial "course_content.html" . }}
-  {{ range .Pages }}
-    <div class="mb-2">
-      <article class="content pt-3 mt-1">
-        {{- .Content -}}
-      </article>
-    </div>  
+  {{ if not .Params.show_section_page }}
+    {{ range .Pages }}
+      <div class="mb-2">
+        <article class="content pt-3 mt-1">
+          {{- .Content -}}
+        </article>
+      </div>  
+    {{ end }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/4645

### Description (What does it do?)
This adds conditional rendering of sections for pages in theme

### How can this be tested?
1. in local Hugo themes repo, switch to `main` branch
2. start course with the following command: `yarn start course 12.108-fall-2004`. This should pull course from rc
3. Access course page on `http://localhost:3000/pages/image-gallery/`
4. Identify that it has no content under the table.
<img width="1680" alt="Screenshot 2024-08-13 at 4 06 11 PM" src="https://github.com/user-attachments/assets/6d53c7ff-d9ef-4a86-9753-e22bbd533c10">

5. Switch to `umar/4645-broken-image-galleries-in-legacy-courses` branch in themes repo.
6. In you local copy of course edit the file `12.108-fall-2004/content/pages/image-gallery/_index.md` and add `show_section_pages: true` in the front matter.
<img width="388" alt="Screenshot 2024-08-13 at 4 17 19 PM" src="https://github.com/user-attachments/assets/3317c87f-46a2-42ee-bbf7-896730fce66b">

7. Refresh page in browser. This should add the summary of pages under the table.
<img width="1680" alt="Screenshot 2024-08-13 at 4 01 31 PM" src="https://github.com/user-attachments/assets/d65cf740-21f9-4b6b-8feb-8a6a72fe6211">