### PR TITLE
Upgrade hugo-bin-extended to ^0.144.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "exec-sh": "^0.4.0",
     "file-loader": "^5.0.2",
-    "hugo-bin-extended": "^0.142.0",
+    "hugo-bin-extended": "^0.144.0",
     "imports-loader": "^0.8.0",
     "inquirer": "^12.0.0",
     "jest": "^27.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9166,15 +9166,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hugo-bin-extended@npm:^0.142.0":
-  version: 0.142.0
-  resolution: "hugo-bin-extended@npm:0.142.0"
+"hugo-bin-extended@npm:^0.144.0":
+  version: 0.144.2
+  resolution: "hugo-bin-extended@npm:0.144.2"
   dependencies:
     "@xhmikosr/bin-wrapper": "npm:^13.0.5"
     package-config: "npm:^5.0.0"
   bin:
     hugo: bin/cli.js
-  checksum: 10c0/fd79393cc5f6229f8161945dc7a8641d44c75920c742e78542f2589bc998c77a24fcbb780571056cfe5bba51b83fd97892b1c511ad5a6fbe66917c647767a5a4
+  checksum: 10c0/8a6a16851788b93e9f406d5d4a4e59dab0232fa8ae0db86a16c0f224ae64ab00908bdae447dcbcdcaa44df06036c2c9a1a7acdc931ab41c800abff292dd0e988
   languageName: node
   linkType: hard
 
@@ -12667,7 +12667,7 @@ __metadata:
     formik: "npm:^2.4.6"
     fuse.js: "npm:^7.0.0"
     history: "npm:^5.3.0"
-    hugo-bin-extended: "npm:^0.142.0"
+    hugo-bin-extended: "npm:^0.144.0"
     imports-loader: "npm:^0.8.0"
     inquirer: "npm:^12.0.0"
     isomorphic-fetch: "npm:^3.0.0"


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Upgrades `hugo-bin-extended` from `^0.142.0` to `^0.144.0`. 
Note: this is a local upgrade only, for production we need to create a PR in `ol-infrastructure`. Which can wait until our next `hugo-bin-extended` upgrade (to `0.146.0+`).

Why I didn't do `0.145.0` or `0.146.0` in this PR?
For some reason, `0.145.0` caused the server to fail to compile, with an error that appeared to be related to `Go`. That issue is resolved in `0.146.0`.

However, [v0.146.0](https://github.com/gohugoio/hugo/releases/tag/v0.146.0) is kind of a big upgrade, which also introduced a regression (fixed in `v0.146.1`). Other than that, v0.145.0 deprecated the use of `_build` in front matter so we need to update that and look if there's anything else. We can do that in the next PR.

For now, this PR upgrades to `^0.144.0`.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
