### PR TITLE
fixed context for the resource_url partial

### DIFF
--- a/base-theme/layouts/partials/get_resource_download_link.html
+++ b/base-theme/layouts/partials/get_resource_download_link.html
@@ -1,4 +1,4 @@
-{{- $resourceParams := . -}}
+{{- $resourceParams := .Params -}}
 {{- $downloadLink := $resourceParams.file | default nil -}}
 
 {{ if and (eq $downloadLink nil) (eq $resourceParams.resourcetype "Video") }}

--- a/base-theme/layouts/partials/resource_body_v2.html
+++ b/base-theme/layouts/partials/resource_body_v2.html
@@ -1,4 +1,4 @@
-{{ $downloadableLink := partial "get_resource_download_link.html" .Params }}   
+{{ $downloadableLink := partial "get_resource_download_link.html" . }}   
 <div class="resource-page-container">
   {{- if ne .Params.resourcetype "Video" }}
     {{- if .Content -}}

--- a/course-v2/layouts/partials/resource_list_item.html
+++ b/course-v2/layouts/partials/resource_list_item.html
@@ -1,4 +1,4 @@
-{{ $downloadableLink := partial "get_resource_download_link.html" .params }}
+{{ $downloadableLink := partial "get_resource_download_link.html" . }}
 <div class="resource-item resource-list-page">
   <div class="row">
     <div class="d-inline-flex">


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/5111

### Description (What does it do?)
The download button for resources in offline courses compiles a different relative URL than the preview URL. As a result, downloading the resources results in a 404 error. 

The issue lies with the context changes for the partial that compiles the resource URL for the download button.

### How can this be tested?
This PR would be tested properly in RC but following the details reported in https://github.com/mitodl/hq/issues/5111 the change can be viewed as following in the local environment:

1. Go to your local themes repository and switch to the `master` branch
2. Run the following command after adding the path to your local projects repository
`yarn start course 1.012-spring-2002 --config <path-to-ocw-hugo-projects>/ocw-course-v2/config-offline.yaml`
3. Go to `http://localhost:3000/resources/bostonpeninsulasmall/`
4. Inspect the download button element and it should show the incorrect href starting with `./static_resources/` as shown in the picture below:
<img width="1436" alt="Screenshot 2025-01-07 at 6 58 17 PM" src="https://github.com/user-attachments/assets/252aec2a-6d58-485c-b188-5d5ee647fa8b" />

5. Switch to this branch in your local themes repository
6. The href should be updated to `../../static_resources/` as shown in picture below:
<img width="1436" alt="Screenshot 2025-01-07 at 7 01 34 PM" src="https://github.com/user-attachments/assets/bd1fbaba-8896-4d85-8698-6005293132c2" />
