### PR TITLE
Include hide_download in data.json

### DIFF
--- a/course-v2/layouts/index.coursedata.json
+++ b/course-v2/layouts/index.coursedata.json
@@ -13,7 +13,7 @@
   "instructors": [
   {{- range $index, $instructor := $instructors -}}
   {{- if $index -}}
-    ,  
+    ,
   {{- end -}}
   {
     "first_name":  {{- $instructor.first_name | jsonify -}},
@@ -34,6 +34,7 @@
   "term":  {{- $courseData.term | jsonify -}},
   "year":  {{- $courseData.year | jsonify -}},
   "level":  {{- $courseData.level | jsonify -}},
+  "hide_download": {{- $courseData.hide_download | jsonify -}},
   "image_src": {{- $courseImageUrl | jsonify -}},
   "course_image_metadata": {{- $courseImageMetadata.Params | jsonify -}}
 }

--- a/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
+++ b/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
@@ -56,6 +56,7 @@
     "Graduate",
     "Undergraduate"
   ],
+  "hide_download": false,
   "image_src": "/courses/ocw-ci-test-course/example_jpg.jpg",
   "course_image_metadata": {
     "body": "",

--- a/www/assets/js/LearningResources.ts
+++ b/www/assets/js/LearningResources.ts
@@ -81,6 +81,7 @@ export interface CourseJSON {
   term: string
   year: string
   level: Level[] | null
+  hide_download: boolean
   image_src: string
   course_image_metadata: CourseImageMetadata
 }

--- a/www/assets/js/factories/search.ts
+++ b/www/assets/js/factories/search.ts
@@ -191,6 +191,7 @@ export const makeCourseJSON = (): CourseJSON => ({
   department_numbers:      [casual.word, casual.word],
   learning_resource_types: [casual.word, casual.word],
   year:                    String(casual.year),
+  hide_download:           casual.boolean,
   course_image_metadata:   {
     file:           casual.string,
     image_metadata: {


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5126

### Description (What does it do?)
Adds `hide_download` to the `data.json` template for courses

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Run `yarn start course res.15-005-spring-2019-2`
- Go to http://localhost:3000/data.json, it should include `"hide_download": true`
- Run `yarn start course res.10-001-spring-2016`
- Go to http://localhost:3000/data.json, it should include `"hide_download": false`
