### PR TITLE
Update Faculty Advisory Committee membership

### DIFF
--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -512,8 +512,16 @@
           Professor, Department of Electrical Engineering and Computer Science
         </div>
         <div class="pb-4">
+          <h4>Gerardo Berlanga Molina</h4>
+          Undergraduate student, Mechanical Engineering
+        </div>
+        <div class="pb-4">
           <h4>Michel DeGraff</h4>
           Professor of Linguistics, Director of MIT-Haiti Initiative
+        </div>
+        <div class="pb-4">
+          <h4>Stephanie Han</h4>
+          Undergraduate student, Finance
         </div>
         <div class="pb-4">
           <h4>Gloria H. Kang</h4>
@@ -525,6 +533,10 @@
           Sciences
         </div>
         <div class="pb-4">
+          <h4>R. Scott Kemp</h4>
+          Associate Professor of Nuclear Science and Engineering; Director, MIT Laboratory for Nuclear Security and Policy
+        </div>
+        <div class="pb-4">
           <h4>Eric Klopfer</h4>
           Professor and Section Head, Comparative Media Studies/Writing;
           Director of Scheller Teacher Education Program
@@ -533,6 +545,8 @@
           <h4>Robert Miller</h4>
           Distinguished Professor of Computer Science, Education Officer for Computer Science
         </div>
+      </div>
+      <div class="col-12 col-lg-6">
         <div class="pb-4">
           <h4>Caitlin Mueller</h4>
           Associate Professor, Department of Architecture; Associate Professor,
@@ -543,8 +557,6 @@
           Professor, Program in Media Arts and Sciences; Faculty Chair, MIT
           Mind+Hand+Heart
         </div>
-      </div>
-      <div class="col-12 col-lg-6">
         <div class="pb-4">
           <h4>Krishna Rajagopal</h4>
           Professor of Physics
@@ -558,19 +570,11 @@
           Associate Professor, Department of Nuclear Science and Engineering
         </div>
         <div class="pb-4">
-          <h4>Yufei Zhao</h4>
-          Associate Professor of Mathematics
-        </div>
-        <div class="pb-4">
           <h3>Ex-Officio Members</h3>
         </div>
         <div class="pb-4">
           <h4>Christopher Capozzola</h4>
           Senior Associate Dean for Open Learning, Professor of History
-        </div>
-        <div class="pb-4">
-          <h4>Eric Grimson</h4>
-          Vice President for Open Learning, MIT Chancellor for Academic Advancement
         </div>
         <div class="pb-4">
           <h4>Curt Newton</h4>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6445.

### Description (What does it do?)
This PR updates the Faculty Advisory Committee membership on the About OCW page.

### How can this be tested?
Run `yarn start www`, and then navigate to http://localhost:3000/about. Verify that the Faculty Advisory Committee section has been updated properly with the changes in the linked issue.
