### PR TITLE
Improve accessibility for external links by adding aria-label

### DIFF
--- a/base-theme/layouts/partials/external_resource_link.html
+++ b/base-theme/layouts/partials/external_resource_link.html
@@ -5,7 +5,6 @@
 {{- $onClick := "" -}}
 {{- if $hasWarning -}}
   {{- $className = printf "%s %s" "external-link-warning" $className -}}
-  {{/* Prevents external links from being clicked before corresponding JS is fully loaded. */}}
   {{- $onClick = "event.preventDefault()" -}}
 {{- end -}}
 {{- if not (in $href "ocw.mit.edu") -}}
@@ -15,14 +14,15 @@
       "class" $className
       "onClick" $onClick
       "target" "_blank"
+      "ariaLabel" (printf "%s (opens in a new tab)" $text)
     )
   -}}
 {{- else -}}
   {{- partial "link" (dict
-    "href" $href
-    "text" $text
-    "class" .class
-    "onClick" ""
+      "href" $href
+      "text" $text
+      "class" .class
+      "onClick" ""
     )
   -}}
 {{- end -}}

--- a/base-theme/layouts/partials/external_resource_link.html
+++ b/base-theme/layouts/partials/external_resource_link.html
@@ -3,9 +3,14 @@
 {{- $hasWarning := default true .has_external_license_warning -}}
 {{- $className := printf "%s %s" "external-link" (default "" .class) -}}
 {{- $onClick := "" -}}
+{{- $ariaLabel := "" -}}
 {{- if $hasWarning -}}
   {{- $className = printf "%s %s" "external-link-warning" $className -}}
+  {{- $ariaLabel = printf "%s (opens warning dialog)" $text -}}
+  {{/* Prevents external links from being clicked before corresponding JS is fully loaded. */}}
   {{- $onClick = "event.preventDefault()" -}}
+{{- else -}}
+  {{- $ariaLabel = printf "%s (opens in a new tab)" $text -}}
 {{- end -}}
 {{- if not (in $href "ocw.mit.edu") -}}
   {{- partial "link" (dict
@@ -14,7 +19,7 @@
       "class" $className
       "onClick" $onClick
       "target" "_blank"
-      "ariaLabel" (printf "%s (opens in a new tab)" $text)
+      "ariaLabel" $ariaLabel
     )
   -}}
 {{- else -}}

--- a/base-theme/layouts/partials/link.html
+++ b/base-theme/layouts/partials/link.html
@@ -4,6 +4,7 @@
 {{- $text := .text | default "" -}}
 {{- $target := .target | default "" -}}
 {{- $onClick := .onClick | default "" -}}
+{{- $ariaLabel := .ariaLabel | default "" -}}
 {{- $stripLinkOffline := .stripLinkOffline | default false -}}
 {{- $hideLinkOffline := .hideLinkOffline | default false -}}
 {{- if $stripLinkOffline -}}
@@ -13,7 +14,7 @@
   {{- $class = print $class " hide-offline" -}}
 {{- end -}}
 {{- if or $href $name -}}
-<a {{ if $name }} name="{{ $name }}"{{ end }} {{ if $class }} class="{{ $class }}" {{ end }} {{ if $target }} target="{{ $target }}" {{ end }} {{ if $href }} href="{{ $href }}"{{ end }} {{ if $onClick }} onclick="{{ $onClick | safeJS }}" {{ end }} >{{ $text }}</a>
+<a {{ if $name }} name="{{ $name }}"{{ end }} {{ if $class }} class="{{ $class }}" {{ end }} {{ if $target }} target="{{ $target }}" {{ end }} {{ if $href }} href="{{ $href }}"{{ end }} {{ if $onClick }} onclick="{{ $onClick | safeJS }}" {{ end }} {{ if $ariaLabel }} aria-label="{{ $ariaLabel }}"{{ end }} >{{ $text }}</a>
 {{- else -}}
 <span>{{ $text }}</span>
 {{- end -}}

