### PR TITLE
Fix external links on mobile

### DIFF
--- a/base-theme/assets/js/external_link_modal.ts
+++ b/base-theme/assets/js/external_link_modal.ts
@@ -1,8 +1,12 @@
+import { MOBILE_COURSE_NAV_DRAWER_ID } from "../../../course-v2/assets/js/mobile_course_drawers"
+
 export const EXTERNAL_LINK_MODAL_ID = "external-link-modal"
 
 export function initExternalLinkModal() {
   $("a.external-link-warning").on("click", event => {
     event.preventDefault()
+
+    $(`#${MOBILE_COURSE_NAV_DRAWER_ID}`).trigger("offcanvas.close")
 
     const targetUrl = $(event.currentTarget).attr("href")
     if (!targetUrl) {

--- a/course-v2/assets/js/external_link_modal.ts
+++ b/course-v2/assets/js/external_link_modal.ts
@@ -1,8 +1,0 @@
-import { MOBILE_COURSE_NAV_DRAWER_ID } from "./mobile_course_drawers"
-
-export function initExternalLinkModal() {
-  $("a.external-link-warning").on("click", _ => {
-    // Close the drawer in mobile view before showing the modal.
-    $(`#${MOBILE_COURSE_NAV_DRAWER_ID}`).trigger("offcanvas.close")
-  })
-}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6180.

### Description (What does it do?)
This PR fixes an issue with opening external links caused by two conflicting external link modals (for mobile and non-mobile).

### How can this be tested?
Run `yarn start course 8.02-spring-2019` (or any other course with external links in the menu). Verify that the links work properly in mobile view. This should be tested with multiple browsers, including Chrome.