### PR TITLE
feat: added image picture partial and migrated existing images to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Use the shared `picture_element.html` partial for content images that should be 
 ) }}
 ```
 
-The partial renders WebP `srcset` candidates at `480w`, `800w`, `1280w`, and `1920w`, with the original image URL kept on the fallback `<img>`. Root-relative and absolute URLs are optimized; relative paths are emitted as a plain `<img>` so offline bundles continue to use original local assets. Fastly IO currently has WebP enabled for OCW; add other formats only after the service defaults support them.
+The partial renders optimized `srcset` candidates at `480w`, `800w`, `1280w`, `1920w`, `2560w`, and `3840w` using `format=auto&quality=75`. `format=auto` lets Fastly content-negotiate the best format (WebP, AVIF, or original) based on the browser's `Accept` header — no explicit format needs to be hard-coded. The extended breakpoints cover 2× and 3× retina displays. Root-relative and absolute URLs are optimized; relative paths (used in offline builds) are emitted as a plain `<img>` unchanged.
 
 Choose `sizes` based on the rendered slot width, not the source image width. Use `100vw` for full-width content images, `50vw` for two-column desktop layouts with a `100vw` mobile fallback, and fixed values such as `200px` only when the component has a fixed image slot.
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Use the shared `picture_element.html` partial for content images that should be 
 ) }}
 ```
 
-The partial renders optimized `srcset` candidates at `480w`, `800w`, `1280w`, `1920w`, `2560w`, and `3840w` using `format=auto&quality=75`. `format=auto` lets Fastly content-negotiate the best format (WebP, AVIF, or original) based on the browser's `Accept` header — no explicit format needs to be hard-coded. The extended breakpoints cover 2× and 3× retina displays. Root-relative and absolute URLs are optimized; relative paths (used in offline builds) are emitted as a plain `<img>` unchanged.
+The partial renders optimized `srcset` candidates at `480w`, `800w`, `1280w`, and `1920w` using `format=auto&quality=75`. `format=auto` lets Fastly content-negotiate the best format (WebP, AVIF, or original) based on the browser's `Accept` header — no explicit format needs to be hard-coded. `1920w` is the maximum — it covers a 2× retina display at up to 960px CSS width, which is sufficient for all layout slots in the codebase. Root-relative and absolute URLs are optimized; relative paths (used in offline builds) are emitted as a plain `<img>` unchanged.
 
 Choose `sizes` based on the rendered slot width, not the source image width. Use `100vw` for full-width content images, `50vw` for two-column desktop layouts with a `100vw` mobile fallback, and fixed values such as `200px` only when the component has a fixed image slot.
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,23 @@ To further explain the various environment variables and what they do:
 
 Most tests in OCW Hugo Themes should be written as e2e tests with Playwright. See [End to End Testing](./tests-e2e/README.md) for more.
 
+### Responsive images
+
+Use the shared `picture_element.html` partial for content images that should be served through Fastly Image Optimizer:
+
+```go-html-template
+{{ partial "picture_element.html" (dict
+  "src" (partial "resource_url.html" (dict "context" . "url" .Params.file))
+  "alt" "Descriptive alt text"
+  "class" "img-fluid"
+  "sizes" "(min-width: 992px) 50vw, 100vw"
+) }}
+```
+
+The partial renders WebP `srcset` candidates at `480w`, `800w`, `1280w`, and `1920w`, with the original image URL kept on the fallback `<img>`. Root-relative and absolute URLs are optimized; relative paths are emitted as a plain `<img>` so offline bundles continue to use original local assets. Fastly IO currently has WebP enabled for OCW; add other formats only after the service defaults support them.
+
+Choose `sizes` based on the rendered slot width, not the source image width. Use `100vw` for full-width content images, `50vw` for two-column desktop layouts with a `100vw` mobile fallback, and fixed values such as `200px` only when the component has a fixed image slot.
+
 ### Miscellaneous commands
 
 - `WEBPACK_ANALYZE=true yarn run build:webpack`: This builds the project for production and should open an analysis of the bundle in your web browser.

