### PR TITLE
Update text on Download Course page

### DIFF
--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -17,8 +17,12 @@
       </div>
       <div class="col-12 col-md-9">
         This package contains the same content as the online version of the course
-        {{- if $containsVideos }}, <em>except for the audio/video materials</em>. These can be downloaded below{{ end }}.
-        For help downloading and using course materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
+        {{- if $containsVideos }}, <em>except for the audio/video materials</em>, which can be downloaded using the links below{{ end }}. Once downloaded, follow the steps below.
+        For more help using these materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
+        <ol>
+          <li>To open the homepage, click on the <strong>index.html</strong> file.</li>
+          <li>To find the course resource files such as PDFs, open the <strong>static_resources</strong> folder.</li>
+        </ol>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5773.

### Description (What does it do?)
This PR updates the text on the download course page, as indicated below.

If the course contains video materials, the text is:

This package contains the same content as the online version of the course, except for the audio/video materials, which can be downloaded using the links below. Once downloaded, follow the steps below. For more help using these materials, read our [FAQs](https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-).
1. To open the homepage, click on the index.html file.
1. To find the course resource files such as PDFs, open the static_resources folder.

Otherwise, the text is

This package contains the same content as the online version of the course. Once downloaded, follow the steps below. For more help using these materials, read our [FAQs](https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-).
1. To open the homepage, click on the index.html file.
1. To find the course resource files such as PDFs, open the static_resources folder.

### How can this be tested?
Run `yarn state <course_id>` for a course that has videos, such as `18.01-fall-2006` and for a course that does not have videos, such as `21w.758-spring-2013`. Navigate to `http://localhost:3000/download/` and verify that the text has been updated.

