### PR TITLE
Update OCW Stories copy

### DIFF
--- a/www/layouts/partials/home_stories.html
+++ b/www/layouts/partials/home_stories.html
@@ -18,9 +18,8 @@
         <div class="carousel-header d-flex flex-column mx-auto container stories-carousel-header">
           <h2 class="mx-auto">OpenCourseWare Stories</h2>
           <p class="mx-auto text-center">
-            MIT students' stories reflect a relentless pursuit of knowledge and innovation.
-            From coding breakthroughs to launching startups, their journey showcases the Institute's
-            commitment to pushing boundaries and changing the world.
+            Stories from the OpenCourseWare community reflect the profound
+            impact of sharing knowledge and the transformative power of open education.
           </p>
         </div>
         <div class="carousel-section d-flex align-items-center">

--- a/www/layouts/stories/list.html
+++ b/www/layouts/stories/list.html
@@ -9,21 +9,21 @@
   <div class="testimonial-banner list d-flex flex-column">
     <div class="standard-width container text-center">
       <h1>OpenCourseWare Stories</h1>
-      <p>MIT students' stories reflect a relentless pursuit of knowledge and innovation. From coding breakthroughs to launching startups, their journey showcases the Institute's commitment to pushing boundaries and changing the world.</p>
+      <p>Stories from the OpenCourseWare community reflect the profound impact of sharing knowledge and the transformative power of open education.</p>
     </div>
   </div>
   <div class="standard-width container">
     <div class="d-flex flex-wrap stories-list-item-container">
       {{ range $index, $testimonial := $stories }}
         <div class="d-flex flex-nowrap justify-content-center col-12 col-md-6 {{ if or (eq (mod $index 8) 0) (eq (mod $index 8) 1) }}col-lg-6{{ else }}col-lg-4{{ end }} p-0 stories-list-item">
-          <a 
-            data-modal-content-id="modal-content-{{ $index }}" 
-            class="item-wrapper d-block testimonial-link {{if $testimonial.Params.is_quote}}js-modal-trigger{{end}} text-decoration-none" 
-            {{ if $testimonial.Params.is_quote }} 
-              href="#" 
-              data-toggle="modal" 
-            {{ else }} 
-              href="{{ $testimonial.RelPermalink }}" 
+          <a
+            data-modal-content-id="modal-content-{{ $index }}"
+            class="item-wrapper d-block testimonial-link {{if $testimonial.Params.is_quote}}js-modal-trigger{{end}} text-decoration-none"
+            {{ if $testimonial.Params.is_quote }}
+              href="#"
+              data-toggle="modal"
+            {{ else }}
+              href="{{ $testimonial.RelPermalink }}"
             {{ end }}
           >
             {{ partial "testimonial_card.html" (dict "testimonial" $testimonial "index" $index "source" "list") }}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6645.

### Description (What does it do?)
This PR changes the copy for OCW Stories. Note that there are two locations where the text has been updated.

### How can this be tested?
Run `yarn start www`, and then navigate to `http://localhost:3000` and verify that the text under `OpenCourseWare Stories` has been updated properly with the changes in the linked issue. Then, navigate to `http://localhost:3000/stories` and also verify that the text has been updated.