--- a/base-theme/assets/js/utils.test.ts
+++ b/base-theme/assets/js/utils.test.ts
@@ -5,10 +5,10 @@ describe("fastlyOptimizedUrl", () => {
     expect(
       fastlyOptimizedUrl("/images/example.jpg", {
         format:  "webp",
-        quality: "60",
+        quality: "75",
         width:   "480"
       })
-    ).toBe("/images/example.jpg?format=webp&quality=60&width=480")
+    ).toBe("/images/example.jpg?format=webp&quality=75&width=480")
   })
 
   it("preserves existing query params", () => {

--- a/base-theme/assets/js/utils.test.ts
+++ b/base-theme/assets/js/utils.test.ts
@@ -1,0 +1,64 @@
+import { fastlyOptimizedGalleryUrl, fastlyOptimizedUrl } from "./utils"
+
+describe("fastlyOptimizedUrl", () => {
+  it("adds Fastly params to root-relative URLs", () => {
+    expect(
+      fastlyOptimizedUrl("/images/example.jpg", {
+        format:  "webp",
+        quality: "60",
+        width:   "480"
+      })
+    ).toBe("/images/example.jpg?format=webp&quality=60&width=480")
+  })
+
+  it("preserves existing query params", () => {
+    expect(
+      fastlyOptimizedUrl("https://example.edu/image.jpg?foo=bar", {
+        width: "1280"
+      })
+    ).toBe("https://example.edu/image.jpg?foo=bar&width=1280")
+  })
+
+  it("leaves relative offline paths unchanged", () => {
+    expect(
+      fastlyOptimizedUrl("../../static_resources/example.jpg", {
+        width: "480"
+      })
+    ).toBe("../../static_resources/example.jpg")
+  })
+})
+
+describe("fastlyOptimizedGalleryUrl", () => {
+  it("resolves relative gallery images against a root-relative base URL", () => {
+    expect(
+      fastlyOptimizedGalleryUrl("example.jpg", "/courses/example/", {
+        format: "webp",
+        width:  "480"
+      })
+    ).toBe("/courses/example/example.jpg?format=webp&width=480")
+  })
+
+  it("resolves relative gallery images against an absolute base URL", () => {
+    expect(
+      fastlyOptimizedGalleryUrl(
+        "example.jpg",
+        "https://ocw.mit.edu/courses/example/",
+        {
+          format: "webp",
+          width:  "1920"
+        }
+      )
+    ).toBe(
+      "https://ocw.mit.edu/courses/example/example.jpg?format=webp&width=1920"
+    )
+  })
+
+  it("leaves relative gallery images unchanged for offline base URLs", () => {
+    expect(
+      fastlyOptimizedGalleryUrl("example.jpg", "../../", {
+        format: "webp",
+        width:  "480"
+      })
+    ).toBe("example.jpg")
+  })
+})

--- a/base-theme/assets/js/utils.ts
+++ b/base-theme/assets/js/utils.ts
@@ -48,3 +48,18 @@ function setOrGetLocalStorageItemHelper(
     return false
   }
 }
+
+/**
+ * Appends Fastly Image Optimizer query params to an image URL.
+ * Only applies to absolute (http/https) or root-relative (/) URLs;
+ * relative paths (offline builds) are returned unchanged.
+ */
+export function fastlyOptimizedUrl(
+  url: string,
+  params: Record<string, string>
+): string {
+  if (!url || (!url.startsWith("http") && !url.startsWith("/"))) return url
+  const separator = url.includes("?") ? "&" : "?"
+  const qs = new URLSearchParams(params).toString()
+  return `${url}${separator}${qs}`
+}

--- a/base-theme/assets/js/utils.ts
+++ b/base-theme/assets/js/utils.ts
@@ -58,8 +58,33 @@ export function fastlyOptimizedUrl(
   url: string,
   params: Record<string, string>
 ): string {
-  if (!url || (!url.startsWith("http") && !url.startsWith("/"))) return url
+  if (!url || (!/^https?:\/\//.test(url) && !url.startsWith("/"))) return url
   const separator = url.includes("?") ? "&" : "?"
   const qs = new URLSearchParams(params).toString()
   return `${url}${separator}${qs}`
+}
+
+/**
+ * Resolves gallery item hrefs against an online gallery base URL before adding
+ * Fastly params. Relative offline paths are intentionally left unchanged.
+ */
+export function fastlyOptimizedGalleryUrl(
+  url: string,
+  baseUrl: string,
+  params: Record<string, string>
+): string {
+  let resolvedUrl = url
+
+  if (url && !/^https?:\/\//.test(url) && !url.startsWith("/")) {
+    if (/^https?:\/\//.test(baseUrl)) {
+      resolvedUrl = new URL(
+        url,
+        baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`
+      ).toString()
+    } else if (baseUrl.startsWith("/")) {
+      resolvedUrl = `${baseUrl.replace(/\/?$/, "/")}${url.replace(/^\/+/, "")}`
+    }
+  }
+
+  return fastlyOptimizedUrl(resolvedUrl, params)
 }

--- a/base-theme/layouts/partials/collection_cover_image.html
+++ b/base-theme/layouts/partials/collection_cover_image.html
@@ -6,6 +6,6 @@
   {{- $collectionImageMetadata = partial "resource_metadata.html" $collectionImageUuid.content }}
   {{- $url := delimit (slice (strings.TrimSuffix "/" $staticApiBaseUrl) $collectionImageMetadata.Params.file) "" -}}
   <div id="collection-header">
-    <img src='{{ partial "resource_url.html" (dict "context" . "url" $url) }}' alt='{{ $collectionImageMetadata.Params.metadata.image_alt }}' />
+    {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" $url)) "alt" $collectionImageMetadata.Params.metadata.image_alt "sizes" "100vw") }}
   </div>
 {{ end }}

--- a/base-theme/layouts/partials/course_carousel_card.html
+++ b/base-theme/layouts/partials/course_carousel_card.html
@@ -20,7 +20,7 @@
 <div class="item-wrapper {{ if not $isMobile }}col-{{ (div 12 .itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
   <div class="course-card card bg-white">
     <a href="{{ partial "site_root_url.html" $urlPath }}" aria-hidden="true" tabindex="-1">
-      <img src="{{ partial "resource_url.html" (dict "context" . "url" $courseImageSrc) }}" alt=""/>
+      {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" $courseImageSrc)) "sizes" "(min-width: 992px) 25vw, (min-width: 768px) 33vw, 100vw") }}
     </a>
     <div class="course-card-content pt-1 px-3 pb-3">
       <div class="course-level">

--- a/base-theme/layouts/partials/image_page.html
+++ b/base-theme/layouts/partials/image_page.html
@@ -23,7 +23,7 @@
 {{- if .Params.file -}}
     <div class="row">
         <div class="col-12">
-            <img class="mw-100 mt-2" src="{{ partial "resource_url.html" (dict "context" . "url" .Params.file) }}" alt="{{ if .Params.image_metadata }}{{ index .Params.image_metadata "image-alt" }}{{ end }}" />
+            {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" .Params.file)) "alt" (cond (isset .Params "image_metadata") (index .Params.image_metadata "image-alt" | default "") "") "class" "mw-100 mt-2" "sizes" "100vw") }}
         </div>
     </div>
 {{- end -}}

--- a/base-theme/layouts/partials/image_page.html
+++ b/base-theme/layouts/partials/image_page.html
@@ -23,7 +23,7 @@
 {{- if .Params.file -}}
     <div class="row">
         <div class="col-12">
-            {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" .Params.file)) "alt" (cond (isset .Params "image_metadata") (index .Params.image_metadata "image-alt" | default "") "") "class" "mw-100 mt-2" "sizes" "100vw") }}
+            {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" .Params.file)) "alt" (index (.Params.image_metadata | default dict) "image-alt" | default "") "class" "mw-100 mt-2" "sizes" "100vw") }}
         </div>
     </div>
 {{- end -}}

--- a/base-theme/layouts/partials/image_page.html
+++ b/base-theme/layouts/partials/image_page.html
@@ -21,9 +21,15 @@
 {{- end -}}
 
 {{- if .Params.file -}}
+    {{- $src := partial "resource_url.html" (dict "context" . "url" .Params.file) -}}
+    {{- $canOptimize := or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
+    {{- if $canOptimize -}}
+        {{- $sep := cond (strings.Contains $src "?") "&" "?" -}}
+        {{- $src = printf "%s%sformat=auto&quality=75" $src $sep -}}
+    {{- end -}}
     <div class="row">
         <div class="col-12">
-            {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" .Params.file)) "alt" (index (.Params.image_metadata | default dict) "image-alt" | default "") "class" "mw-100 mt-2" "sizes" "100vw") }}
+            <img class="mw-100 mt-2" src="{{ $src }}" alt="{{ index (.Params.image_metadata | default dict) "image-alt" | default "" }}" loading="eager" />
         </div>
     </div>
 {{- end -}}

--- a/base-theme/layouts/partials/image_page.html
+++ b/base-theme/layouts/partials/image_page.html
@@ -21,15 +21,9 @@
 {{- end -}}
 
 {{- if .Params.file -}}
-    {{- $src := partial "resource_url.html" (dict "context" . "url" .Params.file) -}}
-    {{- $canOptimize := or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
-    {{- if $canOptimize -}}
-        {{- $sep := cond (strings.Contains $src "?") "&" "?" -}}
-        {{- $src = printf "%s%sformat=auto&quality=75" $src $sep -}}
-    {{- end -}}
     <div class="row">
         <div class="col-12">
-            <img class="mw-100 mt-2" src="{{ $src }}" alt="{{ index (.Params.image_metadata | default dict) "image-alt" | default "" }}" loading="eager" />
+            {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" .Params.file)) "alt" (index (.Params.image_metadata | default dict) "image-alt" | default "") "class" "mw-100 mt-2" "loading" "eager") }}
         </div>
     </div>
 {{- end -}}

--- a/base-theme/layouts/partials/image_resource.html
+++ b/base-theme/layouts/partials/image_resource.html
@@ -12,7 +12,7 @@
     <a href="{{- $imageHref -}}" target="_blank">
 {{- end -}}
 {{- $metadata := .resource.Params.image_metadata | default dict -}}
-<img src="{{ partial "resource_url.html" (dict "context" .context "url" .resource.Params.file) }}" {{ if index $metadata "image-alt" -}}alt="{{ index $metadata "image-alt" }}"{{- end }} />
+{{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" .context "url" .resource.Params.file)) "alt" (index $metadata "image-alt" | default "") "sizes" "100vw") }}
 {{- if $imageHref -}}
     </a>
 {{- end -}}

--- a/base-theme/layouts/partials/image_resource.html
+++ b/base-theme/layouts/partials/image_resource.html
@@ -12,7 +12,7 @@
     <a href="{{- $imageHref -}}" target="_blank">
 {{- end -}}
 {{- $metadata := .resource.Params.image_metadata | default dict -}}
-{{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" .context "url" .resource.Params.file)) "alt" (index $metadata "image-alt" | default "") "sizes" "100vw") }}
+{{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" .context "url" .resource.Params.file)) "alt" (index $metadata "image-alt" | default "")) }}
 {{- if $imageHref -}}
     </a>
 {{- end -}}

--- a/base-theme/layouts/partials/picture_element.html
+++ b/base-theme/layouts/partials/picture_element.html
@@ -19,10 +19,12 @@
   Output (when optimizable):
     <picture>
       <source type="image/avif"
-              srcset="<src>?format=avif&quality=60&width=1280 1280w,
+              srcset="<src>?format=avif&quality=60&width=480 480w,
+                      <src>?format=avif&quality=60&width=800 800w,
+                      <src>?format=avif&quality=60&width=1280 1280w,
                       <src>?format=avif&quality=60&width=1920 1920w"
               sizes="...">
-      <img src="<src>" ...>
+      <img src="<src>" alt="..." ...>
     </picture>
 */}}
 
@@ -38,15 +40,17 @@
   {{- $canOptimize := or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
   {{- if $canOptimize -}}
     {{- $separator := cond (strings.Contains $src "?") "&" "?" -}}
+    {{- $avif480  := printf "%s%sformat=avif&quality=60&width=480 480w"   $src $separator -}}
+    {{- $avif800  := printf "%s%sformat=avif&quality=60&width=800 800w"   $src $separator -}}
     {{- $avif1280 := printf "%s%sformat=avif&quality=60&width=1280 1280w" $src $separator -}}
     {{- $avif1920 := printf "%s%sformat=avif&quality=60&width=1920 1920w" $src $separator -}}
 <picture>
   <source type="image/avif"
-          srcset="{{ $avif1280 }}, {{ $avif1920 }}"
+          srcset="{{ $avif480 }}, {{ $avif800 }}, {{ $avif1280 }}, {{ $avif1920 }}"
           sizes="{{ $sizes }}">
-  <img src="{{ $src }}"{{ with $alt }} alt="{{ . }}"{{ end }}{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
+  <img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
 </picture>
   {{- else -}}
-<img src="{{ $src }}"{{ with $alt }} alt="{{ . }}"{{ end }}{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
+<img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
   {{- end -}}
 {{- end -}}

--- a/base-theme/layouts/partials/picture_element.html
+++ b/base-theme/layouts/partials/picture_element.html
@@ -1,0 +1,52 @@
+{{/*
+  Renders a responsive <picture> element with AVIF srcset via Fastly Image Optimizer,
+  falling back to the original image for non-AVIF browsers and offline builds.
+
+  Parameters (via dict):
+    .src      — required — already-resolved image URL (from resource_url.html or similar)
+    .alt      — optional — alt text (default "")
+    .class    — optional — CSS class(es) for the <img> element
+    .sizes    — optional — sizes attribute (default "100vw")
+    .loading  — optional — loading attribute (default "lazy")
+    .decoding — optional — decoding attribute (default "async")
+
+  Optimization is applied when the src is an absolute URL (http(s)://) or a root-relative
+  path (/images/...). Both will be served through Fastly in production.
+
+  When the src is a relative path (e.g. ../../static_resources/..., used in offline builds),
+  the partial emits a plain <img> without optimization.
+
+  Output (when optimizable):
+    <picture>
+      <source type="image/avif"
+              srcset="<src>?format=avif&quality=60&width=1280 1280w,
+                      <src>?format=avif&quality=60&width=1920 1920w"
+              sizes="...">
+      <img src="<src>" ...>
+    </picture>
+*/}}
+
+{{- $src      := .src | default "" -}}
+{{- $alt      := .alt | default "" -}}
+{{- $class    := .class | default "" -}}
+{{- $sizes    := .sizes | default "100vw" -}}
+{{- $loading  := .loading | default "lazy" -}}
+{{- $decoding := .decoding | default "async" -}}
+
+{{- if $src -}}
+  {{/* Optimize absolute URLs and root-relative paths; skip relative paths (offline) */}}
+  {{- $canOptimize := or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
+  {{- if $canOptimize -}}
+    {{- $separator := cond (strings.Contains $src "?") "&" "?" -}}
+    {{- $avif1280 := printf "%s%sformat=avif&quality=60&width=1280 1280w" $src $separator -}}
+    {{- $avif1920 := printf "%s%sformat=avif&quality=60&width=1920 1920w" $src $separator -}}
+<picture>
+  <source type="image/avif"
+          srcset="{{ $avif1280 }}, {{ $avif1920 }}"
+          sizes="{{ $sizes }}">
+  <img src="{{ $src }}"{{ with $alt }} alt="{{ . }}"{{ end }}{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
+</picture>
+  {{- else -}}
+<img src="{{ $src }}"{{ with $alt }} alt="{{ . }}"{{ end }}{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
+  {{- end -}}
+{{- end -}}

--- a/base-theme/layouts/partials/picture_element.html
+++ b/base-theme/layouts/partials/picture_element.html
@@ -1,6 +1,10 @@
 {{/*
-  Renders a responsive <picture> element with AVIF srcset via Fastly Image Optimizer,
-  falling back to the original image for non-AVIF browsers and offline builds.
+  Renders a responsive <picture> element with WebP srcset via Fastly Image Optimizer,
+  falling back to the original image for non-WebP browsers and offline builds.
+
+  Fastly IO is configured with webp=True in image_optimizer_default_settings.
+  WebP is the only format currently enabled at the Fastly service level; AVIF support
+  can be added once avif=True is set in the Pulumi config for ocw_site.
 
   Parameters (via dict):
     .src      — required — already-resolved image URL (from resource_url.html or similar)
@@ -18,11 +22,11 @@
 
   Output (when optimizable):
     <picture>
-      <source type="image/avif"
-              srcset="<src>?format=avif&quality=60&width=480 480w,
-                      <src>?format=avif&quality=60&width=800 800w,
-                      <src>?format=avif&quality=60&width=1280 1280w,
-                      <src>?format=avif&quality=60&width=1920 1920w"
+      <source type="image/webp"
+              srcset="<src>?format=webp&quality=60&width=480 480w,
+                      <src>?format=webp&quality=60&width=800 800w,
+                      <src>?format=webp&quality=60&width=1280 1280w,
+                      <src>?format=webp&quality=60&width=1920 1920w"
               sizes="...">
       <img src="<src>" alt="..." ...>
     </picture>
@@ -40,13 +44,13 @@
   {{- $canOptimize := or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
   {{- if $canOptimize -}}
     {{- $separator := cond (strings.Contains $src "?") "&" "?" -}}
-    {{- $avif480  := printf "%s%sformat=avif&quality=60&width=480 480w"   $src $separator -}}
-    {{- $avif800  := printf "%s%sformat=avif&quality=60&width=800 800w"   $src $separator -}}
-    {{- $avif1280 := printf "%s%sformat=avif&quality=60&width=1280 1280w" $src $separator -}}
-    {{- $avif1920 := printf "%s%sformat=avif&quality=60&width=1920 1920w" $src $separator -}}
-<picture>
-  <source type="image/avif"
-          srcset="{{ $avif480 }}, {{ $avif800 }}, {{ $avif1280 }}, {{ $avif1920 }}"
+    {{- $webp480  := printf "%s%sformat=webp&quality=60&width=480 480w"   $src $separator -}}
+    {{- $webp800  := printf "%s%sformat=webp&quality=60&width=800 800w"   $src $separator -}}
+    {{- $webp1280 := printf "%s%sformat=webp&quality=60&width=1280 1280w" $src $separator -}}
+    {{- $webp1920 := printf "%s%sformat=webp&quality=60&width=1920 1920w" $src $separator -}}
+<picture style="display: contents">
+  <source type="image/webp"
+          srcset="{{ $webp480 }}, {{ $webp800 }}, {{ $webp1280 }}, {{ $webp1920 }}"
           sizes="{{ $sizes }}">
   <img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
 </picture>

--- a/base-theme/layouts/partials/picture_element.html
+++ b/base-theme/layouts/partials/picture_element.html
@@ -22,11 +22,22 @@
 
   Output (when optimizable):
     <picture>
+      <!-- 3x DPR (e.g. modern smartphones): Fastly dpr=3 returns width*3 physical pixels -->
       <source type="image/webp"
-              srcset="<src>?format=webp&quality=60&width=480 480w,
-                      <src>?format=webp&quality=60&width=800 800w,
-                      <src>?format=webp&quality=60&width=1280 1280w,
-                      <src>?format=webp&quality=60&width=1920 1920w"
+              media="(-webkit-min-device-pixel-ratio: 3), (min-resolution: 288dpi)"
+              srcset="<src>?format=webp&quality=75&width=480&dpr=3 480w, ..."
+              sizes="...">
+      <!-- 2x DPR (e.g. Retina laptops, iPhone): Fastly dpr=2 returns width*2 physical pixels -->
+      <source type="image/webp"
+              media="(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)"
+              srcset="<src>?format=webp&quality=75&width=480&dpr=2 480w, ..."
+              sizes="...">
+      <!-- 1x DPR fallback -->
+      <source type="image/webp"
+              srcset="<src>?format=webp&quality=75&width=480 480w,
+                      <src>?format=webp&quality=75&width=800 800w,
+                      <src>?format=webp&quality=75&width=1280 1280w,
+                      <src>?format=webp&quality=75&width=1920 1920w"
               sizes="...">
       <img src="<src>" alt="..." ...>
     </picture>
@@ -43,12 +54,28 @@
   {{/* Optimize absolute URLs and root-relative paths; skip relative paths (offline) */}}
   {{- $canOptimize := or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
   {{- if $canOptimize -}}
-    {{- $separator := cond (strings.Contains $src "?") "&" "?" -}}
-    {{- $webp480  := printf "%s%sformat=webp&quality=60&width=480 480w"   $src $separator -}}
-    {{- $webp800  := printf "%s%sformat=webp&quality=60&width=800 800w"   $src $separator -}}
-    {{- $webp1280 := printf "%s%sformat=webp&quality=60&width=1280 1280w" $src $separator -}}
-    {{- $webp1920 := printf "%s%sformat=webp&quality=60&width=1920 1920w" $src $separator -}}
+    {{- $separator   := cond (strings.Contains $src "?") "&" "?" -}}
+    {{- $webp480     := printf "%s%sformat=webp&quality=75&width=480 480w"          $src $separator -}}
+    {{- $webp800     := printf "%s%sformat=webp&quality=75&width=800 800w"          $src $separator -}}
+    {{- $webp1280    := printf "%s%sformat=webp&quality=75&width=1280 1280w"        $src $separator -}}
+    {{- $webp1920    := printf "%s%sformat=webp&quality=75&width=1920 1920w"        $src $separator -}}
+    {{- $webp480_2x  := printf "%s%sformat=webp&quality=75&width=480&dpr=2 480w"   $src $separator -}}
+    {{- $webp800_2x  := printf "%s%sformat=webp&quality=75&width=800&dpr=2 800w"   $src $separator -}}
+    {{- $webp1280_2x := printf "%s%sformat=webp&quality=75&width=1280&dpr=2 1280w" $src $separator -}}
+    {{- $webp1920_2x := printf "%s%sformat=webp&quality=75&width=1920&dpr=2 1920w" $src $separator -}}
+    {{- $webp480_3x  := printf "%s%sformat=webp&quality=75&width=480&dpr=3 480w"   $src $separator -}}
+    {{- $webp800_3x  := printf "%s%sformat=webp&quality=75&width=800&dpr=3 800w"   $src $separator -}}
+    {{- $webp1280_3x := printf "%s%sformat=webp&quality=75&width=1280&dpr=3 1280w" $src $separator -}}
+    {{- $webp1920_3x := printf "%s%sformat=webp&quality=75&width=1920&dpr=3 1920w" $src $separator -}}
 <picture style="display: contents">
+  <source type="image/webp"
+          media="(-webkit-min-device-pixel-ratio: 3), (min-resolution: 288dpi)"
+          srcset="{{ $webp480_3x }}, {{ $webp800_3x }}, {{ $webp1280_3x }}, {{ $webp1920_3x }}"
+          sizes="{{ $sizes }}">
+  <source type="image/webp"
+          media="(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)"
+          srcset="{{ $webp480_2x }}, {{ $webp800_2x }}, {{ $webp1280_2x }}, {{ $webp1920_2x }}"
+          sizes="{{ $sizes }}">
   <source type="image/webp"
           srcset="{{ $webp480 }}, {{ $webp800 }}, {{ $webp1280 }}, {{ $webp1920 }}"
           sizes="{{ $sizes }}">

--- a/base-theme/layouts/partials/picture_element.html
+++ b/base-theme/layouts/partials/picture_element.html
@@ -32,9 +32,7 @@
          srcset="<src>?format=auto&quality=75&width=480 480w,
                  <src>?format=auto&quality=75&width=800 800w,
                  <src>?format=auto&quality=75&width=1280 1280w,
-                 <src>?format=auto&quality=75&width=1920 1920w,
-                 <src>?format=auto&quality=75&width=2560 2560w,
-                 <src>?format=auto&quality=75&width=3840 3840w"
+                 <src>?format=auto&quality=75&width=1920 1920w"
          sizes="..."
          alt="..." ...>
 
@@ -42,8 +40,9 @@
     <img src="<src>?format=auto&quality=75" alt="..." ...>
 
   DPR handling: browsers using `w` descriptors already factor in devicePixelRatio when
-  selecting a srcset candidate. The extended breakpoints (2560w, 3840w) cover 2x and 3x
-  retina displays natively — no Fastly dpr= param or extra <source> elements are needed.
+  selecting a srcset candidate. 1920w is the maximum — images wider than 1920px are
+  uncommon in the OCW content library, and 1920w already covers a 2x retina display
+  at up to 960px CSS width.
 */}}
 
 {{- $src           := .src | default "" -}}
@@ -65,9 +64,7 @@
       {{- $w800  := printf "%s%sformat=auto&quality=75&width=800 800w"   $src $separator -}}
       {{- $w1280 := printf "%s%sformat=auto&quality=75&width=1280 1280w" $src $separator -}}
       {{- $w1920 := printf "%s%sformat=auto&quality=75&width=1920 1920w" $src $separator -}}
-      {{- $w2560 := printf "%s%sformat=auto&quality=75&width=2560 2560w" $src $separator -}}
-      {{- $w3840 := printf "%s%sformat=auto&quality=75&width=3840 3840w" $src $separator -}}
-<img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} srcset="{{ $w480 }}, {{ $w800 }}, {{ $w1280 }}, {{ $w1920 }}, {{ $w2560 }}, {{ $w3840 }}" sizes="{{ $sizes }}" loading="{{ $loading }}" decoding="{{ $decoding }}"{{ with $fetchpriority }} fetchpriority="{{ . }}"{{ end }} />
+<img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} srcset="{{ $w480 }}, {{ $w800 }}, {{ $w1280 }}, {{ $w1920 }}" sizes="{{ $sizes }}" loading="{{ $loading }}" decoding="{{ $decoding }}"{{ with $fetchpriority }} fetchpriority="{{ . }}"{{ end }} />
     {{- else -}}
       {{- $optimizedSrc := printf "%s%sformat=auto&quality=75" $src $separator -}}
 <img src="{{ $optimizedSrc }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}"{{ with $fetchpriority }} fetchpriority="{{ . }}"{{ end }} />

--- a/base-theme/layouts/partials/picture_element.html
+++ b/base-theme/layouts/partials/picture_element.html
@@ -1,5 +1,5 @@
 {{/*
-  Renders a responsive <img> with srcset/sizes via Fastly Image Optimizer.
+  Renders a responsive <img> with Fastly Image Optimizer.
 
   Uses format=auto so Fastly serves WebP to browsers that accept it (via the Accept
   request header) and the original format to browsers that do not. This is semantically
@@ -12,7 +12,11 @@
     .src           — required — already-resolved image URL (from resource_url.html or similar)
     .alt           — optional — alt text (default "")
     .class         — optional — CSS class(es) for the <img> element
-    .sizes         — optional — sizes attribute (default "100vw")
+    .sizes         — optional — sizes attribute; when provided, a full srcset is emitted so
+                                Fastly serves the most appropriate width for each viewport.
+                                When omitted, only format=auto&quality=75 is applied to src
+                                (format optimization without size variants). Callers should
+                                only pass sizes when the display width is known.
     .loading       — optional — loading attribute (default "lazy")
     .decoding      — optional — decoding attribute (default "async")
     .fetchpriority — optional — fetchpriority hint ("high", "low", "auto")
@@ -23,7 +27,7 @@
   When the src is a relative path (e.g. ../../static_resources/..., used in offline builds),
   the partial emits a plain <img> without optimization.
 
-  Output (when optimizable):
+  Output (when optimizable, sizes provided):
     <img src="<src>"
          srcset="<src>?format=auto&quality=75&width=480 480w,
                  <src>?format=auto&quality=75&width=800 800w,
@@ -34,6 +38,9 @@
          sizes="..."
          alt="..." ...>
 
+  Output (when optimizable, no sizes):
+    <img src="<src>?format=auto&quality=75" alt="..." ...>
+
   DPR handling: browsers using `w` descriptors already factor in devicePixelRatio when
   selecting a srcset candidate. The extended breakpoints (2560w, 3840w) cover 2x and 3x
   retina displays natively — no Fastly dpr= param or extra <source> elements are needed.
@@ -42,7 +49,7 @@
 {{- $src           := .src | default "" -}}
 {{- $alt           := .alt | default "" -}}
 {{- $class         := .class | default "" -}}
-{{- $sizes         := .sizes | default "100vw" -}}
+{{- $sizes         := .sizes | default "" -}}
 {{- $loading       := .loading | default "lazy" -}}
 {{- $decoding      := .decoding | default "async" -}}
 {{- $fetchpriority := .fetchpriority | default "" -}}
@@ -52,13 +59,19 @@
   {{- $canOptimize := or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
   {{- if $canOptimize -}}
     {{- $separator := cond (strings.Contains $src "?") "&" "?" -}}
-    {{- $w480  := printf "%s%sformat=auto&quality=75&width=480 480w"   $src $separator -}}
-    {{- $w800  := printf "%s%sformat=auto&quality=75&width=800 800w"   $src $separator -}}
-    {{- $w1280 := printf "%s%sformat=auto&quality=75&width=1280 1280w" $src $separator -}}
-    {{- $w1920 := printf "%s%sformat=auto&quality=75&width=1920 1920w" $src $separator -}}
-    {{- $w2560 := printf "%s%sformat=auto&quality=75&width=2560 2560w" $src $separator -}}
-    {{- $w3840 := printf "%s%sformat=auto&quality=75&width=3840 3840w" $src $separator -}}
+    {{- if $sizes -}}
+      {{/* sizes provided: emit full srcset so browser picks the right width */}}
+      {{- $w480  := printf "%s%sformat=auto&quality=75&width=480 480w"   $src $separator -}}
+      {{- $w800  := printf "%s%sformat=auto&quality=75&width=800 800w"   $src $separator -}}
+      {{- $w1280 := printf "%s%sformat=auto&quality=75&width=1280 1280w" $src $separator -}}
+      {{- $w1920 := printf "%s%sformat=auto&quality=75&width=1920 1920w" $src $separator -}}
+      {{- $w2560 := printf "%s%sformat=auto&quality=75&width=2560 2560w" $src $separator -}}
+      {{- $w3840 := printf "%s%sformat=auto&quality=75&width=3840 3840w" $src $separator -}}
 <img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} srcset="{{ $w480 }}, {{ $w800 }}, {{ $w1280 }}, {{ $w1920 }}, {{ $w2560 }}, {{ $w3840 }}" sizes="{{ $sizes }}" loading="{{ $loading }}" decoding="{{ $decoding }}"{{ with $fetchpriority }} fetchpriority="{{ . }}"{{ end }} />
+    {{- else -}}
+      {{- $optimizedSrc := printf "%s%sformat=auto&quality=75" $src $separator -}}
+<img src="{{ $optimizedSrc }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}"{{ with $fetchpriority }} fetchpriority="{{ . }}"{{ end }} />
+    {{- end -}}
   {{- else -}}
 <img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}"{{ with $fetchpriority }} fetchpriority="{{ . }}"{{ end }} />
   {{- end -}}

--- a/base-theme/layouts/partials/picture_element.html
+++ b/base-theme/layouts/partials/picture_element.html
@@ -9,12 +9,13 @@
   Fastly IO is configured with webp=True in image_optimizer_default_settings.
 
   Parameters (via dict):
-    .src      — required — already-resolved image URL (from resource_url.html or similar)
-    .alt      — optional — alt text (default "")
-    .class    — optional — CSS class(es) for the <img> element
-    .sizes    — optional — sizes attribute (default "100vw")
-    .loading  — optional — loading attribute (default "lazy")
-    .decoding — optional — decoding attribute (default "async")
+    .src           — required — already-resolved image URL (from resource_url.html or similar)
+    .alt           — optional — alt text (default "")
+    .class         — optional — CSS class(es) for the <img> element
+    .sizes         — optional — sizes attribute (default "100vw")
+    .loading       — optional — loading attribute (default "lazy")
+    .decoding      — optional — decoding attribute (default "async")
+    .fetchpriority — optional — fetchpriority hint ("high", "low", "auto")
 
   Optimization is applied when the src is an absolute URL (http(s)://) or a root-relative
   path (/images/...). Both will be served through Fastly in production.
@@ -38,12 +39,13 @@
   retina displays natively — no Fastly dpr= param or extra <source> elements are needed.
 */}}
 
-{{- $src      := .src | default "" -}}
-{{- $alt      := .alt | default "" -}}
-{{- $class    := .class | default "" -}}
-{{- $sizes    := .sizes | default "100vw" -}}
-{{- $loading  := .loading | default "lazy" -}}
-{{- $decoding := .decoding | default "async" -}}
+{{- $src           := .src | default "" -}}
+{{- $alt           := .alt | default "" -}}
+{{- $class         := .class | default "" -}}
+{{- $sizes         := .sizes | default "100vw" -}}
+{{- $loading       := .loading | default "lazy" -}}
+{{- $decoding      := .decoding | default "async" -}}
+{{- $fetchpriority := .fetchpriority | default "" -}}
 
 {{- if $src -}}
   {{/* Optimize absolute URLs and root-relative paths; skip relative paths (offline) */}}
@@ -56,8 +58,8 @@
     {{- $w1920 := printf "%s%sformat=auto&quality=75&width=1920 1920w" $src $separator -}}
     {{- $w2560 := printf "%s%sformat=auto&quality=75&width=2560 2560w" $src $separator -}}
     {{- $w3840 := printf "%s%sformat=auto&quality=75&width=3840 3840w" $src $separator -}}
-<img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} srcset="{{ $w480 }}, {{ $w800 }}, {{ $w1280 }}, {{ $w1920 }}, {{ $w2560 }}, {{ $w3840 }}" sizes="{{ $sizes }}" loading="{{ $loading }}" decoding="{{ $decoding }}" />
+<img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} srcset="{{ $w480 }}, {{ $w800 }}, {{ $w1280 }}, {{ $w1920 }}, {{ $w2560 }}, {{ $w3840 }}" sizes="{{ $sizes }}" loading="{{ $loading }}" decoding="{{ $decoding }}"{{ with $fetchpriority }} fetchpriority="{{ . }}"{{ end }} />
   {{- else -}}
-<img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
+<img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}"{{ with $fetchpriority }} fetchpriority="{{ . }}"{{ end }} />
   {{- end -}}
 {{- end -}}

--- a/base-theme/layouts/partials/picture_element.html
+++ b/base-theme/layouts/partials/picture_element.html
@@ -22,22 +22,11 @@
 
   Output (when optimizable):
     <picture>
-      <!-- 3x DPR (e.g. modern smartphones): Fastly dpr=3 returns width*3 physical pixels -->
       <source type="image/webp"
-              media="(-webkit-min-device-pixel-ratio: 3), (min-resolution: 288dpi)"
-              srcset="<src>?format=webp&quality=75&width=480&dpr=3 480w, ..."
-              sizes="...">
-      <!-- 2x DPR (e.g. Retina laptops, iPhone): Fastly dpr=2 returns width*2 physical pixels -->
-      <source type="image/webp"
-              media="(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)"
-              srcset="<src>?format=webp&quality=75&width=480&dpr=2 480w, ..."
-              sizes="...">
-      <!-- 1x DPR fallback -->
-      <source type="image/webp"
-              srcset="<src>?format=webp&quality=75&width=480 480w,
-                      <src>?format=webp&quality=75&width=800 800w,
-                      <src>?format=webp&quality=75&width=1280 1280w,
-                      <src>?format=webp&quality=75&width=1920 1920w"
+              srcset="<src>?format=webp&quality=60&width=480 480w,
+                      <src>?format=webp&quality=60&width=800 800w,
+                      <src>?format=webp&quality=60&width=1280 1280w,
+                      <src>?format=webp&quality=60&width=1920 1920w"
               sizes="...">
       <img src="<src>" alt="..." ...>
     </picture>
@@ -54,28 +43,12 @@
   {{/* Optimize absolute URLs and root-relative paths; skip relative paths (offline) */}}
   {{- $canOptimize := or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
   {{- if $canOptimize -}}
-    {{- $separator   := cond (strings.Contains $src "?") "&" "?" -}}
-    {{- $webp480     := printf "%s%sformat=webp&quality=75&width=480 480w"          $src $separator -}}
-    {{- $webp800     := printf "%s%sformat=webp&quality=75&width=800 800w"          $src $separator -}}
-    {{- $webp1280    := printf "%s%sformat=webp&quality=75&width=1280 1280w"        $src $separator -}}
-    {{- $webp1920    := printf "%s%sformat=webp&quality=75&width=1920 1920w"        $src $separator -}}
-    {{- $webp480_2x  := printf "%s%sformat=webp&quality=75&width=480&dpr=2 480w"   $src $separator -}}
-    {{- $webp800_2x  := printf "%s%sformat=webp&quality=75&width=800&dpr=2 800w"   $src $separator -}}
-    {{- $webp1280_2x := printf "%s%sformat=webp&quality=75&width=1280&dpr=2 1280w" $src $separator -}}
-    {{- $webp1920_2x := printf "%s%sformat=webp&quality=75&width=1920&dpr=2 1920w" $src $separator -}}
-    {{- $webp480_3x  := printf "%s%sformat=webp&quality=75&width=480&dpr=3 480w"   $src $separator -}}
-    {{- $webp800_3x  := printf "%s%sformat=webp&quality=75&width=800&dpr=3 800w"   $src $separator -}}
-    {{- $webp1280_3x := printf "%s%sformat=webp&quality=75&width=1280&dpr=3 1280w" $src $separator -}}
-    {{- $webp1920_3x := printf "%s%sformat=webp&quality=75&width=1920&dpr=3 1920w" $src $separator -}}
+    {{- $separator := cond (strings.Contains $src "?") "&" "?" -}}
+    {{- $webp480  := printf "%s%sformat=webp&quality=60&width=480 480w"   $src $separator -}}
+    {{- $webp800  := printf "%s%sformat=webp&quality=60&width=800 800w"   $src $separator -}}
+    {{- $webp1280 := printf "%s%sformat=webp&quality=60&width=1280 1280w" $src $separator -}}
+    {{- $webp1920 := printf "%s%sformat=webp&quality=60&width=1920 1920w" $src $separator -}}
 <picture style="display: contents">
-  <source type="image/webp"
-          media="(-webkit-min-device-pixel-ratio: 3), (min-resolution: 288dpi)"
-          srcset="{{ $webp480_3x }}, {{ $webp800_3x }}, {{ $webp1280_3x }}, {{ $webp1920_3x }}"
-          sizes="{{ $sizes }}">
-  <source type="image/webp"
-          media="(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)"
-          srcset="{{ $webp480_2x }}, {{ $webp800_2x }}, {{ $webp1280_2x }}, {{ $webp1920_2x }}"
-          sizes="{{ $sizes }}">
   <source type="image/webp"
           srcset="{{ $webp480 }}, {{ $webp800 }}, {{ $webp1280 }}, {{ $webp1920 }}"
           sizes="{{ $sizes }}">

--- a/base-theme/layouts/partials/picture_element.html
+++ b/base-theme/layouts/partials/picture_element.html
@@ -1,10 +1,12 @@
 {{/*
-  Renders a responsive <picture> element with WebP srcset via Fastly Image Optimizer,
-  falling back to the original image for non-WebP browsers and offline builds.
+  Renders a responsive <img> with srcset/sizes via Fastly Image Optimizer.
+
+  Uses format=auto so Fastly serves WebP to browsers that accept it (via the Accept
+  request header) and the original format to browsers that do not. This is semantically
+  equivalent to a <picture><source type="image/webp"> fallback, but emits a plain <img>
+  so the DOM structure is unchanged and existing CSS selectors keep working.
 
   Fastly IO is configured with webp=True in image_optimizer_default_settings.
-  WebP is the only format currently enabled at the Fastly service level; AVIF support
-  can be added once avif=True is set in the Pulumi config for ocw_site.
 
   Parameters (via dict):
     .src      — required — already-resolved image URL (from resource_url.html or similar)
@@ -21,15 +23,19 @@
   the partial emits a plain <img> without optimization.
 
   Output (when optimizable):
-    <picture>
-      <source type="image/webp"
-              srcset="<src>?format=webp&quality=60&width=480 480w,
-                      <src>?format=webp&quality=60&width=800 800w,
-                      <src>?format=webp&quality=60&width=1280 1280w,
-                      <src>?format=webp&quality=60&width=1920 1920w"
-              sizes="...">
-      <img src="<src>" alt="..." ...>
-    </picture>
+    <img src="<src>"
+         srcset="<src>?format=auto&quality=75&width=480 480w,
+                 <src>?format=auto&quality=75&width=800 800w,
+                 <src>?format=auto&quality=75&width=1280 1280w,
+                 <src>?format=auto&quality=75&width=1920 1920w,
+                 <src>?format=auto&quality=75&width=2560 2560w,
+                 <src>?format=auto&quality=75&width=3840 3840w"
+         sizes="..."
+         alt="..." ...>
+
+  DPR handling: browsers using `w` descriptors already factor in devicePixelRatio when
+  selecting a srcset candidate. The extended breakpoints (2560w, 3840w) cover 2x and 3x
+  retina displays natively — no Fastly dpr= param or extra <source> elements are needed.
 */}}
 
 {{- $src      := .src | default "" -}}
@@ -44,16 +50,13 @@
   {{- $canOptimize := or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
   {{- if $canOptimize -}}
     {{- $separator := cond (strings.Contains $src "?") "&" "?" -}}
-    {{- $webp480  := printf "%s%sformat=webp&quality=60&width=480 480w"   $src $separator -}}
-    {{- $webp800  := printf "%s%sformat=webp&quality=60&width=800 800w"   $src $separator -}}
-    {{- $webp1280 := printf "%s%sformat=webp&quality=60&width=1280 1280w" $src $separator -}}
-    {{- $webp1920 := printf "%s%sformat=webp&quality=60&width=1920 1920w" $src $separator -}}
-<picture style="display: contents">
-  <source type="image/webp"
-          srcset="{{ $webp480 }}, {{ $webp800 }}, {{ $webp1280 }}, {{ $webp1920 }}"
-          sizes="{{ $sizes }}">
-  <img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
-</picture>
+    {{- $w480  := printf "%s%sformat=auto&quality=75&width=480 480w"   $src $separator -}}
+    {{- $w800  := printf "%s%sformat=auto&quality=75&width=800 800w"   $src $separator -}}
+    {{- $w1280 := printf "%s%sformat=auto&quality=75&width=1280 1280w" $src $separator -}}
+    {{- $w1920 := printf "%s%sformat=auto&quality=75&width=1920 1920w" $src $separator -}}
+    {{- $w2560 := printf "%s%sformat=auto&quality=75&width=2560 2560w" $src $separator -}}
+    {{- $w3840 := printf "%s%sformat=auto&quality=75&width=3840 3840w" $src $separator -}}
+<img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} srcset="{{ $w480 }}, {{ $w800 }}, {{ $w1280 }}, {{ $w1920 }}, {{ $w2560 }}, {{ $w3840 }}" sizes="{{ $sizes }}" loading="{{ $loading }}" decoding="{{ $decoding }}" />
   {{- else -}}
 <img src="{{ $src }}" alt="{{ $alt }}"{{ with $class }} class="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="{{ $decoding }}" />
   {{- end -}}

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -2,30 +2,50 @@ import { fastlyOptimizedUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
-  galleries.forEach(gallery => {
+  galleries.forEach((gallery) => {
     const baseUrl = gallery.getAttribute("data-base-url")
 
     const links = gallery.querySelectorAll("a[href]")
-    const items = Array.from(links).map(link => {
+    const items = Array.from(links).map((link) => {
       const src = link.getAttribute("href") || ""
       return {
         src,
         srct: fastlyOptimizedUrl(src, {
-          format:  "avif",
+          format: "avif",
           quality: "60",
-          width:   "480"
+          width: "480",
         }),
-        title:       link.innerHTML,
-        description: link.getAttribute("data-credit") || ""
+        title: link.innerHTML,
+        description: link.getAttribute("data-credit") || "",
       }
     })
+
+    // nanogallery2 renders thumbnails as plain <img> (no <picture>), so AVIF
+    // thumbnails will fail in non-AVIF browsers. Watch for img elements as
+    // nanogallery2 creates them (including lazy-loaded ones) and attach an
+    // onerror that falls back to format=auto when AVIF is not supported.
+    const addAvifFallback = (img: HTMLImageElement) => {
+      if (img.dataset.avifFallbackSet) return
+      img.dataset.avifFallbackSet = "1"
+      img.addEventListener(
+        "error",
+        () => {
+          img.src = img.src.replace(/\bformat=avif\b/, "format=auto")
+        },
+        { once: true }
+      )
+    }
+    const observer = new MutationObserver(() => {
+      gallery.querySelectorAll<HTMLImageElement>("img").forEach(addAvifFallback)
+    })
+    observer.observe(gallery, { childList: true, subtree: true })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL:    baseUrl,
-      items:           items,
-      allowHTMLinData: true
+      itemsBaseURL: baseUrl,
+      items: items,
+      allowHTMLinData: true,
     })
   })
 }

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -1,21 +1,46 @@
+/**
+ * Appends Fastly Image Optimizer query params to an image URL.
+ * Only applies to absolute (http/https) or root-relative (/) URLs;
+ * relative paths (offline) are returned unchanged.
+ */
+function fastlyOptimizedUrl(
+  url: string,
+  params: Record<string, string>
+): string {
+  if (!url || (!url.startsWith("http") && !url.startsWith("/"))) return url
+  const separator = url.includes("?") ? "&" : "?"
+  const qs = Object.entries(params)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("&")
+  return `${url}${separator}${qs}`
+}
+
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
-  galleries.forEach(gallery => {
+  galleries.forEach((gallery) => {
     const baseUrl = gallery.getAttribute("data-base-url")
 
     const links = gallery.querySelectorAll("a[href]")
-    const items = Array.from(links).map(link => ({
-      src:         link.getAttribute("href"),
-      title:       link.innerHTML,
-      description: link.getAttribute("data-credit") || ""
-    }))
+    const items = Array.from(links).map((link) => {
+      const src = link.getAttribute("href") || ""
+      return {
+        src,
+        srct: fastlyOptimizedUrl(src, {
+          format: "avif",
+          quality: "60",
+          width: "480",
+        }),
+        title: link.innerHTML,
+        description: link.getAttribute("data-credit") || "",
+      }
+    })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL:    baseUrl,
-      items:           items,
-      allowHTMLinData: true
+      itemsBaseURL: baseUrl,
+      items: items,
+      allowHTMLinData: true,
     })
   })
 }

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -1,19 +1,4 @@
-/**
- * Appends Fastly Image Optimizer query params to an image URL.
- * Only applies to absolute (http/https) or root-relative (/) URLs;
- * relative paths (offline) are returned unchanged.
- */
-function fastlyOptimizedUrl(
-  url: string,
-  params: Record<string, string>
-): string {
-  if (!url || (!url.startsWith("http") && !url.startsWith("/"))) return url
-  const separator = url.includes("?") ? "&" : "?"
-  const qs = Object.entries(params)
-    .map(([k, v]) => `${k}=${v}`)
-    .join("&")
-  return `${url}${separator}${qs}`
-}
+import { fastlyOptimizedUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -2,21 +2,21 @@ import { fastlyOptimizedUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
-  galleries.forEach((gallery) => {
+  galleries.forEach(gallery => {
     const baseUrl = gallery.getAttribute("data-base-url")
 
     const links = gallery.querySelectorAll("a[href]")
-    const items = Array.from(links).map((link) => {
+    const items = Array.from(links).map(link => {
       const src = link.getAttribute("href") || ""
       return {
         src,
         srct: fastlyOptimizedUrl(src, {
-          format: "avif",
+          format:  "avif",
           quality: "60",
-          width: "480",
+          width:   "480"
         }),
-        title: link.innerHTML,
-        description: link.getAttribute("data-credit") || "",
+        title:       link.innerHTML,
+        description: link.getAttribute("data-credit") || ""
       }
     })
 
@@ -43,9 +43,9 @@ export function initImageGalleriesFromMarkup() {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL: baseUrl,
-      items: items,
-      allowHTMLinData: true,
+      itemsBaseURL:    baseUrl,
+      items:           items,
+      allowHTMLinData: true
     })
   })
 }

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -17,30 +17,30 @@ function fastlyOptimizedUrl(
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
-  galleries.forEach((gallery) => {
+  galleries.forEach(gallery => {
     const baseUrl = gallery.getAttribute("data-base-url")
 
     const links = gallery.querySelectorAll("a[href]")
-    const items = Array.from(links).map((link) => {
+    const items = Array.from(links).map(link => {
       const src = link.getAttribute("href") || ""
       return {
         src,
         srct: fastlyOptimizedUrl(src, {
-          format: "avif",
+          format:  "avif",
           quality: "60",
-          width: "480",
+          width:   "480"
         }),
-        title: link.innerHTML,
-        description: link.getAttribute("data-credit") || "",
+        title:       link.innerHTML,
+        description: link.getAttribute("data-credit") || ""
       }
     })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL: baseUrl,
-      items: items,
-      allowHTMLinData: true,
+      itemsBaseURL:    baseUrl,
+      items:           items,
+      allowHTMLinData: true
     })
   })
 }

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -1,17 +1,21 @@
-import { fastlyOptimizedUrl } from "../../../base-theme/assets/js/utils"
+import { fastlyOptimizedGalleryUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
   galleries.forEach(gallery => {
-    const baseUrl = gallery.getAttribute("data-base-url")
+    const baseUrl = gallery.getAttribute("data-base-url") || ""
 
     const links = gallery.querySelectorAll("a[href]")
     const items = Array.from(links).map(link => {
       const src = link.getAttribute("href") || ""
       return {
-        src,
-        srct: fastlyOptimizedUrl(src, {
-          format:  "avif",
+        src: fastlyOptimizedGalleryUrl(src, baseUrl, {
+          format:  "webp",
+          quality: "60",
+          width:   "1920"
+        }),
+        srct: fastlyOptimizedGalleryUrl(src, baseUrl, {
+          format:  "webp",
           quality: "60",
           width:   "480"
         }),
@@ -20,17 +24,17 @@ export function initImageGalleriesFromMarkup() {
       }
     })
 
-    // nanogallery2 renders thumbnails as plain <img> (no <picture>), so AVIF
-    // thumbnails will fail in non-AVIF browsers. Watch for img elements as
+    // nanogallery2 renders thumbnails as plain <img> (no <picture>), so WebP
+    // thumbnails will fail in non-WebP browsers. Watch for img elements as
     // nanogallery2 creates them (including lazy-loaded ones) and attach an
-    // onerror that falls back to format=auto when AVIF is not supported.
+    // onerror that falls back to format=auto when WebP is not supported.
     const addAvifFallback = (img: HTMLImageElement) => {
       if (img.dataset.avifFallbackSet) return
       img.dataset.avifFallbackSet = "1"
       img.addEventListener(
         "error",
         () => {
-          img.src = img.src.replace(/\bformat=avif\b/, "format=auto")
+          img.src = img.src.replace(/\bformat=webp\b/, "format=auto")
         },
         { once: true }
       )

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -11,12 +11,12 @@ export function initImageGalleriesFromMarkup() {
       return {
         src: fastlyOptimizedGalleryUrl(src, baseUrl, {
           format:  "webp",
-          quality: "60",
+          quality: "75",
           width:   "1920"
         }),
         srct: fastlyOptimizedGalleryUrl(src, baseUrl, {
           format:  "webp",
-          quality: "60",
+          quality: "75",
           width:   "480"
         }),
         title:       link.innerHTML,

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -28,9 +28,9 @@ export function initImageGalleriesFromMarkup() {
     // thumbnails will fail in non-WebP browsers. Watch for img elements as
     // nanogallery2 creates them (including lazy-loaded ones) and attach an
     // onerror that falls back to format=auto when WebP is not supported.
-    const addAvifFallback = (img: HTMLImageElement) => {
-      if (img.dataset.avifFallbackSet) return
-      img.dataset.avifFallbackSet = "1"
+    const addWebpFallback = (img: HTMLImageElement) => {
+      if (img.dataset.webpFallbackSet) return
+      img.dataset.webpFallbackSet = "1"
       img.addEventListener(
         "error",
         () => {
@@ -39,8 +39,19 @@ export function initImageGalleriesFromMarkup() {
         { once: true }
       )
     }
-    const observer = new MutationObserver(() => {
-      gallery.querySelectorAll<HTMLImageElement>("img").forEach(addAvifFallback)
+    const addWebpFallbackFromNode = (node: Node) => {
+      if (!(node instanceof Element)) return
+      if (node instanceof HTMLImageElement) {
+        addWebpFallback(node)
+        return
+      }
+      node.querySelectorAll<HTMLImageElement>("img").forEach(addWebpFallback)
+    }
+    gallery.querySelectorAll<HTMLImageElement>("img").forEach(addWebpFallback)
+    const observer = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        mutation.addedNodes.forEach(addWebpFallbackFromNode)
+      })
     })
     observer.observe(gallery, { childList: true, subtree: true })
 

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -2,6 +2,8 @@ import { fastlyOptimizedGalleryUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
+  if (galleries.length === 0) return
+
   galleries.forEach(gallery => {
     const baseUrl = gallery.getAttribute("data-base-url") || ""
 
@@ -10,12 +12,12 @@ export function initImageGalleriesFromMarkup() {
       const src = link.getAttribute("href") || ""
       return {
         src: fastlyOptimizedGalleryUrl(src, baseUrl, {
-          format:  "webp",
+          format:  "auto",
           quality: "75",
           width:   "1920"
         }),
         srct: fastlyOptimizedGalleryUrl(src, baseUrl, {
-          format:  "webp",
+          format:  "auto",
           quality: "75",
           width:   "480"
         }),
@@ -23,37 +25,6 @@ export function initImageGalleriesFromMarkup() {
         description: link.getAttribute("data-credit") || ""
       }
     })
-
-    // nanogallery2 renders thumbnails as plain <img> (no <picture>), so WebP
-    // thumbnails will fail in non-WebP browsers. Watch for img elements as
-    // nanogallery2 creates them (including lazy-loaded ones) and attach an
-    // onerror that falls back to format=auto when WebP is not supported.
-    const addWebpFallback = (img: HTMLImageElement) => {
-      if (img.dataset.webpFallbackSet) return
-      img.dataset.webpFallbackSet = "1"
-      img.addEventListener(
-        "error",
-        () => {
-          img.src = img.src.replace(/\bformat=webp\b/, "format=auto")
-        },
-        { once: true }
-      )
-    }
-    const addWebpFallbackFromNode = (node: Node) => {
-      if (!(node instanceof Element)) return
-      if (node instanceof HTMLImageElement) {
-        addWebpFallback(node)
-        return
-      }
-      node.querySelectorAll<HTMLImageElement>("img").forEach(addWebpFallback)
-    }
-    gallery.querySelectorAll<HTMLImageElement>("img").forEach(addWebpFallback)
-    const observer = new MutationObserver(mutations => {
-      mutations.forEach(mutation => {
-        mutation.addedNodes.forEach(addWebpFallbackFromNode)
-      })
-    })
-    observer.observe(gallery, { childList: true, subtree: true })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/course-v2/layouts/partials/course_image_section.html
+++ b/course-v2/layouts/partials/course_image_section.html
@@ -7,9 +7,7 @@
     <div class="course-image-section-container">
       <div class="course-image-container">
         <div class="d-flex flex-column">
-          <img class="course-image" src="{{ $courseImageUrl }}"
-            alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}"
-          />
+          {{ partial "picture_element.html" (dict "src" $courseImageUrl "alt" (index $courseImageMetadata.Params.image_metadata "image-alt") "class" "course-image" "sizes" "(min-width: 992px) 33vw, 100vw") }}
         </div>
         <div class="course-image-caption">
           <span>{{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}</span>

--- a/course-v2/layouts/partials/course_image_section.html
+++ b/course-v2/layouts/partials/course_image_section.html
@@ -7,7 +7,7 @@
     <div class="course-image-section-container">
       <div class="course-image-container">
         <div class="d-flex flex-column">
-          {{ partial "picture_element.html" (dict "src" $courseImageUrl "alt" (index $courseImageMetadata.Params.image_metadata "image-alt") "class" "course-image" "sizes" "(min-width: 992px) 33vw, 100vw") }}
+          {{ partial "picture_element.html" (dict "src" $courseImageUrl "alt" (index $courseImageMetadata.Params.image_metadata "image-alt") "class" "course-image" "sizes" "(min-width: 992px) 33vw, 100vw" "loading" "eager" "fetchpriority" "high") }}
         </div>
         <div class="course-image-caption">
           <span>{{ $courseImageMetadata.Params.image_metadata.caption | .RenderString }}</span>

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -2,20 +2,20 @@ import { fastlyOptimizedUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
-  galleries.forEach((gallery) => {
+  galleries.forEach(gallery => {
     const baseUrl = gallery.getAttribute("data-base-url")
 
     const links = gallery.querySelectorAll("a[href]")
-    const items = Array.from(links).map((link) => {
+    const items = Array.from(links).map(link => {
       const src = link.getAttribute("href") || ""
       return {
         src,
         srct: fastlyOptimizedUrl(src, {
-          format: "avif",
+          format:  "avif",
           quality: "60",
-          width: "480",
+          width:   "480"
         }),
-        title: link.innerHTML,
+        title: link.innerHTML
       }
     })
 
@@ -42,9 +42,9 @@ export function initImageGalleriesFromMarkup() {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL: baseUrl,
-      items: items,
-      allowHTMLinData: true,
+      itemsBaseURL:    baseUrl,
+      items:           items,
+      allowHTMLinData: true
     })
   })
 }

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -1,19 +1,4 @@
-/**
- * Appends Fastly Image Optimizer query params to an image URL.
- * Only applies to absolute (http/https) or root-relative (/) URLs;
- * relative paths (offline) are returned unchanged.
- */
-function fastlyOptimizedUrl(
-  url: string,
-  params: Record<string, string>
-): string {
-  if (!url || (!url.startsWith("http") && !url.startsWith("/"))) return url
-  const separator = url.includes("?") ? "&" : "?"
-  const qs = Object.entries(params)
-    .map(([k, v]) => `${k}=${v}`)
-    .join("&")
-  return `${url}${separator}${qs}`
-}
+import { fastlyOptimizedUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -2,29 +2,49 @@ import { fastlyOptimizedUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
-  galleries.forEach(gallery => {
+  galleries.forEach((gallery) => {
     const baseUrl = gallery.getAttribute("data-base-url")
 
     const links = gallery.querySelectorAll("a[href]")
-    const items = Array.from(links).map(link => {
+    const items = Array.from(links).map((link) => {
       const src = link.getAttribute("href") || ""
       return {
         src,
         srct: fastlyOptimizedUrl(src, {
-          format:  "avif",
+          format: "avif",
           quality: "60",
-          width:   "480"
+          width: "480",
         }),
-        title: link.innerHTML
+        title: link.innerHTML,
       }
     })
+
+    // nanogallery2 renders thumbnails as plain <img> (no <picture>), so AVIF
+    // thumbnails will fail in non-AVIF browsers. Watch for img elements as
+    // nanogallery2 creates them (including lazy-loaded ones) and attach an
+    // onerror that falls back to format=auto when AVIF is not supported.
+    const addAvifFallback = (img: HTMLImageElement) => {
+      if (img.dataset.avifFallbackSet) return
+      img.dataset.avifFallbackSet = "1"
+      img.addEventListener(
+        "error",
+        () => {
+          img.src = img.src.replace(/\bformat=avif\b/, "format=auto")
+        },
+        { once: true }
+      )
+    }
+    const observer = new MutationObserver(() => {
+      gallery.querySelectorAll<HTMLImageElement>("img").forEach(addAvifFallback)
+    })
+    observer.observe(gallery, { childList: true, subtree: true })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL:    baseUrl,
-      items:           items,
-      allowHTMLinData: true
+      itemsBaseURL: baseUrl,
+      items: items,
+      allowHTMLinData: true,
     })
   })
 }

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -17,29 +17,29 @@ function fastlyOptimizedUrl(
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
-  galleries.forEach((gallery) => {
+  galleries.forEach(gallery => {
     const baseUrl = gallery.getAttribute("data-base-url")
 
     const links = gallery.querySelectorAll("a[href]")
-    const items = Array.from(links).map((link) => {
+    const items = Array.from(links).map(link => {
       const src = link.getAttribute("href") || ""
       return {
         src,
         srct: fastlyOptimizedUrl(src, {
-          format: "avif",
+          format:  "avif",
           quality: "60",
-          width: "480",
+          width:   "480"
         }),
-        title: link.innerHTML,
+        title: link.innerHTML
       }
     })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL: baseUrl,
-      items: items,
-      allowHTMLinData: true,
+      itemsBaseURL:    baseUrl,
+      items:           items,
+      allowHTMLinData: true
     })
   })
 }

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -1,20 +1,45 @@
+/**
+ * Appends Fastly Image Optimizer query params to an image URL.
+ * Only applies to absolute (http/https) or root-relative (/) URLs;
+ * relative paths (offline) are returned unchanged.
+ */
+function fastlyOptimizedUrl(
+  url: string,
+  params: Record<string, string>
+): string {
+  if (!url || (!url.startsWith("http") && !url.startsWith("/"))) return url
+  const separator = url.includes("?") ? "&" : "?"
+  const qs = Object.entries(params)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("&")
+  return `${url}${separator}${qs}`
+}
+
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
-  galleries.forEach(gallery => {
+  galleries.forEach((gallery) => {
     const baseUrl = gallery.getAttribute("data-base-url")
 
     const links = gallery.querySelectorAll("a[href]")
-    const items = Array.from(links).map(link => ({
-      src:   link.getAttribute("href"),
-      title: link.innerHTML
-    }))
+    const items = Array.from(links).map((link) => {
+      const src = link.getAttribute("href") || ""
+      return {
+        src,
+        srct: fastlyOptimizedUrl(src, {
+          format: "avif",
+          quality: "60",
+          width: "480",
+        }),
+        title: link.innerHTML,
+      }
+    })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL:    baseUrl,
-      items:           items,
-      allowHTMLinData: true
+      itemsBaseURL: baseUrl,
+      items: items,
+      allowHTMLinData: true,
     })
   })
 }

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -27,9 +27,9 @@ export function initImageGalleriesFromMarkup() {
     // thumbnails will fail in non-WebP browsers. Watch for img elements as
     // nanogallery2 creates them (including lazy-loaded ones) and attach an
     // onerror that falls back to format=auto when WebP is not supported.
-    const addAvifFallback = (img: HTMLImageElement) => {
-      if (img.dataset.avifFallbackSet) return
-      img.dataset.avifFallbackSet = "1"
+    const addWebpFallback = (img: HTMLImageElement) => {
+      if (img.dataset.webpFallbackSet) return
+      img.dataset.webpFallbackSet = "1"
       img.addEventListener(
         "error",
         () => {
@@ -38,8 +38,19 @@ export function initImageGalleriesFromMarkup() {
         { once: true }
       )
     }
-    const observer = new MutationObserver(() => {
-      gallery.querySelectorAll<HTMLImageElement>("img").forEach(addAvifFallback)
+    const addWebpFallbackFromNode = (node: Node) => {
+      if (!(node instanceof Element)) return
+      if (node instanceof HTMLImageElement) {
+        addWebpFallback(node)
+        return
+      }
+      node.querySelectorAll<HTMLImageElement>("img").forEach(addWebpFallback)
+    }
+    gallery.querySelectorAll<HTMLImageElement>("img").forEach(addWebpFallback)
+    const observer = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        mutation.addedNodes.forEach(addWebpFallbackFromNode)
+      })
     })
     observer.observe(gallery, { childList: true, subtree: true })
 

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -1,17 +1,21 @@
-import { fastlyOptimizedUrl } from "../../../base-theme/assets/js/utils"
+import { fastlyOptimizedGalleryUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
   galleries.forEach(gallery => {
-    const baseUrl = gallery.getAttribute("data-base-url")
+    const baseUrl = gallery.getAttribute("data-base-url") || ""
 
     const links = gallery.querySelectorAll("a[href]")
     const items = Array.from(links).map(link => {
       const src = link.getAttribute("href") || ""
       return {
-        src,
-        srct: fastlyOptimizedUrl(src, {
-          format:  "avif",
+        src: fastlyOptimizedGalleryUrl(src, baseUrl, {
+          format:  "webp",
+          quality: "60",
+          width:   "1920"
+        }),
+        srct: fastlyOptimizedGalleryUrl(src, baseUrl, {
+          format:  "webp",
           quality: "60",
           width:   "480"
         }),
@@ -19,17 +23,17 @@ export function initImageGalleriesFromMarkup() {
       }
     })
 
-    // nanogallery2 renders thumbnails as plain <img> (no <picture>), so AVIF
-    // thumbnails will fail in non-AVIF browsers. Watch for img elements as
+    // nanogallery2 renders thumbnails as plain <img> (no <picture>), so WebP
+    // thumbnails will fail in non-WebP browsers. Watch for img elements as
     // nanogallery2 creates them (including lazy-loaded ones) and attach an
-    // onerror that falls back to format=auto when AVIF is not supported.
+    // onerror that falls back to format=auto when WebP is not supported.
     const addAvifFallback = (img: HTMLImageElement) => {
       if (img.dataset.avifFallbackSet) return
       img.dataset.avifFallbackSet = "1"
       img.addEventListener(
         "error",
         () => {
-          img.src = img.src.replace(/\bformat=avif\b/, "format=auto")
+          img.src = img.src.replace(/\bformat=webp\b/, "format=auto")
         },
         { once: true }
       )

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -11,12 +11,12 @@ export function initImageGalleriesFromMarkup() {
       return {
         src: fastlyOptimizedGalleryUrl(src, baseUrl, {
           format:  "webp",
-          quality: "60",
+          quality: "75",
           width:   "1920"
         }),
         srct: fastlyOptimizedGalleryUrl(src, baseUrl, {
           format:  "webp",
-          quality: "60",
+          quality: "75",
           width:   "480"
         }),
         title: link.innerHTML

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -2,6 +2,8 @@ import { fastlyOptimizedGalleryUrl } from "../../../base-theme/assets/js/utils"
 
 export function initImageGalleriesFromMarkup() {
   const galleries = document.querySelectorAll(".image-gallery")
+  if (galleries.length === 0) return
+
   galleries.forEach(gallery => {
     const baseUrl = gallery.getAttribute("data-base-url") || ""
 
@@ -10,49 +12,18 @@ export function initImageGalleriesFromMarkup() {
       const src = link.getAttribute("href") || ""
       return {
         src: fastlyOptimizedGalleryUrl(src, baseUrl, {
-          format:  "webp",
+          format:  "auto",
           quality: "75",
           width:   "1920"
         }),
         srct: fastlyOptimizedGalleryUrl(src, baseUrl, {
-          format:  "webp",
+          format:  "auto",
           quality: "75",
           width:   "480"
         }),
         title: link.innerHTML
       }
     })
-
-    // nanogallery2 renders thumbnails as plain <img> (no <picture>), so WebP
-    // thumbnails will fail in non-WebP browsers. Watch for img elements as
-    // nanogallery2 creates them (including lazy-loaded ones) and attach an
-    // onerror that falls back to format=auto when WebP is not supported.
-    const addWebpFallback = (img: HTMLImageElement) => {
-      if (img.dataset.webpFallbackSet) return
-      img.dataset.webpFallbackSet = "1"
-      img.addEventListener(
-        "error",
-        () => {
-          img.src = img.src.replace(/\bformat=webp\b/, "format=auto")
-        },
-        { once: true }
-      )
-    }
-    const addWebpFallbackFromNode = (node: Node) => {
-      if (!(node instanceof Element)) return
-      if (node instanceof HTMLImageElement) {
-        addWebpFallback(node)
-        return
-      }
-      node.querySelectorAll<HTMLImageElement>("img").forEach(addWebpFallback)
-    }
-    gallery.querySelectorAll<HTMLImageElement>("img").forEach(addWebpFallback)
-    const observer = new MutationObserver(mutations => {
-      mutations.forEach(mutation => {
-        mutation.addedNodes.forEach(addWebpFallbackFromNode)
-      })
-    })
-    observer.observe(gallery, { childList: true, subtree: true })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/course-v3/layouts/partials/course_image_section.html
+++ b/course-v3/layouts/partials/course_image_section.html
@@ -4,7 +4,7 @@
 
 
 <div class="course-image-section-container w-100 align-self-stretch d-inline-flex flex-column justify-content-center align-items-start overflow-hidden">
-  <img class="course-image align-self-stretch rounded-top" src="{{ $courseImageUrl }}" alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}" loading="lazy" decoding="async" />
+  {{ partial "picture_element.html" (dict "src" $courseImageUrl "alt" (index $courseImageMetadata.Params.image_metadata "image-alt") "class" "course-image align-self-stretch rounded-top" "sizes" "(min-width: 992px) 33vw, 100vw") }}
   <div class="align-self-stretch d-flex flex-column justify-content-start align-items-start gap-3">
     <div class="course-card-content align-self-stretch p-3 bg-white rounded-bottom d-flex flex-column justify-content-start align-items-start">
       <div class="course-description align-self-stretch">

--- a/course-v3/layouts/partials/course_image_section.html
+++ b/course-v3/layouts/partials/course_image_section.html
@@ -4,7 +4,7 @@
 
 
 <div class="course-image-section-container w-100 align-self-stretch d-inline-flex flex-column justify-content-center align-items-start overflow-hidden">
-  <img class="course-image align-self-stretch rounded-top" src="{{ $courseImageUrl }}" alt="{{ index $courseImageMetadata.Params.image_metadata "image-alt" }}" loading="eager" decoding="async" fetchpriority="high" />
+  {{ partial "picture_element.html" (dict "src" $courseImageUrl "alt" (index $courseImageMetadata.Params.image_metadata "image-alt") "class" "course-image align-self-stretch rounded-top" "sizes" "(min-width: 992px) 33vw, 100vw") }}
   <div class="align-self-stretch d-flex flex-column justify-content-start align-items-start gap-3">
     <div class="course-card-content align-self-stretch p-3 bg-white rounded-bottom d-flex flex-column justify-content-start align-items-start">
       <div class="course-description align-self-stretch">

--- a/course-v3/layouts/partials/course_image_section.html
+++ b/course-v3/layouts/partials/course_image_section.html
@@ -4,7 +4,7 @@
 
 
 <div class="course-image-section-container w-100 align-self-stretch d-inline-flex flex-column justify-content-center align-items-start overflow-hidden">
-  {{ partial "picture_element.html" (dict "src" $courseImageUrl "alt" (index $courseImageMetadata.Params.image_metadata "image-alt") "class" "course-image align-self-stretch rounded-top" "sizes" "(min-width: 992px) 33vw, 100vw") }}
+  {{ partial "picture_element.html" (dict "src" $courseImageUrl "alt" (index $courseImageMetadata.Params.image_metadata "image-alt") "class" "course-image align-self-stretch rounded-top" "sizes" "(min-width: 992px) 33vw, 100vw" "loading" "eager" "fetchpriority" "high") }}
   <div class="align-self-stretch d-flex flex-column justify-content-start align-items-start gap-3">
     <div class="course-card-content align-self-stretch p-3 bg-white rounded-bottom d-flex flex-column justify-content-start align-items-start">
       <div class="course-description align-self-stretch">

--- a/test-sites/ocw-ci-test-course/content/pages/external-resources-page.md
+++ b/test-sites/ocw-ci-test-course/content/pages/external-resources-page.md
@@ -10,3 +10,5 @@ This is an external resource {{% resource_link "8ef7f3de-f238-4b3f-afb1-2d11a16f
 This link opens a warning dialog: {{% resource_link "8ef7f3de-f238-4b3f-afb1-2d11a16f7247" "Google.com" %}}
 
 This link DOES NOT open a warning dialog: {{% resource_link "4de28921-ab79-4ac4-933f-bbc0f4c99647" "OCW main" %}}
+
+{{% resource_link "5388b0c3-c599-4c42-8a3c-f89beed7c154" "this" %}} is an internal link to example_jpg resource. And [this](https://google.com) is an external link.

--- a/www/assets/css/about.scss
+++ b/www/assets/css/about.scss
@@ -372,6 +372,13 @@
             width: 100% !important;
           }
         }
+
+        @include media-breakpoint-up(lg) {
+          img {
+            width: 900px;
+            height: auto;
+          }
+        }
       }
 
       #presidents-message {

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -134,8 +134,7 @@
       <div id="impact-report" class="pb-7">
         <div class="row no-gutters px-lg-6">
           <div class="col-12 col-lg-6">
-            <img class="img-responsive w-100" src="/images/about/impact-report.jpeg"
-              alt="Students engaging with MIT OpenCourseWare" />
+            {{ partial "picture_element.html" (dict "src" "/images/about/impact-report.jpeg" "alt" "Students engaging with MIT OpenCourseWare" "class" "img-responsive w-100" "sizes" "(min-width: 992px) 50vw, 100vw") }}
           </div>
           <div class="col-12 col-lg-6 bg-black px-0">
             <div class="d-flex justify-content-center align-items-center h-100 px-sm-7 px-5 py-5">
@@ -261,7 +260,7 @@
               President's Message
             </h1>
             <div id="president-image" class="d-inline-block">
-              <img class="img-responsive" src="/images/about/president-kornbluth.jpeg" alt="" />
+              {{ partial "picture_element.html" (dict "src" "/images/about/president-kornbluth.jpeg" "class" "img-responsive" "sizes" "(min-width: 992px) 50vw, 100vw") }}
               <div class="text-left px-3 px-lg-0 pt-4">
                 MIT President Sally Kornbluth
               </div>

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -165,8 +165,7 @@
       <div id="impact-report" class="pb-7">
         <div class="row no-gutters px-lg-6">
           <div class="col-12 col-lg-6">
-            <img class="img-responsive w-100" src="/images/about/impact-report.jpeg"
-              alt="Students engaging with MIT OpenCourseWare" />
+            {{ partial "picture_element.html" (dict "src" "/images/about/impact-report.jpeg" "alt" "Students engaging with MIT OpenCourseWare" "class" "img-responsive w-100" "sizes" "(min-width: 992px) 50vw, 100vw") }}
           </div>
           <div class="col-12 col-lg-6 bg-black px-0">
             <div class="d-flex justify-content-center align-items-center h-100 px-sm-7 px-5 py-5">
@@ -292,7 +291,7 @@
               President's Message
             </h1>
             <div id="president-image" class="d-inline-block">
-              <img class="img-responsive" src="/images/about/president-kornbluth.jpeg" alt="" />
+              {{ partial "picture_element.html" (dict "src" "/images/about/president-kornbluth.jpeg" "class" "img-responsive" "sizes" "(min-width: 992px) 50vw, 100vw") }}
               <div class="text-left px-3 px-lg-0 pt-4">
                 MIT President Sally Kornbluth
               </div>

--- a/www/layouts/about/section.html
+++ b/www/layouts/about/section.html
@@ -291,7 +291,7 @@
               President's Message
             </h1>
             <div id="president-image" class="d-inline-block">
-              {{ partial "picture_element.html" (dict "src" "/images/about/president-kornbluth.jpeg" "class" "img-responsive" "sizes" "(min-width: 992px) 50vw, 100vw") }}
+              {{ partial "picture_element.html" (dict "src" "/images/about/president-kornbluth.jpeg" "class" "img-responsive" "sizes" "(min-width: 992px) 900px, 100vw" "loading" "eager") }}
               <div class="text-left px-3 px-lg-0 pt-4">
                 MIT President Sally Kornbluth
               </div>

--- a/www/layouts/educator/section.html
+++ b/www/layouts/educator/section.html
@@ -132,11 +132,7 @@
       <div class="section-content">
         <div class="row">
           <div class="col-lg-6">
-            <img
-              width="100%"
-              src="/images/educator/discover-oer-1.jpg"
-              alt=""
-            />
+            {{ partial "picture_element.html" (dict "src" "/images/educator/discover-oer-1.jpg" "class" "w-100" "sizes" "(min-width: 992px) 50vw, 100vw") }}
           </div>
           <div class="col-lg-6 d-flex my-auto">
             <div class="section-inner-content">
@@ -200,32 +196,20 @@
             </div>
           </div>
           <div class="col-lg-6">
-            <img
-              width="100%"
-              src="/images/educator/adapt-oer.jpg"
-              alt=""
-            />
+            {{ partial "picture_element.html" (dict "src" "/images/educator/adapt-oer.jpg" "class" "w-100" "sizes" "(min-width: 992px) 50vw, 100vw") }}
           </div>
         </div>
         <div class="row my-5">
           {{/* hide on small and extra-small devices */}}
           <div class="col-12 d-none d-sm-block">
             <a href="https://chalk-radio.simplecast.com/episodes/nuclear-gets-personal-with-prof-michael-short" target="_blank">
-              <img
-                width="100%"
-                src="/images/educator/students-discover-things.png"
-                alt="Students discover things about themselves through nuclear science.' Prof. Michael Short, Chalk Radio Podcast, Episode 1 Season 1."
-              />
+              {{ partial "picture_element.html" (dict "src" "/images/educator/students-discover-things.png" "alt" "Students discover things about themselves through nuclear science.' Prof. Michael Short, Chalk Radio Podcast, Episode 1 Season 1." "class" "w-100" "sizes" "100vw") }}
             </a>
           </div>
           {{/* hide on medium, large and extra large devices. */}}
           <div class="col-12 d-block d-sm-none">
             <a href="https://chalk-radio.simplecast.com/episodes/nuclear-gets-personal-with-prof-michael-short" target="_blank">
-              <img
-                width="100%"
-                src="/images/educator/students-discover-things-mobile.png"
-                alt="Students discover things about themselves through nuclear science.' Prof. Michael Short, Chalk Radio Podcast, Episode 1 Season 1."
-              />
+              {{ partial "picture_element.html" (dict "src" "/images/educator/students-discover-things-mobile.png" "alt" "Students discover things about themselves through nuclear science.' Prof. Michael Short, Chalk Radio Podcast, Episode 1 Season 1." "class" "w-100" "sizes" "100vw") }}
             </a>
           </div>
         </div>
@@ -236,11 +220,7 @@
       <div class="section-content">
         <div class="row">
           <div class="col-lg-6">
-            <img
-              width="100%"
-              src="/images/educator/share-adaptations.jpg"
-              alt=""
-            />
+            {{ partial "picture_element.html" (dict "src" "/images/educator/share-adaptations.jpg" "class" "w-100" "sizes" "(min-width: 992px) 50vw, 100vw") }}
           </div>
           <div class="col-lg-6 d-flex my-auto">
             <div class="section-inner-content">
@@ -320,11 +300,7 @@
             </div>
           </div>
           <div class="col-lg-6">
-            <img
-              width="100%"
-              src="/images/educator/explore-reflective-practice.jpg"
-              alt=""
-            />
+            {{ partial "picture_element.html" (dict "src" "/images/educator/explore-reflective-practice.jpg" "class" "w-100" "sizes" "(min-width: 992px) 50vw, 100vw") }}
           </div>
         </div>
 
@@ -361,11 +337,7 @@
       <div class="section-content">
         <div class="row">
           <div class="col-lg-6">
-            <img
-              width="100%"
-              src="/images/educator/connect.jpg"
-              alt=""
-            />
+            {{ partial "picture_element.html" (dict "src" "/images/educator/connect.jpg" "class" "w-100" "sizes" "(min-width: 992px) 50vw, 100vw") }}
           </div>
           <div class="col-lg-6 d-flex my-auto">
             <div class="section-inner-content">

--- a/www/layouts/partials/milestone_card_desktop.html
+++ b/www/layouts/partials/milestone_card_desktop.html
@@ -1,6 +1,6 @@
 <div id="milestone-card-desktop-{{ .Title }}" class="milestone-card">
   <div class="milestone-card-img">
-    <img src="{{ .Params.image }}" />
+    {{ partial "picture_element.html" (dict "src" .Params.image "sizes" "(min-width: 992px) 25vw, 50vw") }}
     <span class="milestone-card-img-dot"></span>
     <span class="timeline-red-dot"></span>
     <span class="timeline-red-line"></span>

--- a/www/layouts/partials/milestone_card_mobile.html
+++ b/www/layouts/partials/milestone_card_mobile.html
@@ -1,7 +1,7 @@
 <div class="w-100 d-flex justify-content-center mx-4 pb-4">
   <div id="milestone-card-mobile-{{ .Title }}" class="milestone-card milestone-card-mobile">
     <div class="milestone-card-img milestone-card-img-mobile">
-      <img src="{{ .Params.image }}" />
+      {{ partial "picture_element.html" (dict "src" .Params.image "sizes" "80vw") }}
     </div>
     <div class="milestone-card-content milestone-card-content-mobile">
       <h3>{{ .Title }}</h3>

--- a/www/layouts/partials/promo-carousel.html
+++ b/www/layouts/partials/promo-carousel.html
@@ -19,7 +19,7 @@
       <div class="carousel-item {{ if eq $index 0}}active{{ end }}">
         <div class="carousel-content d-flex m-auto align-items-center bg-white">
           <div class="img-container p-2">
-            <img class="promo-image img-fluid" src="{{ partial "resource_url.html" (dict "context" . "url" (partial "resource_metadata.html" $promo.Params.image.content).Params.file) }}" alt="" />
+            {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" (partial "resource_metadata.html" $promo.Params.image.content).Params.file)) "class" "promo-image img-fluid" "sizes" "(min-width: 768px) 50vw, 100vw") }}
           </div>
           <div class="promo-info d-flex flex-column px-2 px-md-4 align-items-start h-100">
             <h2>{{ $promo.Params.title }}</h2>

--- a/www/layouts/partials/staff_card.html
+++ b/www/layouts/partials/staff_card.html
@@ -2,7 +2,7 @@
 <div class="staff-card">
   <div class="staff-picture d-flex justify-content-center align-item-center overflow-hidden">
   {{- if .Params.image -}}
-    <img class="flex-shrink-0" src="{{ .Params.image }}" alt="{{ $fullName }}" />
+    {{ partial "picture_element.html" (dict "src" .Params.image "alt" $fullName "class" "flex-shrink-0" "sizes" "(min-width: 768px) 200px, 50vw") }}
   {{- end -}}
   </div>
   <h3>{{ $fullName }}</h3>

--- a/www/layouts/partials/testimonial_card.html
+++ b/www/layouts/partials/testimonial_card.html
@@ -3,11 +3,7 @@
 <div class="h-100 testimonial-card">
   <div class="testimonial d-flex flex-column rounded h-100">
     <div class="testimonial-image-wrapper">
-      <img 
-        src="{{ partial "resource_url.html" (dict "context" . "url" (partial "resource_metadata.html" $testimonial.Params.image.content).Params.file) }}" 
-        alt="{{ $testimonial.Title }}" 
-        class="testimonial-image"
-      >
+      {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" (partial "resource_metadata.html" $testimonial.Params.image.content).Params.file)) "alt" $testimonial.Title "class" "testimonial-image" "sizes" "(min-width: 768px) 33vw, 100vw") }}
     </div>
     <div class="testimonial-title {{if $testimonial.Params.is_quote}}quote{{ end }}">
       {{ if eq .source "list" }}

--- a/www/layouts/stories/single.html
+++ b/www/layouts/stories/single.html
@@ -17,10 +17,7 @@
       <div class="testimonial standard-width mx-auto d-flex align-items-center">
         <div class="single-testimonial-image-wrapper">
           <div class="img-container single-testimonial-page">
-            <img
-              src="{{ partial "resource_url.html" (dict "context" . "url" (partial "resource_metadata.html" $story.Params.image.content).Params.file) }}"
-              alt=""
-            />
+            {{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" . "url" (partial "resource_metadata.html" $story.Params.image.content).Params.file)) "sizes" "(min-width: 768px) 33vw, 100vw") }}
           </div>
         </div>
         <div class="detail d-flex flex-column flex-nowrap justify-content-center">


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10884

### Description (What does it do?)
Added picture partial for Fastly based optimization with original-image fallback behavior.

### Netlify
https://ocw-hugo-themes-course-v3-pr-1791--ocw-next.netlify.app/

### How can this be tested?
1. Open the Netlify preview in browser: DevTools → **Network** tab → filter **Img**.
2. On the course homepage, the course hero image request URL should contain `format=webp&quality=60&width=<breakpoint>`.
3. On a resource image page (e.g. `/resources/15-s21iap14/`), the displayed image should similarly use the WebP srcset.