--- a/base-theme/layouts/partials/link.html
+++ b/base-theme/layouts/partials/link.html
@@ -14,7 +14,7 @@
   {{- $class = print $class " hide-offline" -}}
 {{- end -}}
 {{- if or $href $name -}}
-<a {{ if $name }} name="{{ $name }}"{{ end }} {{ if $class }} class="{{ $class }}" {{ end }} {{ if $target }} target="{{ $target }}" {{ end }} {{ if $href }} href="{{ $href }}"{{ end }} {{ if $onClick }} onclick="{{ $onClick | safeJS }}" {{ end }} {{ if $ariaLabel }} aria-label="{{ $ariaLabel }}"{{ end }} >{{ $text }}</a>
+<a {{ if $name }} name="{{ $name }}"{{ end }} {{ if $class }} class="{{ $class }}" {{ end }} {{ if $target }} target="{{ $target }}" {{ end }} {{ if $href }} href="{{ $href }}"{{ end }} {{ if $onClick }} onclick="{{ $onClick | safeJS }}" {{ end }}>{{ $text }}</a>
 {{- else -}}
 <span>{{ $text }}</span>
 {{- end -}}

--- a/base-theme/layouts/partials/link.html
+++ b/base-theme/layouts/partials/link.html
@@ -14,7 +14,7 @@
   {{- $class = print $class " hide-offline" -}}
 {{- end -}}
 {{- if or $href $name -}}
-<a {{ if $name }} name="{{ $name }}"{{ end }} {{ if $class }} class="{{ $class }}" {{ end }} {{ if $target }} target="{{ $target }}" {{ end }} {{ if $href }} href="{{ $href }}"{{ end }} {{ if $ariaLabel }} aria-label="{{ $ariaLabel }}" {{ end }}{{ if $onClick }} onclick="{{ $onClick | safeJS }}" {{ end }}>{{ $text }}</a>
+<a {{ if $name }} name="{{ $name }}"{{ end }} {{ if $class }} class="{{ $class }}" {{ end }} {{ if $target }} target="{{ $target }}" {{ end }} {{ if $href }} href="{{ $href }}"{{ end }} {{ if $ariaLabel }} aria-label="{{ $ariaLabel }}" {{ end }} {{ if $onClick }} onclick="{{ $onClick | safeJS }}" {{ end }}>{{ $text }}</a>
 {{- else -}}
 <span>{{ $text }}</span>
 {{- end -}}

--- a/base-theme/layouts/partials/link.html
+++ b/base-theme/layouts/partials/link.html
@@ -14,7 +14,7 @@
   {{- $class = print $class " hide-offline" -}}
 {{- end -}}
 {{- if or $href $name -}}
-<a {{ if $name }} name="{{ $name }}"{{ end }} {{ if $class }} class="{{ $class }}" {{ end }} {{ if $target }} target="{{ $target }}" {{ end }} {{ if $href }} href="{{ $href }}"{{ end }} {{ if $onClick }} onclick="{{ $onClick | safeJS }}" {{ end }}>{{ $text }}</a>
+<a {{ if $name }} name="{{ $name }}"{{ end }} {{ if $class }} class="{{ $class }}" {{ end }} {{ if $target }} target="{{ $target }}" {{ end }} {{ if $href }} href="{{ $href }}"{{ end }} {{ if $ariaLabel }} aria-label="{{ $ariaLabel }}" {{ end }}{{ if $onClick }} onclick="{{ $onClick | safeJS }}" {{ end }}>{{ $text }}</a>
 {{- else -}}
 <span>{{ $text }}</span>
 {{- end -}}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6480

### Description (What does it do?)
This PR improves the accessibility of external links by modifying the `link.html` partial to include `aria-label` attributes.

### How can this be tested?
If you have Mac, please use its VoiceOver. Otherwise only inspect the aria-label attributes in `anchor` tags.
1. Checkout to this branch.
2. `yarn start course peter-test-2024-02-20`
3. Inspect the external links in the left navbar.
