### PR TITLE
 Improve accessibility for external links

### DIFF
--- a/base-theme/layouts/partials/external_resource_link.html
+++ b/base-theme/layouts/partials/external_resource_link.html
@@ -3,14 +3,11 @@
 {{- $hasWarning := default true .has_external_license_warning -}}
 {{- $className := printf "%s %s" "external-link" (default "" .class) -}}
 {{- $onClick := "" -}}
-{{- $ariaLabel := "" -}}
+{{- $ariaLabel := printf "%s (opens in a new tab)" $text -}}
 {{- if $hasWarning -}}
   {{- $className = printf "%s %s" "external-link-warning" $className -}}
-  {{- $ariaLabel = printf "%s (opens warning dialog)" $text -}}
   {{/* Prevents external links from being clicked before corresponding JS is fully loaded. */}}
   {{- $onClick = "event.preventDefault()" -}}
-{{- else -}}
-  {{- $ariaLabel = printf "%s (opens in a new tab)" $text -}}
 {{- end -}}
 {{- if not (in $href "ocw.mit.edu") -}}
   {{- partial "link" (dict

--- a/base-theme/layouts/partials/external_resource_link.html
+++ b/base-theme/layouts/partials/external_resource_link.html
@@ -3,7 +3,8 @@
 {{- $hasWarning := default true .has_external_license_warning -}}
 {{- $className := printf "%s %s" "external-link" (default "" .class) -}}
 {{- $onClick := "" -}}
-{{- $ariaLabel := printf "%s (opens in a new tab)" $text -}}
+{{- $ariaLabel := $text | markdownify | plainify -}}
+{{- $ariaLabel = printf "%s (opens in a new tab)" $ariaLabel -}}
 {{- if $hasWarning -}}
   {{- $className = printf "%s %s" "external-link-warning" $className -}}
   {{/* Prevents external links from being clicked before corresponding JS is fully loaded. */}}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6480

### Description (What does it do?)
The voiced text is now consistently `opens in a new tab` irrespective of whether the ER opens the warning dialog or not.

### How can this be tested?
If you have Mac, please use its VoiceOver. Otherwise only inspect the aria-label attributes in `anchor` tags.
1. Checkout to this branch.
2. `yarn start course peter-test-2024-02-20`
3. Inspect the external links in the left navbar.
