### PR TITLE
Update SEO URLs for offline build to include complete URL

### DIFF
--- a/base-theme/layouts/partials/seo.html
+++ b/base-theme/layouts/partials/seo.html
@@ -1,7 +1,6 @@
 {{ define "seo" }}
 
   {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-  {{- $path := partial "site_root_url.html" .RelPermalink -}}
 
   <!-- default value for the meta description -->
   {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
@@ -19,13 +18,13 @@
   {{/*  Facebook Open Graph  */}}
   <meta property="og:site_name" content="MIT OpenCourseWare">
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://{{ strings.TrimSuffix "/" $sitemapDomain }}{{ .RelPermalink }}" />
+  <meta property="og:url" content="{{ .Permalink }}" />
   <meta property="og:title" content="{{- $title -}}" />
   <meta property="og:description" content="{{- $metaDataDescription -}}" />
 
   {{ partial "extra_metadata.html" (dict "context" . ) }}
 
-  <link rel="canonical" href="https://{{ strings.TrimSuffix "/" $sitemapDomain }}{{ .RelPermalink }}" />
+  <link rel="canonical" href="{{ .Permalink }}" />
 
   <script type="application/ld+json">
       {

--- a/course-offline/layouts/partials/seo.html
+++ b/course-offline/layouts/partials/seo.html
@@ -1,7 +1,7 @@
 {{ define "seo" }}
 
   {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-  {{- $fullURL = printf "https://%s/courses/%s%s" (strings.TrimSuffix "/" $sitemapDomain) .Site.Data.course.course_id .RelPermalink -}}
+  {{- $fullURL := printf "https://%s/courses/%s%s" (strings.TrimSuffix "/" $sitemapDomain) .Site.Data.course.course_id .RelPermalink -}}
 
   <!-- default value for the meta description -->
   {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}

--- a/course-offline/layouts/partials/seo.html
+++ b/course-offline/layouts/partials/seo.html
@@ -1,7 +1,7 @@
 {{ define "seo" }}
 
   {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-  {{- $fullURL := printf "https://%s/courses/%s%s" (strings.TrimSuffix "/" $sitemapDomain) .Site.Data.course.course_id .RelPermalink -}}
+  {{- $fullURL := printf "https://%s/courses/%s%s" (strings.TrimSuffix "/" $sitemapDomain) .Site.Data.course.site_url_path .RelPermalink -}}
 
   <!-- default value for the meta description -->
   {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}

--- a/course-offline/layouts/partials/seo.html
+++ b/course-offline/layouts/partials/seo.html
@@ -1,6 +1,7 @@
 {{ define "seo" }}
 
   {{- $sitemapDomain := partial "sitemap_domain.html" -}}
+  {{- $fullURL = printf "https://%s/courses/%s%s" (strings.TrimSuffix "/" $sitemapDomain) .Site.Data.course.course_id .RelPermalink -}}
 
   <!-- default value for the meta description -->
   {{- $defaultMetadataDescription := "MIT OpenCourseWare is a web based publication of virtually all MIT course content. OCW is open and available to the world and is a permanent MIT activity" -}}
@@ -18,13 +19,13 @@
   {{/*  Facebook Open Graph  */}}
   <meta property="og:site_name" content="MIT OpenCourseWare">
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://{{ strings.TrimSuffix "/" $sitemapDomain }}{{ .RelPermalink }}" />
+  <meta property="og:url" content="{{- $fullURL -}}" />
   <meta property="og:title" content="{{- $title -}}" />
   <meta property="og:description" content="{{- $metaDataDescription -}}" />
 
   {{ partial "extra_metadata.html" (dict "context" . ) }}
 
-  <link rel="canonical" href="https://{{ strings.TrimSuffix "/" $sitemapDomain }}{{ .RelPermalink }}" />
+  <link rel="canonical" href="{{- $fullURL -}}" />
 
   <script type="application/ld+json">
       {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7693.

### Description (What does it do?)
Note: https://github.com/mitodl/ocw-studio/pull/2676 must be merged, deployed, and all courses need to be updated via a mass publish before this change is deployed.  

### How can this be tested?
This should be tested in OCW Studio to validate the entire publishing pipeline. First, make sure that the `API_BEARER_TOKEN` is set in the `.env` file; this is required for offline builds. Then, set `OCW_HUGO_THEMES_BRANCH=pt/update_seo_urls`, and upsert the theme assets pipeline with `docker compose exec web ./manage.py upsert_theme_assets_pipeline`. Navigate to Concourse, unpause the pipeline, and wait for the theme assets build to complete successfully. Then, run the following for any course:

```
docker compose exec web ./manage.py backpopulate_pipelines --filter <course-id>
docker compose exec web ./manage.py reset_sync_states --filter <course-id> --skip_sync
docker compose exec web ./manage.py sync_website_to_backend --filter <course-id>
```

Publish the course, and wait for the offline build to complete (this can be monitored in Concourse). Once the offline build finishes, navigate to the `ocw-content-live/courses/<course name>` bucket on Minio, and download the associated ZIP file. Inspect the source for pages, and ensure that the `<meta property="og:url" ... >` and `<link rel="canonical" ... > tags are pointing to the live pages.