### PR TITLE
Update Faculty Advisory Committee membership

### DIFF
--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -524,10 +524,6 @@
           Undergraduate student, Finance
         </div>
         <div class="pb-4">
-          <h4>Gloria H. Kang</h4>
-          Undergraduate student, Electrical Engineering and Computer Science
-        </div>
-        <div class="pb-4">
           <h4>Nancy Kanwisher</h4>
           Professor of Cognitive Science, Department of Brain & Cognitive
           Sciences


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6481.

### Description (What does it do?)
This PR updates the Faculty Advisory Committee membership on the About OCW page.

### How can this be tested?
Run `yarn start www`, and then navigate to http://localhost:3000/about. Verify that the Faculty Advisory Committee section has been updated properly with the changes in the linked issue.