### PR TITLE
fix login button

### DIFF
--- a/base-theme/assets/js/components/UserMenu.tsx
+++ b/base-theme/assets/js/components/UserMenu.tsx
@@ -19,7 +19,7 @@ export default function UserMenu() {
     apiBaseUrl
   ).toString()
 
-  return isLoading ? null : user?.isAuthenticated ? (
+  return isLoading ? null : user?.is_authenticated ? (
     <div className="dropdown">
       <button
         className="btn btn-link text-white text-decoration-none dropdown-toggle"

--- a/base-theme/assets/js/hooks/user/index.ts
+++ b/base-theme/assets/js/hooks/user/index.ts
@@ -1,36 +1,19 @@
 import { useQuery } from "@tanstack/react-query"
-import { User as UserApi } from "@mitodl/open-api-axios/v0"
+import { User } from "@mitodl/open-api-axios/v0"
 import { usersApi } from "../../clients"
-
-interface User extends Partial<UserApi> {
-  isAuthenticated: boolean
-}
 
 const useUserMe = () =>
   useQuery({
     queryKey: ["userMe"],
     queryFn:  async (): Promise<User> => {
-      try {
-        const response = await usersApi.usersMeRetrieve()
-        return {
-          isAuthenticated: true,
-          ...response.data
-        }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
-        if (error.response?.status === 403) {
-          return {
-            isAuthenticated: false
-          }
-        }
-        throw error
-      }
+      const response = await usersApi.usersMeRetrieve()
+      return response.data as User
     }
   })
 
 const useUserIsAuthenticated = () => {
   const { data: user } = useUserMe()
-  return !!user?.isAuthenticated
+  return !!user?.is_authenticated
 }
 
 export { useUserMe, useUserIsAuthenticated }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "browserslist": "> 0.25%, not dead",
   "dependencies": {
     "@mitodl/course-search-utils": "^2.3.3",
-    "@mitodl/open-api-axios": "^2025.3.6",
+    "@mitodl/open-api-axios": "^2025.4.8",
     "@remixicon/react": "^4.6.0",
     "@sentry/browser": "^9.0.0",
     "@tanstack/react-query": "^4.36.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,13 +1396,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/open-api-axios@npm:^2025.3.6":
-  version: 2025.3.6
-  resolution: "@mitodl/open-api-axios@npm:2025.3.6"
+"@mitodl/open-api-axios@npm:^2025.4.8":
+  version: 2025.4.8
+  resolution: "@mitodl/open-api-axios@npm:2025.4.8"
   dependencies:
     "@types/node": "npm:^22.0.0"
     axios: "npm:^1.6.5"
-  checksum: 10c0/cfe7b76de39a1e1e927ac9f81611dc732b66311101beec883d3bffc70bdf6b856f208e1f57ce3e6c1bd4050bcb14e818d64d5c399080e0d396dcbdcb35e87e1a
+  checksum: 10c0/f35475d40381af218500c53875d9e63a78426ac0c71d4024377248311578648aafad30615b3f91cd73718467a7a3f2557b06ec777735a45ef9c95a7840c6dfe2
   languageName: node
   linkType: hard
 
@@ -11606,7 +11606,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.25.7"
     "@mitodl/course-search-utils": "npm:^2.3.3"
     "@mitodl/ocw-to-hugo": "npm:1.36.0"
-    "@mitodl/open-api-axios": "npm:^2025.3.6"
+    "@mitodl/open-api-axios": "npm:^2025.4.8"
     "@playwright/test": "npm:^1.45.0"
     "@remixicon/react": "npm:^4.6.0"
     "@sentry/browser": "npm:^9.0.0"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7075

### Description (What does it do?)
This PR fixes the feature flagged login button functionality that communicates with the MIT Learn API. There was recently a change to the API. Previously, if you were not logged in, the API would return a 403 when you hit `/api/v0/users/me`. Now, the endpoint returns a 200 with a JSON response indicating that you are not authenticated with `is_authenticated` being `false`. This PR adjusts the hooks here in OCW to account for this change.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/2eebb28f-9055-4eb0-b336-10df44744175)
![image](https://github.com/user-attachments/assets/1694f615-c0da-49c2-abc3-11334025f839)

### How can this be tested?
- Spin up a bare minimum instance of `mit-learn` locally
  - Set up the various environment files based on the examples, using default values
  - Set the following in your `.env` file at the root of the project:
```
COMPOSE_PROFILES=backend,frontend,apisix,keycloak
CSRF_COOKIE_DOMAIN=.odl.local
ALLOWED_REDIRECT_HOSTS=["localhost:3000", "ocw.odl.local:3000"]
CORS_ALLOWED_ORIGINS=["http://localhost:3000", "http://ocw.odl.local:3000"]
CSRF_TRUSTED_ORIGINS=["http://localhost:3000", "http://ocw.odl.local:3000"]
```
- Use a method appropriate to your operating system to determine your local IP address
- Open your `hosts` file (again, this depends on your operating system and you can Google it)
- In your `hosts` file assuming your IP address is, for example, 192.168.1.123, set the following:
```
192.168.1.123 open.odl.local
192.168.1.123 api.open.odl.local
192.168.1.123 kc.ol.local
192.168.1.123 ocw.odl.local
```
- Ensure you have a Posthog API URL and have set `POSTHOG_PROJECT_API_KEY`, `POSTHOG_ENABLED` and `POSTHOG_ENV` in your OCW `.env` file, and in the Posthog project your are pointing to the `ocw-learn-integration` flag is turned on
- Spin up a course locally with `yarn start course`
- Browse to the course at http://ocw.odl.local:3000
- Click the "Log In" button in the upper right
- You should be redirected to a login page in your instance of MIT Learn
- Log in with `admin@odl.local` / `admin`
- Verify that you are redirected back to OCW and the Log In button in the upper right is now a User Menu with the text "Test Admin"
- Click the user menu and click "Logout"
- Verify that you are redirected back to your OCW site and the "Log In" button is there again
