### PR TITLE
disable the bookmark button when loading instead of not rendering it

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ To further explain the various environment variables and what they do:
 | `POSTHOG_ENABLED` | `www`, `course` | `true` | Whether PostHog analytics are enabled
 | `POSTHOG_ENV` | `www`, `course` | `production` | Environment for PostHog
 | `POSTHOG_PROJECT_API_KEY` | `www`, `course` | `api-key` | API key for PostHog |
+| `CSRF_COOKIE_DOMAIN` | N/A | N/A | The cookie domain to use in Axios when communicating with the `mit-learn` API |
 | `MIT_LEARN_BASE_URL` | N/A | `http://learn.odl.local:8062` | The base URL for the frontend of an instance of [`mit-learn`](https://github.com/mitodl/mit-learn) |
 | `MIT_LEARN_API_BASE_URL` | N/A | `http://learn.odl.local:8065` | The base URL for the API gateway (APISIX) of an instance of [`mit-learn`](https://github.com/mitodl/mit-learn) |
 
@@ -222,11 +223,12 @@ at the RC instances and temporarily disable CORS in your browser.
 #### MIT Learn integration
 
 One of the external API's that can be integrated into OCW sites is based on [MIT Learn](https://github.com/mitodl/mit-learn).
-There are two environment variables you can set related to this functionality;
-`MIT_LEARN_BASE_URL` and `MIT_LEARN_API_BASE_URL`. The former is used to construct 
-URLs to the login / logout pages, and the latter is used to construct calls to the API.
-In the following examples, we will assume you are running `mit-learn` locally with:
+There are three environment variables you can set related to this functionality;
+`CSRF_COOKIE_DOMAIN`, `MIT_LEARN_BASE_URL` and `MIT_LEARN_API_BASE_URL`. With the base URLs, the former is used to construct 
+URLs to the login / logout pages, and the latter is used to construct calls to the API. The cookie domain setting is what 
+allows CSRF to work between the sites. In the following examples, we will assume you are running `mit-learn` locally with:
 
+- `CSRF_COOKIE_DOMAIN=.odl.local`
 - `MIT_LEARN_BASE_URL=http://open.odl.local:8062`
 - `MIT_LEARN_API_BASE_URL=http://api.open.odl.local:8065`
 
@@ -248,14 +250,37 @@ bare minimum:
 ```
 COMPOSE_PROFILES=backend,frontend,apisix,keycloak
 CSRF_COOKIE_DOMAIN=.odl.local
-ALLOWED_REDIRECT_HOSTS=["localhost:3000", "ocw.odl.local:3000"]
-CORS_ALLOWED_ORIGINS=["http://localhost:3000", "http://ocw.odl.local:3000"]
-CSRF_TRUSTED_ORIGINS=["http://localhost:3000", "http://ocw.odl.local:3000"]
+ALLOWED_REDIRECT_HOSTS=['localhost:3000', 'ocw.odl.local:3000', 'open.odl.local:8062', 'api.open.odl.local:8063', 'api.open.odl.local:8065']
+CORS_ALLOWED_ORIGINS=['http://localhost:3000', 'http://ocw.odl.local:3000', 'http://open.odl.local:8062', 'http://api.open.odl.local:8063', 'http://api.open.odl.local:8065']
+CSRF_TRUSTED_ORIGINS=['http://localhost:3000', 'http://ocw.odl.local:3000', 'http://open.odl.local:8062', 'http://api.open.odl.local:8063', 'http://api.open.odl.local:8065']
+```
+
+In the `env` folder, you will see some `.local.example.env` files. Create the following files and put the described contents in them:
+
+`backend.local.env`
+
+```
+MAILGUN_SENDER_DOMAIN=open.odl.local
+MAILGUN_KEY=fake
+SKIP_TIKA=True
+```
+
+`shared.local.env` should be blank
+
+`frontend.local.env`
+
+```
+NEXT_PUBLIC_EMBEDLY_KEY=""
 ```
 
 After setting these values and spinning up both `mit-learn` and `ocw-hugo-themes` locally,
 you should be able to hit your OCW dev page at http://ocw.odl.local:3000/ and see a "Log In"
 button in the upper right.
+
+In order for the bookmark functionality to work, the instance of `mit-learn` needs to contain
+the OCW courses that you are trying to bookmark. Read the `mit-learn` Readme about importing data
+and make sure that you backpopulate sufficient OCW data for your purposes using the `backpopulate_ocw_data`
+management command.
 
 ### CORS
 

--- a/base-theme/assets/js/components/BookmarkButton.tsx
+++ b/base-theme/assets/js/components/BookmarkButton.tsx
@@ -16,7 +16,7 @@ const BookmarkButton: React.FC<BookmarkButtonProps> = ({
   const { data: userListMemberships, isLoading: isUserListMembershipsLoading } =
     useUserListMemberList(resource?.id)
   const inUserList = userListMemberships?.length || 0 > 0
-  return !isResourceLoading && !isUserListMembershipsLoading ? (
+  return (
     <ActionButton
       className="bookmark-button"
       edge="circular"
@@ -26,6 +26,7 @@ const BookmarkButton: React.FC<BookmarkButtonProps> = ({
       data-toggle="modal"
       data-target="#add-to-user-list-modal"
       data-resourcereadableid={resourceReadableId}
+      disabled={isResourceLoading || isUserListMembershipsLoading}
     >
       {inUserList ? (
         <RiBookmarkFill aria-hidden />
@@ -33,7 +34,7 @@ const BookmarkButton: React.FC<BookmarkButtonProps> = ({
         <RiBookmarkLine aria-hidden />
       )}
     </ActionButton>
-  ) : null
+  )
 }
 
 export default BookmarkButton


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7305

### Description (What does it do?)
This PR fixes a race condition bug with the bookmark button on the course homepage. We added the button in https://github.com/mitodl/ocw-hugo-themes/pull/1572, and as part of that it was set up to not render unless the `LearningResource` had been returned from the Learn API. The readable ID of the resource is set on a div with the class `bookmark-button-container` while Hugo is rendering the site. These containers are fetched and iterated as part of the initial site load, with `BookmarkButton` elements being initialized for each one inside the container. The button component needs to load the `LearningResource` to check the memberships and change the style of the button if you have bookmarked it. Meanwhile, the `AddToUserList` dialog initialization is running, which fetches all of the bookmark buttons on the page and attaches click listeners to them so when you click the button it changes the readable ID context of the dialog, reinitializing it for whatever course's bookmark button you have clicked. The problem with this is that the `BookmarkButton` elements have not finished loading yet. This PR changes the behavior so that instead of not rendering the buttons when the `LearningResource` has not been returned yet, it is disabled instead. This allows the button to render and the dialog to initialize and attach its event handlers properly.

### How can this be tested?
- Spin up a bare minimum instance of `mit-learn` locally
  - Set up the various environment files based on the examples, using default values
  - Set the following in your `.env` file at the root of the project:
```
COMPOSE_PROFILES=backend,frontend,apisix,keycloak
CSRF_COOKIE_DOMAIN=.odl.local
ALLOWED_REDIRECT_HOSTS=["localhost:3000", "ocw.odl.local:3000"]
CORS_ALLOWED_ORIGINS=["http://localhost:3000", "http://ocw.odl.local:3000"]
CSRF_TRUSTED_ORIGINS=["http://localhost:3000", "http://ocw.odl.local:3000"]
```
- Use a method appropriate to your operating system to determine your local IP address
- Open your `hosts` file (again, this depends on your operating system and you can Google it)
- In your `hosts` file assuming your IP address is, for example, 192.168.1.123, set the following:
```
192.168.1.123 open.odl.local
192.168.1.123 api.open.odl.local
192.168.1.123 kc.ol.local
192.168.1.123 ocw.odl.local
```
- Ensure you have a Posthog API URL and have set `POSTHOG_PROJECT_API_KEY`, `POSTHOG_ENABLED` and `POSTHOG_ENV` in your OCW `.env` file, and in the Posthog project your are pointing to the `ocw-learn-integration` flag is turned on
- Spin up a course locally with `yarn start course`
- Browse to the course at http://ocw.odl.local:3000
- Click the "Log In" button in the upper right
- You should be redirected to a login page in your instance of MIT Learn
- Log in with `admin@odl.local` / `admin`
- Verify that you are redirected back to OCW and the Log In button in the upper right is now a User Menu with the text "Test Admin"
- Click the bookmark button in the upper right of the banner of the course home page
- Verify that the title of the dialog matches the course you are running
- Click the checkbox on the Favorites list and click Save
- Click the user menu in the upper right, then open "My Lists" in a new tab
- Browse the list in MIT Learn and ensure that the course you're running is now in the Favorites list
- Back in OCW, click the bookmark button again and this time click "Create New List" after
- Fill out the list creation dialog fields and click "Create"
- Add the course to the new list we created and verify its presence over in MIT Learn
