### PR TITLE
fix: broken images in offline build for nested pages (pages/pageA/pageB)

### DIFF
--- a/base-offline/layouts/partials/resource_url.html
+++ b/base-offline/layouts/partials/resource_url.html
@@ -1,6 +1,6 @@
 {{ $url := .url }}
 {{ if .url }}
-  {{ $pathToRoot := partial "path_to_root.html" (or .page_context.RelPermalink .context.RelPermalink) }}
+  {{ $pathToRoot := partial "path_to_root.html" .context.RelPermalink }}
   {{ $resourcePath := (urls.Parse .url).Path }}
   {{ $resourceFileName := path.Base $resourcePath }}
   {{ $url = (printf "%s/static_resources/%s" (strings.TrimSuffix "/" $pathToRoot) $resourceFileName) }}

--- a/base-offline/layouts/partials/resource_url.html
+++ b/base-offline/layouts/partials/resource_url.html
@@ -1,6 +1,6 @@
 {{ $url := .url }}
 {{ if .url }}
-  {{ $pathToRoot := partial "path_to_root.html" .context.RelPermalink }}
+  {{ $pathToRoot := partial "path_to_root.html" (or .page_context.RelPermalink .context.RelPermalink) }}
   {{ $resourcePath := (urls.Parse .url).Path }}
   {{ $resourceFileName := path.Base $resourcePath }}
   {{ $url = (printf "%s/static_resources/%s" (strings.TrimSuffix "/" $pathToRoot) $resourceFileName) }}

--- a/base-theme/layouts/partials/image_resource.html
+++ b/base-theme/layouts/partials/image_resource.html
@@ -12,7 +12,7 @@
     <a href="{{- $imageHref -}}" target="_blank">
 {{- end -}}
 {{- $metadata := .context.Params.image_metadata | default dict -}}
-<img src="{{ partial "resource_url.html" (dict "context" .context "url" .context.Params.file) }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
+<img src="{{ partial "resource_url.html" (dict "context" .context "url" .context.Params.file "page_context" .page_context) }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
 {{- if $imageHref -}}
     </a>
 {{- end -}}

--- a/base-theme/layouts/partials/image_resource.html
+++ b/base-theme/layouts/partials/image_resource.html
@@ -3,7 +3,7 @@
 {{- if .href -}}
     {{- $imageHref = .href -}}
 {{- else if .href_uuid -}}
-    {{- range where .context.Site.Pages "Params.uid" .href_uuid -}}
+    {{- range where .resource.Site.Pages "Params.uid" .href_uuid -}}
         {{- $imageHref = .Permalink -}}
     {{- end -}}
 {{- end -}}
@@ -11,8 +11,8 @@
 {{- if $imageHref -}}
     <a href="{{- $imageHref -}}" target="_blank">
 {{- end -}}
-{{- $metadata := .context.Params.image_metadata | default dict -}}
-<img src="{{ partial "resource_url.html" (dict "context" .context "url" .context.Params.file "page_context" .page_context) }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
+{{- $metadata := .resource.Params.image_metadata | default dict -}}
+<img src="{{ partial "resource_url.html" (dict "context" .context "url" .resource.Params.file) }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
 {{- if $imageHref -}}
     </a>
 {{- end -}}

--- a/base-theme/layouts/shortcodes/resource.html
+++ b/base-theme/layouts/shortcodes/resource.html
@@ -11,7 +11,7 @@
 {{- range $.Site.Pages -}}
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
     {{- if eq .Params.resourcetype "Image" -}}
-      {{ partial "image_resource.html" (dict "context" . "href" $href "href_uuid" $href_uuid "page_context" $page) }}
+      {{ partial "image_resource.html" (dict  "context" $page "resource" . "href" $href "href_uuid" $href_uuid) }}
     {{- else if eq .Params.resourcetype "Video" -}}
       {{ partial "video_embed.html" (dict "context" $page "resource" .) }}
     {{- else -}}

--- a/base-theme/layouts/shortcodes/resource.html
+++ b/base-theme/layouts/shortcodes/resource.html
@@ -11,7 +11,7 @@
 {{- range $.Site.Pages -}}
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
     {{- if eq .Params.resourcetype "Image" -}}
-      {{ partial "image_resource.html" (dict  "context" $page "resource" . "href" $href "href_uuid" $href_uuid) }}
+      {{ partial "image_resource.html" (dict "context" $page "resource" . "href" $href "href_uuid" $href_uuid) }}
     {{- else if eq .Params.resourcetype "Video" -}}
       {{ partial "video_embed.html" (dict "context" $page "resource" .) }}
     {{- else -}}

--- a/base-theme/layouts/shortcodes/resource.html
+++ b/base-theme/layouts/shortcodes/resource.html
@@ -11,7 +11,7 @@
 {{- range $.Site.Pages -}}
   {{- if eq (replace .Params.uid "-" "") (replace $uuid "-" "") -}}
     {{- if eq .Params.resourcetype "Image" -}}
-      {{ partial "image_resource.html" (dict "context" . "href" $href "href_uuid" $href_uuid) }}
+      {{ partial "image_resource.html" (dict "context" . "href" $href "href_uuid" $href_uuid "page_context" $page) }}
     {{- else if eq .Params.resourcetype "Video" -}}
       {{ partial "video_embed.html" (dict "context" $page "resource" .) }}
     {{- else -}}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8214

### Description (What does it do?)
This PR fixes the calculation of relative links for image urls in the offline build.

Currently, the process for calculation of image urls is as follows :-

1. [Find](https://github.com/mitodl/ocw-hugo-themes/blob/main/base-theme/layouts/shortcodes/resource.html#L11-L14) the associated resource page and pass forward its context to the `image_resource` partial. The important thing to note here is that the context is of the resource page, and not of the page being built.

2. The `image_resource` partial calls the `resource_url` partial with the same context (that of the resource page and not of the page being built) to calculate a relative url.

3. The `resource_url` partial uses the relative link of the context page, which is essentially the resource page to determine how many `../s` should be added to reach the root. This is incorrect as we should be reading the relative link of the page being built to determine how many levels up do we need to move to reach the root.

4. Particularly, while rendering an image on `pages/A/B`, we should be linking the `<img>` tag to `../../../static_resources/...` but step 3 links it to `../../static_resources/...` as it would be finding the root from `resources/some_image_resource`

We fix this by passing the context of the page being built to the `resource_url` partial, rather than the context of the resource page. We also ensure that we keep passing in the context of the resource page wherever it was being used/needed before.

### How can this be tested?

1. Get the git repo for https://github.mit.edu/mitocwcontent/18.02sc-fall-2010
2. Run an offline build against this repo. Set these vars in `.env`
```
COURSE_HUGO_CONFIG_PATH=<path_to_hugo_projects>ocw-course-v2/config-offline.yaml
STATIC_API_BASE_URL=https://ocw.mit.edu/
```

Then run `yarn build <path_to_18.02_content_repo> <path_to_hugo_projects>/ocw-course-v2/config-offline.yaml`

This will build an offline version of the site. However, it is still missing the static_resources. For that :-
3. Download the 18.02 course from [here](https://ocw.mit.edu/courses/18-02sc-multivariable-calculus-fall-2010/) 
4. From the download, copy the `static_resources` folder and pasted it in the offline built course from step 3. The output of the build is in the dist folder of the content repo.
5. Open the index.html from the dist folder of the content repo.
6. Go to a deeply nested page `pages/1.-vectors-and-matrices/part-a-vectors-determinants-and-planes/session-1-vectors/`
7. Verify that the images load correctly
8. Browse around the course and verify there are no broken images.