### PR TITLE
remove course v2 bundle from the offline theme

### DIFF
--- a/base-theme/layouts/partials/footer-v2.html
+++ b/base-theme/layouts/partials/footer-v2.html
@@ -65,5 +65,7 @@ we want to use this new footer in other themes (www, course-offline etc)
 		<div class="col-12 mt-4 px-0 d-lg-none">
 			{{ partial "footer-v2-copyrights.html" . }}
 		</div>
+    {{ block "basejs" . }}{{ end }}
+    {{ block "extrajs" . }}{{ end }}
 	</div>
 </div>

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -167,8 +167,7 @@
 
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
-  {{ block "basejs" . }}{{ end }}
-  {{ block "extrajs" . }}{{ end }}
+  {{ partial "course_v2_js.html" . }}
 </body>
 
 </html>

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -167,7 +167,6 @@
 
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
-  {{ partial "course_v2_js.html" . }}
 </body>
 
 </html>

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -46,9 +46,6 @@
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
 
-  {{- $js_urls := slice (partial "get_asset_webpack_url.html" "common.js") (partial "get_asset_webpack_url.html"
-  "course_v2.js") -}}
-  {{ partial "include_js.html" (dict "context" . "urls" $js_urls) }}
   <!-- Appzi: Capture Insightful Feedback -->
   {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
   <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>

--- a/course-v2/layouts/home.html
+++ b/course-v2/layouts/home.html
@@ -45,12 +45,6 @@
   {{ partial "external_link_modal" }}
   {{ partialCached "navigation_js.html" . }}
   {{ partialCached "responsive_tables_js.html" . }}
-
-  <!-- Appzi: Capture Insightful Feedback -->
-  {{ partial "mathjax_if_necessary.html" (dict "context" .) }}
-  <script async src="https://w.appzi.io/w.js?token=Tgs1d"></script>
-
-  <!-- End Appzi -->
 </body>
 
 </html>

--- a/course-v2/layouts/partials/course_v2_js.html
+++ b/course-v2/layouts/partials/course_v2_js.html
@@ -1,0 +1,2 @@
+{{ block "basejs" . }}{{ end }}
+{{ block "extrajs" . }}{{ end }}

--- a/course-v2/layouts/partials/course_v2_js.html
+++ b/course-v2/layouts/partials/course_v2_js.html
@@ -1,2 +1,0 @@
-{{ block "basejs" . }}{{ end }}
-{{ block "extrajs" . }}{{ end }}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6907

### Description (What does it do?)
This PR fixes the isolation between the online and offline theme's Javascript bundles. Currently, the `course_v2.js` bundle is loaded in both the online and offline theme. The bundle was being loaded directly in `course-v2/layouts/_default/baseof.html`, and appzi was being loaded in `home.html`. This kind of thing is supposed to be loaded from the `basejs.html` and `extrajs.html` partials, otherwise they will be loaded on anything that inherits the `course-v2` theme. The `basejs` and `extrajs` blocks were not being populated with them being placed where they were in `baseof.html`. Once I moved these into `footer-v2.html` they started working again.

### How can this be tested?
 - Ensure your environment is configured to run OCW sites locally and exported to your terminal
 - Spin up a course with `yarn start course`
 - Ensure that you see the Appzi feedback button on the right hand side
 - Right click and click inspect element to bring up the developer console
 - Search for `course_v2.js` in the source and ensure it is present
 - Download any course content repo, for example: https://github.mit.edu/mitocwcontent/14.44-spring-2007
 - Assuming that this folder is a sibling with `ocw-hugo-themes` and `ocw-hugo-projects`, run `hugo --themesDir ../ocw-hugo-themes/ --config ../ocw-hugo-projects/ocw-course-v2/config-offline.yaml --baseURL / --destination output-offline` from a terminal in the course content repo folder
 - Look at `output-offline/index.html` and ensure that you see no references to `course_v2.js`

