### PR TITLE
adjust logout URL so redirect works

### DIFF
--- a/base-theme/assets/js/components/UserMenu.tsx
+++ b/base-theme/assets/js/components/UserMenu.tsx
@@ -11,7 +11,7 @@ export default function UserMenu() {
   const encodedLocation = encodeURI(window.location.href)
   const myListsUrl = new URL("/dashboard/my-lists", learnBaseUrl).toString()
   const logoutUrl = new URL(
-    `/logout/oidc?next=${encodedLocation}`,
+    `/logout?next=${encodedLocation}`,
     apiBaseUrl
   ).toString()
   const loginUrl = new URL(


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6998

### Description (What does it do?)
This PR adjusts the `logoutUrl` variable in the `UserMenu` component to simply point at `/logout` instead of `/logout/oidc`. Since https://github.com/mitodl/mit-learn/pull/2145 has been merged, the redirect functionality should actually function now.

### How can this be tested?
- Spin up a bare minimum instance of `mit-learn` locally
  - Set up the various environment files based on the examples, using default values
  - Set the following in your `.env` file at the root of the project:
```
COMPOSE_PROFILES=backend,frontend,apisix,keycloak
CSRF_COOKIE_DOMAIN=.odl.local
ALLOWED_REDIRECT_HOSTS=["localhost:3000", "ocw.odl.local:3000"]
CORS_ALLOWED_ORIGINS=["http://localhost:3000", "http://ocw.odl.local:3000"]
CSRF_TRUSTED_ORIGINS=["http://localhost:3000", "http://ocw.odl.local:3000"]
```
- Use a method appropriate to your operating system to determine your local IP address
- Open your `hosts` file (again, this depends on your operating system and you can Google it)
- In your `hosts` file assuming your IP address is, for example, 192.168.1.123, set the following:
```
192.168.1.123 open.odl.local
192.168.1.123 api.open.odl.local
192.168.1.123 kc.ol.local
192.168.1.123 ocw.odl.local
```
- Ensure you have a Posthog API URL and have set `POSTHOG_PROJECT_API_KEY`, `POSTHOG_ENABLED` and `POSTHOG_ENV` in your OCW `.env` file, and in the Posthog project your are pointing to the `ocw-learn-integration` flag is turned on
- Spin up a course locally with `yarn start course`
- Browse to the course at http://ocw.odl.local:3000
- Click the "Log In" button in the upper right
- You should be redirected to a login page in your instance of MIT Learn
- Log in with `admin@odl.local` / `admin`
- Verify that you are redirected back to OCW and the Log In button in the upper right is now a User Menu with the text "Test Admin"
- Click the user menu and click "Logout"
- Verify that you are redirected back to your OCW site and the "Log In" button is there again
