### PR TITLE
Update End-to-End Test Site Content

### DIFF
--- a/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
+++ b/test-sites/__fixtures__/courses/ocw-ci-test-course/data.json
@@ -1,4 +1,5 @@
 {
+  "audience": ["Learners"],
   "course_title": "OCW CI Test Course",
   "course_description": "This is a test course for use in CI pipelines. This course can be found:\n\n- On Github at  {{% resource_link \"5653a8f2-056f-412c-913c-50b4664ed954\" \"https://github.mit.edu/ocw-content-rc/ocw-ci-test-course\" %}}\n- On OCW Studio at {{% resource_link \"8c797ae1-d349-4fdb-9ea0-371d969b89e0\" \"https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course\" %}}\n\nThe content of this course is additionally checked into the `ocw-hugo-themes` repository.\n\n Recommended usage by OL Engineers:\n\n- Clone the github repository to your local.\n- When developing on `ocw-hugo-themes`, make edits in Studio as needed for the tests you want to write. Pull to local, and copy the files to `ocw-hugo-themes/test-sites/ocw-ci-test-course`.",
   "course_description_html": "<p>This is a test course for use in CI pipelines. This course can be found:</p>\n<ul>\n<li>On Github at  <a   class=\"external-link \"   target=\"_blank\"   href=\"https://github.mit.edu/ocw-content-rc/ocw-ci-test-course\"  aria-label=\"https://github.mit.edu/ocw-content-rc/ocw-ci-test-course (opens in a new tab)\"  >https://github.mit.edu/ocw-content-rc/ocw-ci-test-course</a></li>\n<li>On OCW Studio at <a   class=\"external-link \"   target=\"_blank\"   href=\"https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course\"  aria-label=\"https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course (opens in a new tab)\"  >https://ocw-studio-rc.odl.mit.edu/sites/ocw-ci-test-course</a></li>\n</ul>\n<p>The content of this course is additionally checked into the <code>ocw-hugo-themes</code> repository.</p>\n<p> Recommended usage by OL Engineers:</p>\n<ul>\n<li>Clone the github repository to your local.</li>\n<li>When developing on <code>ocw-hugo-themes</code>, make edits in Studio as needed for the tests you want to write. Pull to local, and copy the files to <code>ocw-hugo-themes/test-sites/ocw-ci-test-course</code>.</li>\n</ul>\n",
@@ -6,7 +7,12 @@
     "content": "5388b0c3-c599-4c42-8a3c-f89beed7c154",
     "website": "ocw-ci-test-course"
   },
+  "course_image_thumbnail": {
+    "content": "5388b0c3-c599-4c42-8a3c-f89beed7c154",
+    "website": "ocw-ci-test-course"
+  },
   "site_uid": "554fc3fa-2f4b-4a94-87f4-19e51ae36920",
+  "site_url_path": "courses/ocw-ci-test-course",
   "legacy_uid": "",
   "instructors": [
     {

--- a/test-sites/ocw-ci-test-course/data/course.json
+++ b/test-sites/ocw-ci-test-course/data/course.json
@@ -36,7 +36,12 @@
     ],
     "website": "ocw-www"
   },
+  "audience": ["Learners"],
   "course_image": {
+    "content": "5388b0c3-c599-4c42-8a3c-f89beed7c154",
+    "website": "ocw-ci-test-course"
+  },
+  "course_image_thumbnail": {
     "content": "5388b0c3-c599-4c42-8a3c-f89beed7c154",
     "website": "ocw-ci-test-course"
   },
@@ -57,5 +62,6 @@
     "Exams",
     "Exam Solutions"
   ],
-  "site_uid": "554fc3fa-2f4b-4a94-87f4-19e51ae36920"
+  "site_uid": "554fc3fa-2f4b-4a94-87f4-19e51ae36920",
+  "site_url_path": "courses/ocw-ci-test-course"
 }


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/10157.

### Description (What does it do?)
This PR updates the e2e test site content to be consistent with the Hugo-built version of the test site fixtures in OCW Studio: https://github.com/mitodl/ocw-studio/tree/master/test_site_fixtures. 

### How can this be tested?
If this has not been done recently, run `yarn playwright install` to fetch the latest list of browsers. Run `yarn test:e2e` and verify that all of the end-to-end tests pass.