### PR TITLE
Upgrade Hugo version from 0.115.4 to 0.119.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "exec-sh": "^0.4.0",
     "file-loader": "^5.0.2",
-    "hugo-bin-extended": "0.115.4",
+    "hugo-bin-extended": "^0.117.0",
     "imports-loader": "^0.8.0",
     "inquirer": "^12.0.0",
     "jest": "^27.4.7",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "exec-sh": "^0.4.0",
     "file-loader": "^5.0.2",
-    "hugo-bin-extended": "^0.117.0",
+    "hugo-bin-extended": "^0.119.0",
     "imports-loader": "^0.8.0",
     "inquirer": "^12.0.0",
     "jest": "^27.4.7",

--- a/tests-e2e/jest/build-failures.test.ts
+++ b/tests-e2e/jest/build-failures.test.ts
@@ -85,9 +85,7 @@ describe("OCW Build Failures", () => {
     },
     {
       statusCode: 504,
-      match:      [
-        /ERROR Retry timeout/,
-      ]
+      match:      [/ERROR Retry timeout/]
     }
   ])("Featured course static API failures", async ({ statusCode, match }) => {
     const shouldPatch = (req: IncomingMessage) =>

--- a/tests-e2e/jest/build-failures.test.ts
+++ b/tests-e2e/jest/build-failures.test.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path"
-import { IncomingMessage } from "node:http"
-import LocalOCW from "../LocalOCW"
+import { IncomingMessage, ServerResponse } from "node:http"
+import LocalOCW from "../LocalOcw"
 import { TestSiteAlias } from "../util/test_sites"
 
 interface ExecError extends Error {
@@ -53,14 +53,16 @@ describe("OCW Build Failures", () => {
       let attempt = 0
       const shouldPatch = (req: IncomingMessage) =>
         req.url?.includes("3caa0884-4fdd-4f3c-ba39-67a64c27d877")
-      ocw.fixturesServer.patchHandler((req, res) => {
-        if (shouldPatch(req)) {
-          attempt++
-          const statusCode = responder(attempt)
-          res.writeHead(statusCode)
-          res.end()
+      ocw.fixturesServer.patchHandler(
+        (req: IncomingMessage, res: ServerResponse) => {
+          if (shouldPatch(req)) {
+            attempt++
+            const statusCode = responder(attempt)
+            res.writeHead(statusCode)
+            res.end()
+          }
         }
-      })
+      )
     }
 
     test("should return 504 on the first request then 404 for subsequent requests", async () => {
@@ -80,14 +82,16 @@ describe("OCW Build Failures", () => {
       let attempt = 0
       const shouldPatch = (req: IncomingMessage) =>
         req.url?.includes("some-featured-course")
-      ocw.fixturesServer.patchHandler((req, res) => {
-        if (shouldPatch(req)) {
-          attempt++
-          const statusCode = responder(attempt)
-          res.writeHead(statusCode)
-          res.end()
+      ocw.fixturesServer.patchHandler(
+        (req: IncomingMessage, res: ServerResponse) => {
+          if (shouldPatch(req)) {
+            attempt++
+            const statusCode = responder(attempt)
+            res.writeHead(statusCode)
+            res.end()
+          }
         }
-      })
+      )
     }
 
     test("should return 504 on the first request then 404 for subsequent requests", async () => {
@@ -100,19 +104,22 @@ describe("OCW Build Failures", () => {
     })
   })
 
+  // ─── Featured Course API Failure Tests (New Course) ──────────────────────────
   describe("Featured course static API failures for new course", () => {
     const patchNewCourseRequest = (responder: (attempt: number) => number) => {
       let attempt = 0
       const shouldPatch = (req: IncomingMessage) =>
         req.url?.includes("some-new-course")
-      ocw.fixturesServer.patchHandler((req, res) => {
-        if (shouldPatch(req)) {
-          attempt++
-          const statusCode = responder(attempt)
-          res.writeHead(statusCode)
-          res.end()
+      ocw.fixturesServer.patchHandler(
+        (req: IncomingMessage, res: ServerResponse) => {
+          if (shouldPatch(req)) {
+            attempt++
+            const statusCode = responder(attempt)
+            res.writeHead(statusCode)
+            res.end()
+          }
         }
-      })
+      )
     }
 
     test("should return 504 on the first request then 404 for subsequent requests", async () => {

--- a/tests-e2e/jest/build-failures.test.ts
+++ b/tests-e2e/jest/build-failures.test.ts
@@ -29,7 +29,7 @@ const expectBuildError = async (
 describe("OCW Build Failures", () => {
   const ocw = new LocalOCW({
     rootDestinationDir: path.join(__dirname, "tmp"),
-    fixturesPort: 4322
+    fixturesPort:       4322
   })
 
   beforeEach(async () => {
@@ -74,7 +74,9 @@ describe("OCW Build Failures", () => {
   })
 
   describe("Featured course static API failures for featured course", () => {
-    const patchFeaturedCourseRequest = (responder: (attempt: number) => number) => {
+    const patchFeaturedCourseRequest = (
+      responder: (attempt: number) => number
+    ) => {
       let attempt = 0
       const shouldPatch = (req: IncomingMessage) =>
         req.url?.includes("some-featured-course")

--- a/tests-e2e/jest/build-failures.test.ts
+++ b/tests-e2e/jest/build-failures.test.ts
@@ -104,7 +104,6 @@ describe("OCW Build Failures", () => {
     })
   })
 
-  // ─── Featured Course API Failure Tests (New Course) ──────────────────────────
   describe("Featured course static API failures for new course", () => {
     const patchNewCourseRequest = (responder: (attempt: number) => number) => {
       let attempt = 0

--- a/tests-e2e/jest/build-failures.test.ts
+++ b/tests-e2e/jest/build-failures.test.ts
@@ -2,7 +2,7 @@ import * as path from "node:path"
 import { IncomingMessage } from "node:http"
 import LocalOCW from "../LocalOcw"
 import { TestSiteAlias } from "../util/test_sites"
-
+jest.setTimeout(1000000)
 interface ExecError extends Error {
   stdout: string
   stderr: string
@@ -85,10 +85,8 @@ describe("OCW Build Failures", () => {
     },
     {
       statusCode: 504,
-      match:      [
-        /Failed to fetch featured course info/,
-        /from .*4322\/courses\/some-featured-course.*/,
-        /with error.* Gateway Timeout/
+      match: [
+        /ERROR Retry timeout/,
       ]
     }
   ])("Featured course static API failures", async ({ statusCode, match }) => {

--- a/tests-e2e/jest/build-failures.test.ts
+++ b/tests-e2e/jest/build-failures.test.ts
@@ -85,7 +85,7 @@ describe("OCW Build Failures", () => {
     },
     {
       statusCode: 504,
-      match: [
+      match:      [
         /ERROR Retry timeout/,
       ]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7913,15 +7913,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hugo-bin-extended@npm:0.115.4":
-  version: 0.115.4
-  resolution: "hugo-bin-extended@npm:0.115.4"
+"hugo-bin-extended@npm:^0.117.0":
+  version: 0.117.0
+  resolution: "hugo-bin-extended@npm:0.117.0"
   dependencies:
     "@xhmikosr/bin-wrapper": ^11.0.2
     pkg-conf: ^4.0.0
   bin:
     hugo: bin/cli.js
-  checksum: d486eefbf5d11b94a2a7005b15a43d77e4a66bb967a0cfdf0cced3ccce64f2e975ce8c9474fe1309decbb2d70de92fd14103cd3ba3471a40f87671c05b99f70c
+  checksum: 4c71532107be3cde991a09f8e201325aca0635c72d540ea9a128322569292f4c79dbe24d760302c41bd535c07726026efc0f2510ebfa2b0df84a20d9af21d808
   languageName: node
   linkType: hard
 
@@ -11084,7 +11084,7 @@ __metadata:
     file-loader: ^5.0.2
     fuse.js: ^6.6.2
     history: ^5.3.0
-    hugo-bin-extended: 0.115.4
+    hugo-bin-extended: ^0.117.0
     imports-loader: ^0.8.0
     inquirer: ^12.0.0
     isomorphic-fetch: ^3.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7913,15 +7913,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hugo-bin-extended@npm:^0.117.0":
-  version: 0.117.0
-  resolution: "hugo-bin-extended@npm:0.117.0"
+"hugo-bin-extended@npm:^0.119.0":
+  version: 0.119.0
+  resolution: "hugo-bin-extended@npm:0.119.0"
   dependencies:
     "@xhmikosr/bin-wrapper": ^11.0.2
     pkg-conf: ^4.0.0
   bin:
     hugo: bin/cli.js
-  checksum: 4c71532107be3cde991a09f8e201325aca0635c72d540ea9a128322569292f4c79dbe24d760302c41bd535c07726026efc0f2510ebfa2b0df84a20d9af21d808
+  checksum: f88c90350bb5fac46b983672167ab5691bd6aa8f8847e7196609bc7144b4eac0580c34d05a2409a454cced1b5b92922d29cd95ae2b410d06a2302127dd1216d2
   languageName: node
   linkType: hard
 
@@ -11084,7 +11084,7 @@ __metadata:
     file-loader: ^5.0.2
     fuse.js: ^6.6.2
     history: ^5.3.0
-    hugo-bin-extended: ^0.117.0
+    hugo-bin-extended: ^0.119.0
     imports-loader: ^0.8.0
     inquirer: ^12.0.0
     isomorphic-fetch: ^3.0.0


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR upgrades `hugo-bin-extended` version from `0.115.4` to `0.119.0`. 

As explained in https://github.com/mitodl/ocw-hugo-themes/pull/1495/, there was a problem with our Jest tests pertaining to `504` status code. Hugo's update in `0.117.0` causes them to retry with exponential backoff - retrying 30 times before finally failing, taking quite a long time.

This PR also modifies those tests to simulate API failures efficiently. Rather than triggering Hugo's full exponential backoff (with 30 retries), the tests now return a transient 504 error on the first request and immediately return a 404 on subsequent requests. This effectively short-circuits the retry mechanism, allowing the tests to fail fast without waiting for the full retry cycle.


### How can this be tested?
Checkout to this branch.
Run `yarn install`.
Smoke test and make sure everything is working fine. Test for both online and offline themes.
For detailed testing, you can follow this PR instructions: https://github.com/mitodl/ocw-hugo-themes/pull/1167

To run Jest tests locally:
`yarn test:e2e:jest
`