### PR TITLE
added condition to include nav item only if url is not empty

### DIFF
--- a/course-v2/layouts/partials/nav_item.html
+++ b/course-v2/layouts/partials/nav_item.html
@@ -4,6 +4,12 @@
 {{ $hasChildren := .menuItem.HasChildren }}
 {{ $url := partial "nav_url.html" . }}
 {{ $linkedPage := site.GetPage .menuItem.PageRef }}
+{{ $hasOneValidChild := false }}
+
+{{ if $hasChildren }}
+  {{ $hasOneValidChild = partial "nav_item_has_child.html" .menuItem.Children }}
+{{ end }}
+
 
 <li class="course-nav-list-item">
   <div class="course-nav-parent d-flex flex-direction-row align-items-center justify-content-between">
@@ -17,15 +23,15 @@
             )
           )
         -}}
-      {{ else if $url }}
+      {{ else if or $url $hasOneValidChild }}
         <a class="text-dark nav-link"
           data-uuid="{{ .menuItem.Identifier }}"
-          href="{{ $url }}">
+          {{ if $url }} href="{{ $url }}" {{ end }}>
           {{ .menuItem.Name }}
         </a>
       {{ end }}
     </span>
-    {{ if .menuItem.HasChildren }}
+    {{ if $hasOneValidChild }}
     <button
       class="course-nav-section-toggle"
       type="button"

--- a/course-v2/layouts/partials/nav_item.html
+++ b/course-v2/layouts/partials/nav_item.html
@@ -25,7 +25,7 @@
       {{ else if or $url $hasOneValidChild }}
         <a class="text-dark nav-link"
           data-uuid="{{ .menuItem.Identifier }}"
-          {{ if $url }} href="{{ $url }}" {{ end }}>
+          {{ if $url }} href="{{ $url }}" {{ else }} href="#" {{ end }}>
           {{ .menuItem.Name }}
         </a>
       {{ end }}
@@ -46,7 +46,7 @@
     </button>
     {{ end }}
   </div>
-  {{ if or (not $hasParent) $hasChildren }}
+  {{ if or (and (not $hasParent) $url) $hasOneValidChild }}
   <span class="medium-and-below-only"><hr/></span>
   {{ end }}
   <ul

--- a/course-v2/layouts/partials/nav_item.html
+++ b/course-v2/layouts/partials/nav_item.html
@@ -17,7 +17,7 @@
             )
           )
         -}}
-      {{ else }}
+      {{ else if $url }}
         <a class="text-dark nav-link"
           data-uuid="{{ .menuItem.Identifier }}"
           href="{{ $url }}">

--- a/course-v2/layouts/partials/nav_item.html
+++ b/course-v2/layouts/partials/nav_item.html
@@ -10,7 +10,6 @@
   {{ $hasOneValidChild = partial "nav_item_has_child.html" .menuItem.Children }}
 {{ end }}
 
-
 <li class="course-nav-list-item">
   <div class="course-nav-parent d-flex flex-direction-row align-items-center justify-content-between">
     <span class="course-nav-text-wrapper">

--- a/course-v2/layouts/partials/nav_item_has_child.html
+++ b/course-v2/layouts/partials/nav_item_has_child.html
@@ -1,11 +1,18 @@
-<!-- nav_item_has_child.html -->
 {{ $hasOneValidChild := false }}
 
 {{ range . }}
   {{ $url := partial "nav_url.html" (dict "menuItem" .) }}
-  {{ if $url }}
-    {{ $hasOneValidChild = true }}
-    {{ break }}
+
+  {{ if .HasChildren }}
+    {{ $hasOneValidChild = partial "nav_item_has_child.html" .Children }}
+    {{ if $hasOneValidChild }}
+      {{ break }}
+    {{ end }}
+  {{ else }}
+    {{ if $url }}
+      {{ $hasOneValidChild = true }}
+      {{ break }}
+    {{ end }}
   {{ end }}
 {{ end }}
 

--- a/course-v2/layouts/partials/nav_item_has_child.html
+++ b/course-v2/layouts/partials/nav_item_has_child.html
@@ -1,0 +1,12 @@
+<!-- nav_item_has_child.html -->
+{{ $hasOneValidChild := false }}
+
+{{ range . }}
+  {{ $url := partial "nav_url.html" (dict "menuItem" .) }}
+  {{ if $url }}
+    {{ $hasOneValidChild = true }}
+    {{ break }}
+  {{ end }}
+{{ end }}
+
+{{ return $hasOneValidChild }}


### PR DESCRIPTION
### What are the relevant tickets?
Closes  https://github.com/mitodl/hq/issues/5358

### Description (What does it do?)
Menu items can be links to pages or external resource links. On rendering resources are pulled from DB. If the linked resource has been deleted, the menu item still renders and is broken. On click, it does not show any error but doesn't navigate anywhere either. 

This PR aims to conditionally render menu items if it has a valid URL field. If deleted the related field is empty.

### How can this be tested?
1. Create a test course on `RC`, add an External resource to its Menu, and Publish.
2. In your local themes repo, switch to branch `main`
3. Run command `yarn start course <course-name-on-rc>`, this should pull course from RC
4. Browse the pulled course on `localhost:3000` and validate the menu item is added and navigable
5. After validation, go to the admin panel and delete the related External resource without removing it from menu
6. Publish the course. Remove the local copy of course and repeat steps 3 and 4. The nav item will be there but not navigable.
7. In your local themes repo, switch to branch `umar/5358-allow-studio-user-to-delete-pages`. The broken nav item will disappear.
