### PR TITLE
chore: added youtube player for chalk radio on `about us` page

### DIFF
--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -339,7 +339,7 @@
               behind some of MIT’s most interesting courses, from nuclear physics to film appreciation
               to ethical responsibilities of computing.
             </p>
-            {{ partial "simplecast.html" "a9349695-05d2-4150-bba6-271cbf875ba0" }}
+            {{ partial "youtube_player.html" (dict "youtubeKey" "8kFFg5jAoQc" "startTime" "" "endTime" "" "downloadLink" "" "transcriptLink" "" "captionsLocation" "" "isOffline" false) }}
           </li>
           <li>
             <span class="font-weight-bold">Open Textbooks</span>

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -341,6 +341,7 @@
             </p>
             <iframe
               id="podcast-video"
+              class="w-100 h-100 aspect-ratio-16-9"
               frameborder="0"
               scrolling="no"
               marginheight="0"

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -339,7 +339,17 @@
               behind some of MIT’s most interesting courses, from nuclear physics to film appreciation
               to ethical responsibilities of computing.
             </p>
-            {{ partial "youtube_player.html" (dict "youtubeKey" "p8918BiV01c" "startTime" "" "endTime" "" "downloadLink" "" "transcriptLink" "" "captionsLocation" "" "isOffline" false) }}
+            <iframe
+              id="podcast-video"
+              class="w-100 h-100 aspect-ratio-16-9"
+              frameborder="0"
+              scrolling="no"
+              marginheight="0"
+              marginwidth="0"
+              type="text/html"
+              src="https://www.youtube.com/embed/p8918BiV01c?autoplay=0&fs=0&iv_load_policy=3&showinfo=0&rel=0&cc_load_policy=0&start=0&end=0"
+            >
+            </iframe>
           </li>
           <li>
             <span class="font-weight-bold">Open Textbooks</span>

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -339,7 +339,7 @@
               behind some of MIT’s most interesting courses, from nuclear physics to film appreciation
               to ethical responsibilities of computing.
             </p>
-            {{ partial "youtube_player.html" (dict "youtubeKey" "8kFFg5jAoQc" "startTime" "" "endTime" "" "downloadLink" "" "transcriptLink" "" "captionsLocation" "" "isOffline" false) }}
+            {{ partial "youtube_player.html" (dict "youtubeKey" "p8918BiV01c" "startTime" "" "endTime" "" "downloadLink" "" "transcriptLink" "" "captionsLocation" "" "isOffline" false) }}
           </li>
           <li>
             <span class="font-weight-bold">Open Textbooks</span>

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -304,7 +304,7 @@
     </div>
   </div>
   <div id="beyond-course-materials" class="container max-content-width section py-5 py-lg-8">
-    <div class="row">
+    <div class="row align-items-center">
       <div class="col-12 col-lg-6 pr-lg-8">
         <h1 class="text-center-mobile pb-5">Beyond Course Materials</h1>
         <p class="pb-lg-5">

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -341,7 +341,6 @@
             </p>
             <iframe
               id="podcast-video"
-              class="w-100 h-100 aspect-ratio-16-9"
               frameborder="0"
               scrolling="no"
               marginheight="0"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6943

### Description (What does it do?)
This PR adds a YouTube player for Chalk Radio, replacing the Simplecast player on the `About Us` page on the OCW home.

### How can this be tested?
1. Switch to this branch and run the homepage with: `yarn start www`
2. Go to `http://localhost:3000/about/` and scroll half way down to verify that it has YouTube player for Chalk radio as shown in the screenshot above
3. Play the video to verify that it works