### PR TITLE
fix: issues with learn-deployed v3 theme

### DIFF
--- a/course-v3/layouts/partials/get_course_download_url.html
+++ b/course-v3/layouts/partials/get_course_download_url.html
@@ -1,4 +1,3 @@
-{{- $domain := strings.TrimSuffix "/" (getenv "STATIC_API_BASE_URL") -}}
 {{- $trimmedBaseUrl := strings.TrimPrefix "/" (strings.TrimSuffix "/" site.BaseURL) -}}
 {{- $shortId := site.Data.course.site_short_id -}}
-{{- return printf "%v/%v/%v.zip" $domain $trimmedBaseUrl $shortId -}}
+{{- return printf "/%v/%v.zip" $trimmedBaseUrl $shortId -}}

--- a/course-v3/layouts/partials/get_course_download_url.html
+++ b/course-v3/layouts/partials/get_course_download_url.html
@@ -1,3 +1,3 @@
-{{- $trimmedBaseUrl := strings.TrimPrefix "/" (strings.TrimSuffix "/" site.BaseURL) -}}
+{{- $trimmedBasePath := strings.TrimSuffix "/" (urls.Parse site.BaseURL).Path -}}
 {{- $shortId := site.Data.course.site_short_id -}}
-{{- return printf "/%v/%v.zip" $trimmedBaseUrl $shortId -}}
+{{- return printf "/%v/%v.zip" $trimmedBasePath $shortId -}}

--- a/course-v3/layouts/partials/get_course_download_url.html
+++ b/course-v3/layouts/partials/get_course_download_url.html
@@ -1,3 +1,3 @@
-{{- $trimmedBasePath := strings.TrimSuffix "/" (urls.Parse site.BaseURL).Path -}}
+{{- $trimmedBasePath := strings.TrimSuffix "/" (strings.TrimPrefix "/" (urls.Parse site.BaseURL).Path) -}}
 {{- $shortId := site.Data.course.site_short_id -}}
 {{- return printf "/%v/%v.zip" $trimmedBasePath $shortId -}}

--- a/course-v3/layouts/partials/resource_url.html
+++ b/course-v3/layouts/partials/resource_url.html
@@ -1,0 +1,17 @@
+{{- $url := .url -}}
+{{/*
+  Here we are disassembling the URL and returning a URL rooted at RESOURCE_BASE_URL.
+  Resource paths from Studio can include a leading course path segment
+  (for example, courses/foo), which is stripped before prefixing.
+  We also prepend Hugo's baseURL path segment before final URL construction.
+*/}}
+{{- if .url -}}
+  {{- $prefix := getenv "RESOURCE_BASE_URL" | default "" -}}
+  {{- $path := (urls.Parse .url).Path -}}
+  {{- $path = strings.TrimPrefix "/" $path -}}
+  {{- $path = replaceRE "^courses/[^/]+/?" "" $path -}}
+  {{- $basePath := (urls.Parse site.BaseURL) -}}
+  {{- $path = printf "%s/%s" (strings.TrimSuffix "/" $basePath.Path) (strings.TrimPrefix "/" $path) -}}
+  {{- $url = printf "%s/%s" (strings.TrimSuffix "/" $prefix) (strings.TrimPrefix "/" $path) -}}
+{{- end -}}
+{{- return $url -}}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11124

### Description (What does it do?)
This PR introduces two related improvements:

1. **_Update get_download_url for ZIP packages_**
Refactors the get_download_url logic to support the Learn deployment of Course V3 under the /course/o/... path.

2. **_Fix resource URL handling for subdirectory deployments_**
Resource URLs are currently generated as absolute paths relative to the domain root. While this works for root-level deployments (e.g., /courses/12-108-fall-2004), it breaks when the site is hosted under a subdirectory (e.g., /ocw-course-v3/courses/... or /courses/o/...). This PR updates the resource URL partial to respect the site’s base URL, ensuring assets are correctly resolved in both root and subdirectory deployments.
### How can this be tested?
This is kind of ugly since we need a way to emulate the learn [deploy](https://rc.learn.mit.edu/courses/o/7-016-introductory-biology-fall-2018) somehow. Do let me know if you know of a cleaner way.

1. First, apply this [patch](https://gist.github.com/zawan-ila/2ef4e71c1c82bb95b756a9d2ef881e50). This ensures that the webpack assets load correctly when we deploy to something like `localhost:8000/courses/o/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016`. Secondly, it provides a way to pass the baseURL argument to the build.
2. Now run a course build with `yarn build <path_to_course_content> <path_to_v3_projects_config> <baseURL(e.g /courses/o/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016)>`
3. Now the build output is in the dist folder of the content repo.
4. To the build output, add the website assets (images etc.). This can be done by downloading the offline zip package of the course from prod, and copy pasting the files from there.
4. Create a new directory `build` and inside it create the directory courses/o/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016 `mkdir -p courses/o/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016 `
5. Inside the `courses/o/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016 ` folder, copy the output from the dist folder.
5. Inside the `build` directory, run a http server `python3 -m http.server`
6. Go to `localhost:8000/courses/o/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016 `
7. Verify that all issues identified in the linked issue description are fixed and the acceptance criteria is fulfilled.
8. Also, run a quick check to ensure that all links, assets etc. work correctly, and there are no issues due to incorrect urls. 
