### PR TITLE
Fix milestone links being unclickable due to carousel overlay

### DIFF
--- a/www/assets/css/about.scss
+++ b/www/assets/css/about.scss
@@ -199,6 +199,7 @@
   .carousel-controls {
     top: 50%;
     transform: translateY(-50%);
+    pointer-events: none;
 
     .carousel-prev,
     .carousel-next {
@@ -207,6 +208,9 @@
       background-color: rgba(0, 0, 0, 0.59);
       text-decoration: none;
     }
+  }
+  .carousel-controls a {
+    pointer-events: auto;
   }
 
   ul.dash-bullet-list {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6591

### Description (What does it do?)
Fix milestone links being unclickable due to carousel overlay.

### How can this be tested?
1. Checkout to this branch
2. `yarn start www`
3. Open mobile view in browser using inspect element
4. Go to OCW Milestones: http://localhost:3000/about/
5. Make sure `The New York Times` link is clickable (refer to screenshot below)

<img width="321" alt="image" src="https://github.com/user-attachments/assets/ff7302e7-af80-4717-8b42-cd7c4afcdc6d" />

