### PR TITLE
Fix: Resource List Download Icon not visible

### DIFF
--- a/course-v2/layouts/partials/resource_list.html
+++ b/course-v2/layouts/partials/resource_list.html
@@ -3,7 +3,7 @@
   {{ $hideThumbnail := .hideThumbnail}}
   {{ $hideDownloadIcon := .hideDownloadIcon}}
   {{ range $resourceToRender :=  .resourcesToRender }}
-    {{- partial "resource_list_item.html" (dict "params" . "permalink" (index $resources .resourceIndex).Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
+    {{- partial "resource_list_item.html" (dict "Params" . "permalink" (index $resources .resourceIndex).Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
   {{ end }}
 {{ end }}
 
@@ -11,7 +11,7 @@
   {{ $hideThumbnail := .hideThumbnail}}
   {{ $hideDownloadIcon := .hideDownloadIcon}}
   {{ range .resources }}
-    {{- partial "resource_list_item.html" (dict "params" .Params "permalink" .Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
+    {{- partial "resource_list_item.html" (dict "Params" .Params "permalink" .Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
   {{ end }}
 {{ end }}
 

--- a/course-v2/layouts/partials/resource_list_item.html
+++ b/course-v2/layouts/partials/resource_list_item.html
@@ -3,11 +3,11 @@
   <div class="row">
     <div class="d-inline-flex">
       <a class="resource-thumbnail"{{ if and $downloadableLink (not .hideDownloadIcon) }} href="{{- $downloadableLink -}}" target="_blank" aria-label="Download file" download{{ end }}>
-        {{ $resourceCategory := partial "get_resource_category.html" (dict "resourceType" .params.resourcetype "fileType" .params.file_type) }}
+        {{ $resourceCategory := partial "get_resource_category.html" (dict "resourceType" .Params.resourcetype "fileType" .Params.file_type) }}
         <div class="resource-type-thumbnail {{ $resourceCategory }}">
           <div class="d-flex align-self-center">{{- $resourceCategory -}}</div>
         </div>  
-        <div class="download-container{{if not .params.file_size}} pb-1{{end}}">
+        <div class="download-container{{if not .Params.file_size}} pb-1{{end}}">
           {{ if not .hideDownloadIcon }}
             <span class="download-link">
               {{ if $downloadableLink }}
@@ -18,16 +18,16 @@
                   />
               {{ end }}
             </span>
-            {{ if .params.file_size }}
+            {{ if .Params.file_size }}
               <div class="resource-list-file-size">
-                {{ partial "file_size_formatter.html" .params.file_size }}
+                {{ partial "file_size_formatter.html" .Params.file_size }}
               </div>
             {{ end }}
           {{ end }}
         </div>
       </a>
       <div class="resource-list-item-details">
-        {{ partial "resource_list_item_title.html" (dict "permalink" .permalink "title" .params.title) }}
+        {{ partial "resource_list_item_title.html" (dict "permalink" .permalink "title" .Params.title) }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
We recently changed the way params were handled in the resource list partials for this issue: https://github.com/mitodl/hq/issues/5111

As a side effect, there was an inconsistency in the params passing, due to which `$downloadLink` comes out empty and no download icon appears for resource items in resource list view. There is a case sensitivity: `params` is being passed, but `Params` is being expected.

This PR changes `params` to `Params` making sure it is consistent across different partials.

### Screenshots (if appropriate):
Before:
<img width="563" alt="image" src="https://github.com/user-attachments/assets/ca27a488-5fea-487a-8ef5-5bce330251f0" />

After:
<img width="462" alt="image" src="https://github.com/user-attachments/assets/6e78b6df-186e-4337-b7bc-b601c4aef0d6" />

### How can this be tested?
1. `yarn start course 18.06sc-fall-2011`
2. Go to http://localhost:3000/download
3. Make sure the download icon appears and works as expected! (in both list view, and individual resource page)

