### PR TITLE
Remove invisible download link for PDF files

### DIFF
--- a/base-theme/layouts/partials/pdf_viewer.html
+++ b/base-theme/layouts/partials/pdf_viewer.html
@@ -1,13 +1,5 @@
 <div class="pdf-viewer w-100 pb-5">
-  <div class="pr-4">
-    <a class="download-link" href="{{ partial "resource_url.html" (dict "context" . "url" .Params.file) }}">
-      <div class="btn bg-link-blue text-white rounded float-right mb-3">
-        <span>DOWNLOAD</span>
-        <div class="ripple-container"></div>
-      </div>
-    </a>
-  </div>
-  <div id="pdf-wrapper"></div>
+  <div id="pdf-wrapper" class="mt-5"></div>
   <script type="text/javascript">
     window.addEventListener("load", (event) => {
       const options = {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6408

### Description (What does it do?)
There is currently an invisible download link bar for PDF resources as a bug. This PR removes it. Please refer to the ticket for screenshot of issue.

### Screenshots (if appropriate):
<img width="864" alt="image" src="https://github.com/user-attachments/assets/23fd249e-fd44-495f-a06c-b9b207c06c81" />
`mt-5` is added to keep some space between PDF resource and its viewer.

### How can this be tested?
For online theme:
1. Checkout to this branch.
2. `yarn start course 3.020-spring-2021`
3. Go to a PDF resource, e.g., http://localhost:3000/resources/mit3_020s21_pset01_pdf/
4. Check that the invisible download link is no longer present.

For offline theme:
1. Checkout to this branch.
2. `yarn build ~/path/ocw-content-rc/3.020-spring-2021/ ~/path/ocw-hugo-projects/ocw-course-v2/config-offline.yaml`
3. Go to a PDF resource, e.g., `file:///<path>/ocw-content-rc/3.020-spring-2021/dist/resources/mit3_020s21_l01/index.html`
4. Check that the invisible download link is no longer present.

