### PR TITLE
Fix URLs for SEO in Offline Build

### DIFF
--- a/base-theme/layouts/partials/seo.html
+++ b/base-theme/layouts/partials/seo.html
@@ -19,13 +19,13 @@
   {{/*  Facebook Open Graph  */}}
   <meta property="og:site_name" content="MIT OpenCourseWare">
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://{{ strings.TrimSuffix "/" $sitemapDomain }}/{{- strings.TrimPrefix "/" $path -}}" />
+  <meta property="og:url" content="https://{{ strings.TrimSuffix "/" $sitemapDomain }}{{ .RelPermalink }}" />
   <meta property="og:title" content="{{- $title -}}" />
   <meta property="og:description" content="{{- $metaDataDescription -}}" />
 
   {{ partial "extra_metadata.html" (dict "context" . ) }}
-  
-  <link rel="canonical" href="https://{{ strings.TrimSuffix "/" $sitemapDomain }}/{{- strings.TrimPrefix "/" $path -}}" />
+
+  <link rel="canonical" href="https://{{ strings.TrimSuffix "/" $sitemapDomain }}{{ .RelPermalink }}" />
 
   <script type="application/ld+json">
       {
@@ -33,7 +33,7 @@
         "@type" : "WebPage",
         "name": "MIT OpenCourseWare",
         "description": "{{- $metaDataDescription -}}",
-        "license": "http://creativecommons.org/licenses/by-nc-sa/4.0/", 
+        "license": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
         "publisher": {
           "@type": "CollegeOrUniversity",
           "name": "MIT OpenCourseWare"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7693.

### Description (What does it do?)
This PR fixes an issue where the downloadable versions of courses (offline build) display incorrect URLs for `og:url` and `canonical`, caused by combining two full URLs in both cases. This is fixed by using relative URLs instead.

### How can this be tested?
Make sure that there is a local copy of the course content for a given course, e.g., by running `yarn start course <course-id>`, which will automatically clone the relevant course content repo. Then, run `yarn build <path to local course repos>/<course id> <path to ocw-hugo-projects>/ocw-course-v2/config-offline.yaml`. Examine the source of any HTML page in the `<path to local course repos>/<course id>/dist` directory, and ensure that the URLs in `og:url` and `canonical` look correct. Verify that these URLs look correct in the online build as well.
