### PR TITLE
OCW Team page update - Brett Paci

### DIFF
--- a/www/content/staff/brett-paci.md
+++ b/www/content/staff/brett-paci.md
@@ -1,7 +1,7 @@
 ---
 first_name: Brett
 last_name: Paci
-job_title: Video Publication Manager
+job_title: Assistant Director, OCW Media Production
 image: /images/about/staff/brett-paci.jpeg
 _build:
     render: "never"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7445.

### Description (What does it do?)
This PR updates Brett Paci's title on the OCW Team page.

### How can this be tested?
Run `yarn start www`, and then navigate to http://localhost:3000/about. Verify that Brett Paci's title has been updated properly, as described in the linked issue.