### PR TITLE
set opt_out_capturing_by_default to true in Posthog

### DIFF
--- a/base-theme/assets/js/posthog.ts
+++ b/base-theme/assets/js/posthog.ts
@@ -23,7 +23,7 @@ export function initPostHog(): typeof posthog {
       loaded:                       function() {
         posthog.reloadFeatureFlags()
         console.log("PostHog loaded successfully")
-      },
+      }
     })
     posthog.register({ environment: posthogEnv })
   } else if (posthogEnabled) {

--- a/base-theme/assets/js/posthog.ts
+++ b/base-theme/assets/js/posthog.ts
@@ -17,6 +17,7 @@ export function initPostHog(): typeof posthog {
       api_host:         posthogApiHost,
       capture_pageview: true,
       autocapture:      true,
+      opt_out_capturing_by_default: true,
       persistence:      "localStorage+cookie",
       person_profiles:  "always",
       loaded:           function() {

--- a/base-theme/assets/js/posthog.ts
+++ b/base-theme/assets/js/posthog.ts
@@ -14,13 +14,13 @@ export function initPostHog(): typeof posthog {
 
   if (posthogEnabled && posthogApiKey) {
     posthog.init(posthogApiKey, {
-      api_host: posthogApiHost,
-      capture_pageview: true,
-      autocapture: true,
+      api_host:                     posthogApiHost,
+      capture_pageview:             true,
+      autocapture:                  true,
       opt_out_capturing_by_default: true,
-      persistence: "localStorage+cookie",
-      person_profiles: "always",
-      loaded: function () {
+      persistence:                  "localStorage+cookie",
+      person_profiles:              "always",
+      loaded:                       function() {
         posthog.reloadFeatureFlags()
         console.log("PostHog loaded successfully")
       },

--- a/base-theme/assets/js/posthog.ts
+++ b/base-theme/assets/js/posthog.ts
@@ -14,16 +14,16 @@ export function initPostHog(): typeof posthog {
 
   if (posthogEnabled && posthogApiKey) {
     posthog.init(posthogApiKey, {
-      api_host:         posthogApiHost,
+      api_host: posthogApiHost,
       capture_pageview: true,
-      autocapture:      true,
+      autocapture: true,
       opt_out_capturing_by_default: true,
-      persistence:      "localStorage+cookie",
-      person_profiles:  "always",
-      loaded:           function() {
+      persistence: "localStorage+cookie",
+      person_profiles: "always",
+      loaded: function () {
         posthog.reloadFeatureFlags()
         console.log("PostHog loaded successfully")
-      }
+      },
     })
     posthog.register({ environment: posthogEnv })
   } else if (posthogEnabled) {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7017

### Description (What does it do?)
This PR sets the `opt_out_capturing_by_default` option on `posthog.init` to prevent sending analytics events to Posthog.

### How can this be tested?
- Ensure you have a Posthog project configured in your `.env`
- Run a course with `yarn start course`
- Visit the page and open up the developer console, where you should see "Posthog enabled"
- Click around the page, reload it a few times
- Visit your Posthog dashboard and verify that you do not see any events in the Activity section based on what you've done
