### PR TITLE
Update download page text when no resources found

### DIFF
--- a/course-v2/layouts/partials/resources_header.html
+++ b/course-v2/layouts/partials/resources_header.html
@@ -3,9 +3,7 @@
 {{- $downloadCourseUrl := partial "get_course_download_url.html" . -}}
 {{- $noResourcesFound := partial "show_no_resources_found.html" (dict "context" . "taxonomy" "learning_resource_types") -}}
 {{- $containsVideos := partial "contains_videos.html" (dict "context" . "taxonomy" "learning_resource_types") -}}
-{{- if $hideDownload -}}
-  {{ partial "no_resources_found.html" }}
-{{- else -}}
+{{- if not $hideDownload -}}
 <div class="mb-2">
   <h2>Download</h2>
   <div class="hide-offline download-course-container background-color-light-grey p-3">
@@ -16,6 +14,12 @@
         </a>
       </div>
       <div class="col-12 col-md-9">
+        {{- if $noResourcesFound -}}
+        This package contains the same content as the online version of the course. Once downloaded, to open the homepage, click on the <strong>index.html</strong> file.
+        For more help using these materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
+      </div>
+    </div>
+        {{- else -}}
         This package contains the same content as the online version of the course
         {{- if $containsVideos }}, <em>except for the audio/video materials</em>, which can be downloaded using the links below{{ end }}. Once downloaded, follow the steps below.
         For more help using these materials, read our {{ partial "link.html" (dict "href" $zenDeskUrl "text" "FAQs" "target" "_blank") }}.
@@ -25,6 +29,7 @@
         </ol>
       </div>
     </div>
+    {{- end -}}
   </div>
   <div class="alert-warning p-2 limited-pointer-only">
     <strong>Note: </strong>
@@ -32,7 +37,4 @@
     We recommend using a computer with the downloaded course package.
   </div>
 </div>
-{{- if $noResourcesFound -}}
-  {{ partial "no_resources_found.html" }}
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6189 and closes https://github.com/mitodl/hq/issues/6190.

### Description (What does it do?)
This PR makes two changes to the Course Download page when no resources are found for a course:
1. The `No Resources Found.` message is not displayed.
2. The message next to the `Download course` button is updated to the following:

**This package contains the same content as the online version of the course. Once downloaded, to open the homepage, click on the index.html file. For more help using these materials, read our [FAQs](https://mitocw.zendesk.com/hc/en-us/articles/4414681093659-I-have-downloaded-an-MIT-OpenCourseWare-course-but-I-can-t-access-the-materials-How-do-I-get-started-).**

### How can this be tested?

Run `yarn start course <course name>` for a course with resources, such as `21w.758-spring-2013` and then repeat for a course without resources, such as `10.01-spring-2020`. Confirm that the Download Course page at `localhost:3000/download` has been updated for courses with no resources.

