### PR TITLE
Add mit_learn_topics field in data.json

### DIFF
--- a/course-v2/layouts/index.coursedata.json
+++ b/course-v2/layouts/index.coursedata.json
@@ -29,6 +29,7 @@
   "department_numbers": {{- $courseData.department_numbers | jsonify -}},
   "learning_resource_types": {{- $courseData.learning_resource_types | jsonify -}},
   "topics": {{- $courseData.topics | jsonify -}},
+  "mit_learn_topics": {{- $courseData.mit_learn_topics | jsonify -}},
   "primary_course_number": {{- $courseData.primary_course_number | jsonify -}},
   "extra_course_numbers":  {{- $courseData.extra_course_numbers | jsonify -}},
   "term":  {{- $courseData.term | jsonify -}},

--- a/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
+++ b/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
@@ -48,6 +48,15 @@
       "Quantum Mechanics"
     ]
   ],
+  "mit_learn_topics": [
+    [
+      "Art, Design & Architecture"
+    ],
+    [
+      "Business & Management",
+      "Business Analytics"
+    ]
+  ],
   "primary_course_number": "123",
   "extra_course_numbers": "456",
   "term": "Fall",

--- a/test-sites/ocw-ci-test-course/data/course.json
+++ b/test-sites/ocw-ci-test-course/data/course.json
@@ -17,6 +17,15 @@
       "Quantum Mechanics"
     ]
   ],
+  "mit_learn_topics": [
+    [
+      "Art, Design & Architecture"
+    ],
+    [
+      "Business & Management",
+      "Business Analytics"
+    ]
+  ],
   "legacy_uid": "",
   "instructors": {
     "content": [


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5223

### Description (What does it do?)
Adds `mit_learn_topics` field in `data.json` to be ingested by MIT Learn.


### How can this be tested?
This PR will be tested along with https://github.com/mitodl/ocw-hugo-projects/pull/305. Please refer to the testing instructions mentioned there.
