### PR TITLE
OCW Team page updates

### DIFF
--- a/www/content/staff/brett-paci.md
+++ b/www/content/staff/brett-paci.md
@@ -1,7 +1,7 @@
 ---
 first_name: Brett
 last_name: Paci
-job_title: Assistant Director, OCW Media Production
+job_title: Assistant Director, Media Production
 image: /images/about/staff/brett-paci.jpeg
 _build:
     render: "never"

--- a/www/content/staff/cheryl-siegel.md
+++ b/www/content/staff/cheryl-siegel.md
@@ -1,7 +1,7 @@
 ---
 first_name: Cheryl
 last_name: Siegel
-job_title: OCW Senior Publication and Social Media Manager
+job_title: Senior Publication and Social Media Manager
 image: /images/about/staff/cheryl-siegel.png
 _build:
     render: "never"


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/hq/issues/7445 and https://github.com/mitodl/hq/issues/7497.

### Description (What does it do?)
This PR updates Brett Paci's and Cheryl Siegel's titles on the OCW Team page; the `OCW` is redundant since they are both OCW Team members.

### How can this be tested?
Run `yarn start www`, and then navigate to http://localhost:3000/about. Verify that the titles have been updated properly, removing the `OCW`.