### PR TITLE
Fix some issues with the offline theme

### DIFF
--- a/base-theme/layouts/partials/image_resource.html
+++ b/base-theme/layouts/partials/image_resource.html
@@ -4,7 +4,7 @@
     {{- $imageHref = .href -}}
 {{- else if .href_uuid -}}
     {{- range where .resource.Site.Pages "Params.uid" .href_uuid -}}
-        {{- $imageHref = .Permalink -}}
+        {{- $imageHref = partial "page_url.html" (dict "context" $.context "url" .RelPermalink) -}}
     {{- end -}}
 {{- end -}}
 

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -12,7 +12,7 @@
   <div class="overflow-auto">
     <span class="course-header">
     {{ partialCached "mobile_course_nav.html" . }}
-    {{ partialCached "mobile_course_info.html" . }}
+    {{ partial "mobile_course_info.html" . }}
     {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
     </span>
     {{ $isCourseHomePage := (eq .Params.layout "course_home") }}
@@ -47,7 +47,7 @@
                   </div>
                 </div>
                 {{ if not $isCourseHomePage }}
-                  {{ partialCached "desktop_course_info.html" . }}
+                  {{ partial "desktop_course_info.html" . }}
                 {{ end }}
               </div>
             </div>

--- a/course-v2/layouts/_default/baseof.html
+++ b/course-v2/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <!doctype html>
 <html lang="{{ $.Site.Language.Lang }}">
 {{ partial "head.html" . }}
+{{ $pageDepth := strings.Count "/" .RelPermalink }}
 <body class="course-home-page">
   {{ if $gtmId }}
     <!-- Google Tag Manager (noscript) -->
@@ -12,7 +13,7 @@
   <div class="overflow-auto">
     <span class="course-header">
     {{ partialCached "mobile_course_nav.html" . }}
-    {{ partial "mobile_course_info.html" . }}
+    {{ partialCached "mobile_course_info.html" . $pageDepth }}
     {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
     </span>
     {{ $isCourseHomePage := (eq .Params.layout "course_home") }}
@@ -47,7 +48,7 @@
                   </div>
                 </div>
                 {{ if not $isCourseHomePage }}
-                  {{ partial "desktop_course_info.html" . }}
+                  {{ partialCached "desktop_course_info.html" . $pageDepth }}
                 {{ end }}
               </div>
             </div>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8663


### Description (What does it do?)
This PR fixes two issues currently present in the **offline theme**:-

1. Some legacy courses have images that link to resources. As an example, have a look at the images [here](https://ocw.mit.edu/courses/18-02sc-multivariable-calculus-fall-2010/pages/3.-double-integrals-and-line-integrals-in-the-plane/part-a-double-integrals/session-51-applications-mass-and-average-value/) Clicking on these images leads you to the relevant resource page. However, in the offline theme, clicking on them leads you to a directory listing where you have to again click on `index.html` to open the resource page (see the issue description for a screenshot). This may be unintuitive for some users, and is poor UX generally.
2. The Browse resources button is broken on nested pages ([example](https://ocw-content-offline-live-production.s3.amazonaws.com/courses/18-02sc-multivariable-calculus-fall-2010/pages/1.-vectors-and-matrices/part-a-vectors-determinants-and-planes/session-5-area-and-determinants-in-2d/index.html)) It does work fine on pages are only one level deep ([example](https://ocw-content-offline-live-production.s3.amazonaws.com/courses/18-02sc-multivariable-calculus-fall-2010/pages/1.-vectors-and-matrices/index.html)).

### How can this be tested?
1. Get the git repo for https://github.mit.edu/mitocwcontent/18.02sc-fall-2010
2. Run an offline build against this repo. Set these vars in `.env`
```
COURSE_HUGO_CONFIG_PATH=<path_to_hugo_projects>ocw-course-v2/config-offline.yaml
STATIC_API_BASE_URL=https://ocw.mit.edu/
```

Then run `yarn build <path_to_18.02_content_repo> <path_to_hugo_projects>/ocw-course-v2/config-offline.yaml`

This will build an offline version of the site. However, it is still missing the static_resources. For that :-
3. Download the 18.02 course from [here](https://ocw.mit.edu/courses/18-02sc-multivariable-calculus-fall-2010/) 
4. From the download, copy the `static_resources` folder and pasted it in the offline built course from step 3. The output of the build is in the dist folder of the content repo.
5. Open the index.html from the dist folder of the content repo.
6. Go to a deeply nested page `pages/1.-vectors-and-matrices/part-a-vectors-determinants-and-planes/session-1-vectors/`
7. Verify that the `browse resources` button works correctly
8. Go to shallower pages `pages/1.-vectors-and-matrices/part-a-vectors-determinants-and-planes` and `pages/1.-vectors-and-matrices` and verify that the `browse resources` works correctly
9. Verify that clicking on the images on the nested pages e.g `pages/1.-vectors-and-matrices/part-a-vectors-determinants-and-planes/session-1-vectors/` directly leads to the relevant resource page, instead of going to the "directory page".
10. Build an online version of the course `yarn start course <path_to_18.02_content_repo>` and perform the above verifications there as well to confirm that we haven't accidentally broken something in the online version. Also, have a general look around to verify that the general functionalities work as expected.