### PR TITLE
Remove Course Introduction learning resource type

### DIFF
--- a/course-v2/layouts/partials/learning_resource_type.html
+++ b/course-v2/layouts/partials/learning_resource_type.html
@@ -4,9 +4,7 @@
 <div class="{{ if not $inPanel }}learning-resource-type-item{{ end }}">
   <div class="d-flex">
     <i aria-hidden="true" class="material-icons pr-1">
-      {{- if eq $context "Course Introduction" -}}
-      groups
-      {{- else if in $context "Audio" -}}
+      {{- if in $context "Audio" -}}
       equalizer
       {{- else if in $context "Video" -}}
       theaters
@@ -31,7 +29,7 @@
       {{- else if in $context "Instructor Insights" -}}
       <span class="material-icons-round">
         co_present
-      </span> 
+      </span>
       {{- end -}}
     </i>
     <span>

--- a/www/assets/js/lib/constants.ts
+++ b/www/assets/js/lib/constants.ts
@@ -82,7 +82,6 @@ const RESOURCE_TYPES = [
   "Activity Assignments with Examples",
   "Assignments",
   "Competition Videos",
-  "Course Introduction",
   "Demonstration Audio",
   "Demonstration Videos",
   "Design Assignments",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/7297.

### Description (What does it do?)
This PR removes special formatting for `Course Introduction` learning resource types, since it is no longer an option, and also removes it from search/filtering.

### How can this be tested?
This should be tested together with https://github.com/mitodl/ocw-hugo-projects/pull/342. Make sure that search is configured appropriately in OCW Studio, and verify that `Course Introduction` no longer appears as an option to filter or search by.