### PR TITLE
chore: addressed feedback and fixed bad rebase

### DIFF
--- a/base-theme/layouts/partials/extra_metadata.html
+++ b/base-theme/layouts/partials/extra_metadata.html
@@ -2,7 +2,7 @@
 {{ $imageData := partial "course-image-url.html" $context }}
 {{ $courseImageMetadata := index $imageData 1 }}
 {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-{{- $absCourseImage := printf "https://%s%s" (strings.TrimSuffix "/" $sitemapDomain) $courseImageMetadata.Params.file -}}
+{{- $absCourseImage := printf "https://%s/%s" (strings.TrimSuffix "/" $sitemapDomain) (strings.TrimPrefix "/" $courseImageMetadata.Params.file) -}}
 <meta property="og:image" content="{{- $absCourseImage -}}" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@mitocw" />

--- a/base-theme/layouts/partials/extra_metadata.html
+++ b/base-theme/layouts/partials/extra_metadata.html
@@ -2,7 +2,7 @@
 {{ $imageData := partial "course-image-url.html" $context }}
 {{ $courseImageMetadata := index $imageData 1 }}
 {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-{{- $absCourseImage := printf "https://%s%s" $sitemapDomain $courseImageMetadata.Params.file -}}
+{{- $absCourseImage := printf "https://%s%s" (strings.TrimSuffix "/" $sitemapDomain) $courseImageMetadata.Params.file -}}
 <meta property="og:image" content="{{- $absCourseImage -}}" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@mitocw" />

--- a/base-theme/layouts/partials/resource_body_v3.html
+++ b/base-theme/layouts/partials/resource_body_v3.html
@@ -10,7 +10,7 @@
       {{- end -}}
       
       <div class="resource-single-card">
-        <a class="resource-single-thumbnail-link"{{ if $downloadableLink }} href="{{- $downloadableLink -}}" target="_blank" aria-label="Download {{ .Params.title }}" download{{ end }}>
+        <a class="resource-single-thumbnail-link"{{ if $downloadableLink }} href="{{- $downloadableLink -}}" target="_blank" aria-label="Download {{ .Params.title | plainify }}" download{{ end }}>
           {{ $resourceCategory := partial "get_resource_category.html" (dict "resourceType" .Params.resourcetype "fileType" .Params.file_type) }}
           <div class="resource-card-thumbnail">
             <div class="resource-card-type {{ $resourceCategory }}">{{- $resourceCategory -}}</div>

--- a/course-v3/layouts/lists/single.html
+++ b/course-v3/layouts/lists/single.html
@@ -20,7 +20,7 @@
           </div>
         {{ end }}
         {{- partial "resource_list.html" (dict "context" . "resources" $resources "sort" false) -}}
-      </main>
+      </div>
     </article>
   </div>
 {{ end }}

--- a/course-v3/layouts/partials/extra_metadata.html
+++ b/course-v3/layouts/partials/extra_metadata.html
@@ -2,9 +2,9 @@
 {{ $imageData := partial "course-image-url.html" $context }}
 {{ $courseImageMetadata := index $imageData 1 }}
 {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-{{- $absCourseImage := printf "https://%s%s" $sitemapDomain $courseImageMetadata.Params.file -}}
+{{- $absCourseImage := printf "https://%s%s" (strings.TrimSuffix "/" $sitemapDomain) $courseImageMetadata.Params.file -}}
 <meta property="og:image" content="{{- $absCourseImage -}}" />
-<meta property="og:image:alt" content="{{ $context.Site.Data.course.course_title }}" />
+<meta property="og:image:alt" content="{{ index $courseImageMetadata.Params.image_metadata "image-alt" | default $context.Site.Data.course.course_title | plainify }}" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@mitocw" />
 <meta name="twitter:image:src" content="{{- $absCourseImage -}}" />

--- a/course-v3/layouts/partials/extra_metadata.html
+++ b/course-v3/layouts/partials/extra_metadata.html
@@ -2,7 +2,7 @@
 {{ $imageData := partial "course-image-url.html" $context }}
 {{ $courseImageMetadata := index $imageData 1 }}
 {{- $sitemapDomain := partial "sitemap_domain.html" -}}
-{{- $absCourseImage := printf "https://%s%s" (strings.TrimSuffix "/" $sitemapDomain) $courseImageMetadata.Params.file -}}
+{{- $absCourseImage := printf "https://%s/%s" (strings.TrimSuffix "/" $sitemapDomain) (strings.TrimPrefix "/" $courseImageMetadata.Params.file) -}}
 <meta property="og:image" content="{{- $absCourseImage -}}" />
 <meta property="og:image:alt" content="{{ index $courseImageMetadata.Params.image_metadata "image-alt" | default $context.Site.Data.course.course_title | plainify }}" />
 <meta name="twitter:card" content="summary_large_image" />

--- a/course-v3/layouts/partials/resource_list_item.html
+++ b/course-v3/layouts/partials/resource_list_item.html
@@ -2,7 +2,7 @@
 {{ $resourceCategory := partial "get_resource_category.html" (dict "resourceType" .Params.resourcetype "fileType" .Params.file_type) }}
 <div class="resource-card">
   {{ if not .hideThumbnail }}
-  <a class="resource-card-thumbnail-link"{{ if and $downloadableLink (not .hideDownloadIcon) }} href="{{- $downloadableLink -}}" target="_blank" aria-label="Download {{ .Params.title }}" download{{ end }}>
+  <a class="resource-card-thumbnail-link"{{ if and $downloadableLink (not .hideDownloadIcon) }} href="{{- $downloadableLink -}}" target="_blank" aria-label="Download {{ .Params.title | plainify }}" download{{ end }}>
     <div class="resource-card-thumbnail">
       <div class="resource-card-type {{ $resourceCategory }}">
         {{- $resourceCategory -}}

--- a/course-v3/layouts/partials/seo.html
+++ b/course-v3/layouts/partials/seo.html
@@ -38,7 +38,7 @@
     "publisher" (dict
       "@type" "CollegeOrUniversity"
       "name" "MIT OpenCourseWare"
-      "url" (printf "https://%s" $sitemapDomain)
+      "url" (printf "https://%s" (strings.TrimSuffix "/" $sitemapDomain))
     )
   -}}
   <script type="application/ld+json">


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10568 - follow up to https://github.com/mitodl/ocw-hugo-themes/pull/1759

### Description (What does it do?)

This plainify text and fixes a mismatch in a closing tag and. The rebase before merge mismatched a closing tags which was caught in RC.

### Netlify
https://ocw-hugo-themes-course-v3-pr-1783--ocw-next.netlify.app/

### How can this be tested?

### Manual Local Testing
1. Ensure the sibling `ocw-hugo-projects` repo is checked out with a `config-offline.yaml` pointing at the theme stack `["base-offline", "course-offline-v3", "course-v3", "base-theme"]`.
2. Build the offline site:
   ```bash
   yarn start course <course-name> --config path/to/projects/ocw-course-v3/config-offline.yaml
   ```
3. Verify pages load and render with v3 styling. etc. home page

### Regression Check
- verify from Netlify build that it did not break any existing theme feature
- Run the full E2E suite to confirm existing themes are not broken:
  ```bash
  yarn test:e2e
  ```