### PR TITLE
Add script for testing prefixed v3 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,37 @@ Run `yarn start course --help` , `yarn start www --help`, and see [Environment V
 
 **Customizing site content:** To customize site content, either edit the site markdown locally, or edit the site at https://ocw-studio-rc.odl.mit.edu/sites/. After editing content in Studio, run `yarn start course <course-short-id>` (or `yarn start www` if you're working on ocw-www). If you already had the site locally, you will need to `cd` to the content directory and manually fetch the updated content with `git pull`.
 
+### Testing course-v3 Path Prefixes
+
+To build a course-v3 site at a prefixed path such as `/courses/o/...`, use:
+
+```bash
+yarn build:course-v3-prefixed <course id> --serve
+```
+
+The base URL is derived from course metadata (`data/course.json`): it uses the last segment of `site_url_path` if present, otherwise assembles a slug from `primary_course_number`, `course_title`, `term`, and `year`. The result is joined with the prefix (default `/courses/o`) to form the full site-relative path, e.g., `/courses/o/9.40-spring-2018`. Other defaults come from `COURSE_CONTENT_PATH`, `OCW_TEST_COURSE`, `COURSE_V3_HUGO_CONFIG_PATH`, `RESOURCE_BASE_URL`, and `STATIC_API_BASE_URL`.
+
+```bash
+# Use a different prefix (e.g., testing a /courses/x/... deployment)
+yarn build:course-v3-prefixed 9.40-spring-2018 --base-url-prefix /courses/x --serve
+
+# Skip metadata derivation entirely and set the full path directly
+yarn build:course-v3-prefixed 9.40-spring-2018 --base-url /courses/o/neural-computation --serve
+```
+
+Key flags:
+
+| Flag | Description |
+| --- | --- |
+| `--base-url <path>` | Override the derived site-relative path (e.g., `/courses/o/my-course`) |
+| `--base-url-prefix <path>` | Prefix used when deriving the base URL from course metadata (default: `/courses/o`) |
+| `--content-dir <path>` | Path to course content root (default: `COURSE_CONTENT_PATH`) |
+| `--out-dir <path>` | Output root directory (default: `build/prefixed-course-v3`) |
+| `--clean` | Remove prior output for this course before rebuilding |
+| `--skip-webpack` | Reuse existing webpack assets (faster rebuilds) |
+| `--serve` | Serve the output after building |
+| `--port <number>` | Port for `--serve` (default: `8000`) |
+
 ### Obtaining and Creating Content
 
 Content for the themes in this repo can be generated using an instance of [`ocw-studio`](https://github.com/mitodl/ocw-studio), a CMS used to author OCW sites. The RC instance is located at https://ocw-studio-rc.odl.mit.edu. Its content is published to MIT's Github Enterprise instance under the [`ocw-content-rc`](https://github.mit.edu/ocw-content-rc) organization. For the `www` theme, content can be found in the [`ocw-www`](https://github.mit.edu/ocw-content-rc/ocw-www) repo. For the `course` theme, use any repo in the [`ocw-content-rc`](https://github.mit.edu/ocw-content-rc) organization created using the `ocw-course` starter or create and publish your own.
@@ -157,6 +188,7 @@ To further explain the various environment variables and what they do:
 | `SITEMAP_DOMAIN`          | `base-theme`                  | `ocw.mit.edu`                                       | The domain used when writing fully qualified URLs into the sitemap                                                                                                                           |
 | `WWW_HUGO_CONFIG_PATH`    | `www`                         | `/path/to/ocw-hugo-projects/ocw-www/config.yaml`    | A path to the `ocw-www` Hugo configuration file                                                                                                                                              |
 | `COURSE_HUGO_CONFIG_PATH` | `course`                      | `/path/to/ocw-hugo-projects/ocw-course/config.yaml` | A path to the `ocw-course` Hugo configuration file                                                                                                                                           |
+| `COURSE_V3_BASE_URL_PREFIX` | `course-v3`                  | `/courses/o`                                        | The base URL prefix used when deriving prefixed course-v3 build paths                                                                                                                        |
 | `WWW_CONTENT_PATH`        | `www`                         | `/path/to/ocw-content-rc/ocw-www`                   | A path to a Hugo site that will be rendered when running `yarn start www`                                                                                                                    |
 | `COURSE_CONTENT_PATH`     | `course`                      | `/path/to/ocw-content-rc/`                          | A path to a base folder containing `ocw-course` type Hugo sites                                                                                                                              |
 | `OCW_TEST_COURSE`         | `course`                      | `18.06-spring-2010`                                 | The name of a folder in `COURSE_CONTENT_PATH` containing a Hugo site that will be rendered when running `yarn start course`                                                                  |

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ Run `yarn start course --help` , `yarn start www --help`, and see [Environment V
 To build a course-v3 site at a prefixed path such as `/courses/o/...`, use:
 
 ```bash
-yarn build:course-v3-prefixed <course id> --serve
+yarn build:course-v3-prefixed <short-id> --serve
 ```
 
-The base URL is derived from course metadata (`data/course.json`): it uses the last segment of `site_url_path` if present, otherwise assembles a slug from `primary_course_number`, `course_title`, `term`, and `year`. The result is joined with the prefix (default `/courses/o`) to form the full site-relative path, e.g., `/courses/o/9.40-spring-2018`. Other defaults come from `COURSE_CONTENT_PATH`, `OCW_TEST_COURSE`, `COURSE_V3_HUGO_CONFIG_PATH`, `RESOURCE_BASE_URL`, and `STATIC_API_BASE_URL`.
+The base URL is derived from course metadata (`data/course.json`): it uses the last segment of `site_url_path` if present, otherwise assembles a slug from `primary_course_number`, `course_title`, `term`, and `year`. The result is joined with the prefix (default `/courses/o`) to form the full site-relative path, e.g., `/courses/o/9-40-introduction-to-neural-computation-spring-2018`. Other defaults come from `COURSE_CONTENT_PATH`, `OCW_TEST_COURSE`, `COURSE_V3_HUGO_CONFIG_PATH`, `RESOURCE_BASE_URL`, and `STATIC_API_BASE_URL`.
 
 ```bash
 # Use a different prefix (e.g., testing a /courses/x/... deployment)

--- a/env.ts
+++ b/env.ts
@@ -112,6 +112,10 @@ const envSchema = {
       "../ocw-hugo-projects/ocw-course-v3/config.yaml"
     )
   }),
+  COURSE_V3_BASE_URL_PREFIX: envalid.str({
+    desc:       "Base URL prefix used for prefixed ocw-course-v3 builds",
+    devDefault: "/courses/o"
+  }),
   COURSE_V3_OFFLINE_HUGO_CONFIG_PATH: envalid.str({
     desc:       "Path to the offline ocw-course-v3 Hugo configuration file",
     devDefault: path.resolve(

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:www": "echo This command has been removed. Use `yarn start www` instead.",
     "start:course": "echo This command has been removed. Use `yarn start course` instead.",
     "subset-fonts": "ts-node ./package_scripts/subset-fonts.ts",
+    "build:course-v3-prefixed": "yarn with-env --dev -- ts-node ./package_scripts/build-course-v3-prefixed.ts",
     "prebuild": "rimraf dist",
     "build": "yarn with-env -- ./package_scripts/build.sh",
     "build:githash": "mkdir -p base-theme/dist/static && git rev-parse HEAD > base-theme/dist/static/hash.txt",

--- a/package_scripts/build-course-v3-prefixed.ts
+++ b/package_scripts/build-course-v3-prefixed.ts
@@ -100,14 +100,20 @@ const readCourseMetadata = async (
   return JSON.parse(metadata) as CourseMetadata
 }
 
-const resolveContentDir = (contentDir: string, courseShortId: string): string => {
+const resolveContentDir = (
+  contentDir: string,
+  courseShortId: string
+): string => {
   const resolved = path.resolve(contentDir)
   return fs.existsSync(path.join(resolved, "data/course.json")) ?
     resolved :
     path.join(resolved, courseShortId)
 }
 
-const ensureContent = async (contentDir: string, courseShortId: string): Promise<void> => {
+const ensureContent = async (
+  contentDir: string,
+  courseShortId: string
+): Promise<void> => {
   if (fs.existsSync(path.join(contentDir, "data/course.json"))) return
   const repoUrl = `${env.GIT_CONTENT_SOURCE}/${courseShortId}.git`
   console.log(color.cyan(`Cloning course content from ${repoUrl}...`))

--- a/package_scripts/build-course-v3-prefixed.ts
+++ b/package_scripts/build-course-v3-prefixed.ts
@@ -1,0 +1,305 @@
+import * as fs from "node:fs"
+import * as http from "node:http"
+import * as path from "node:path"
+import { spawn, SpawnOptions } from "node:child_process"
+
+import color from "ansi-colors"
+import { program } from "commander"
+import handler from "serve-handler"
+
+import { env, stringifyEnv } from "../env"
+
+type CourseMetadata = Record<string, string | undefined>
+
+type Options = {
+  baseUrl?: string
+  baseUrlPrefix: string
+  clean: boolean
+  config: string
+  contentDir: string
+  logLevel: string
+  outDir: string
+  port: string
+  resourceBaseUrl: string
+  serve: boolean
+  skipWebpack: boolean
+  staticApiBaseUrl: string
+}
+
+const yarnCommand = process.platform === "win32" ? "yarn.cmd" : "yarn"
+const themesDir = path.resolve(__dirname, "..")
+
+const run = (
+  command: string,
+  args: string[],
+  options: SpawnOptions = {}
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit", ...options })
+    child.on("error", reject)
+    child.on("close", code => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`${command} ${args.join(" ")} exited with ${code}`))
+      }
+    })
+  })
+
+const normalizeBaseUrl = (baseUrl: string): string => {
+  if (!baseUrl.startsWith("/")) {
+    throw new Error("--base-url must be a site-relative path starting with /")
+  }
+
+  const normalized = `/${baseUrl.replace(/^\/+|\/+$/g, "")}`
+  if (normalized === "/") {
+    throw new Error("--base-url must include a course path, not just /")
+  }
+
+  if (normalized.split("/").some(segment => [".", ".."].includes(segment))) {
+    throw new Error("--base-url must not include . or .. path segments")
+  }
+
+  return normalized
+}
+
+const slugify = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
+const courseSlugFromMetadata = (
+  metadata: CourseMetadata,
+  courseShortId: string
+): string => {
+  if (metadata["site_url_path"]) {
+    const pathParts = metadata["site_url_path"].split("/").filter(Boolean)
+    const slug = pathParts[pathParts.length - 1]
+    if (slug) return slug
+  }
+
+  const slugParts = [
+    metadata["primary_course_number"],
+    metadata["course_title"],
+    metadata["term"],
+    metadata["year"]
+  ]
+    .filter((part): part is string => Boolean(part))
+    .map(slugify)
+
+  return slugParts.length > 0 ? slugParts.join("-") : slugify(courseShortId)
+}
+
+const readCourseMetadata = async (
+  contentDir: string
+): Promise<CourseMetadata> => {
+  const metadataPath = path.join(contentDir, "data/course.json")
+  const metadata = await fs.promises.readFile(metadataPath, "utf-8")
+  return JSON.parse(metadata) as CourseMetadata
+}
+
+const resolveContentDir = (contentDir: string, courseShortId: string): string => {
+  const resolved = path.resolve(contentDir)
+  return fs.existsSync(path.join(resolved, "data/course.json")) ?
+    resolved :
+    path.join(resolved, courseShortId)
+}
+
+const ensureContent = async (contentDir: string, courseShortId: string): Promise<void> => {
+  if (fs.existsSync(path.join(contentDir, "data/course.json"))) return
+  const repoUrl = `${env.GIT_CONTENT_SOURCE}/${courseShortId}.git`
+  console.log(color.cyan(`Cloning course content from ${repoUrl}...`))
+  await run("git", ["clone", repoUrl, contentDir])
+}
+
+const ensureCleanTarget = (outDir: string, target: string): void => {
+  const relative = path.relative(outDir, target)
+  if (
+    relative === "" ||
+    relative.startsWith("..") ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(`Refusing to clean path outside out-dir: ${target}`)
+  }
+}
+
+const serveBuild = ({
+  outDir,
+  baseUrl,
+  port
+}: {
+  outDir: string
+  baseUrl: string
+  port: number
+}): void => {
+  const server = http.createServer((request, response) => {
+    return handler(request, response, {
+      public:        outDir,
+      trailingSlash: true
+    })
+  })
+
+  server.listen(port, () => {
+    console.log("")
+    console.log(color.green("Prefixed course build is ready."))
+    console.log(`Serving: ${outDir}`)
+    console.log(`Open:    http://localhost:${port}${baseUrl}/`)
+    console.log("")
+    console.log("Press Ctrl+C to stop the server.")
+  })
+
+  process.on("SIGINT", () => server.close())
+  process.on("SIGTERM", () => server.close())
+}
+
+program
+  .name("build-course-v3-prefixed")
+  .description("Build a course-v3 site under a site-relative base URL.")
+  .argument(
+    "[shortid]",
+    "Short-id of the course to build. Defaults to OCW_TEST_COURSE.",
+    env.OCW_TEST_COURSE
+  )
+  .option(
+    "--content-dir <path>",
+    "Path to the course content root. Defaults to COURSE_CONTENT_PATH.",
+    env.COURSE_CONTENT_PATH
+  )
+  .option(
+    "--base-url <path>",
+    "Site-relative course path. By default, this is derived from course metadata."
+  )
+  .option(
+    "--base-url-prefix <path>",
+    "Site-relative URL prefix to use when deriving --base-url.",
+    env.COURSE_V3_BASE_URL_PREFIX
+  )
+  .option(
+    "--config <path>",
+    "Path to the ocw-course-v3 Hugo config. Defaults to COURSE_V3_HUGO_CONFIG_PATH.",
+    env.COURSE_V3_HUGO_CONFIG_PATH
+  )
+  .option(
+    "--out-dir <path>",
+    "Root directory to serve from.",
+    path.join(themesDir, "build/prefixed-course-v3")
+  )
+  .option(
+    "--resource-base-url <url>",
+    "Base URL to use for resource files. Defaults to RESOURCE_BASE_URL.",
+    env.RESOURCE_BASE_URL
+  )
+  .option(
+    "--static-api-base-url <url>",
+    "Base URL to use for Hugo data fetches. Defaults to STATIC_API_BASE_URL.",
+    env.STATIC_API_BASE_URL
+  )
+  .option("--log-level <level>", "Hugo log level.", "info")
+  .option("--port <number>", "Port to use with --serve.", "8000")
+  .option(
+    "--clean",
+    "Clean this build's static and course output first.",
+    false
+  )
+  .option("--skip-webpack", "Reuse existing Webpack assets in out-dir.", false)
+  .option("--serve", "Serve the output root after building.", false)
+  .showHelpAfterError()
+  .parse()
+
+const main = async () => {
+  const options = program.opts<Options>()
+  const courseShortId = program.processedArgs[0] as string
+  const outDir = path.resolve(options.outDir)
+  const contentDir = resolveContentDir(options.contentDir, courseShortId)
+  await ensureContent(contentDir, courseShortId)
+  const configPath = path.resolve(options.config)
+  const metadata = await readCourseMetadata(contentDir)
+  const baseUrl = normalizeBaseUrl(
+    options.baseUrl ||
+      path.posix.join(
+        "/",
+        options.baseUrlPrefix,
+        courseSlugFromMetadata(metadata, courseShortId)
+      )
+  )
+  const staticOutputPath = path.join(outDir, "static_shared")
+  const destination = path.join(outDir, baseUrl)
+  const port = parseInt(options.port, 10)
+
+  if (Number.isNaN(port)) {
+    throw new Error("--port must be a number")
+  }
+
+  await fs.promises.mkdir(outDir, { recursive: true })
+
+  if (options.clean) {
+    ensureCleanTarget(outDir, staticOutputPath)
+    ensureCleanTarget(outDir, destination)
+    await fs.promises.rm(staticOutputPath, { recursive: true, force: true })
+    await fs.promises.rm(destination, { recursive: true, force: true })
+  }
+
+  const commandEnv = {
+    ...process.env,
+    ...stringifyEnv(env),
+    RESOURCE_BASE_URL:   options.resourceBaseUrl,
+    STATIC_API_BASE_URL: options.staticApiBaseUrl
+  } as NodeJS.ProcessEnv
+
+  if (!options.skipWebpack) {
+    console.log(color.cyan("Building Webpack assets..."))
+    await run(
+      yarnCommand,
+      ["build:webpack", `--output-path=${staticOutputPath}`],
+      {
+        cwd: themesDir,
+        env: commandEnv
+      }
+    )
+  }
+
+  console.log(color.cyan("Building Hugo course..."))
+  await run(
+    yarnCommand,
+    [
+      "hugo",
+      "--source",
+      contentDir,
+      "--config",
+      configPath,
+      "--themesDir",
+      themesDir,
+      "--baseURL",
+      baseUrl,
+      "-d",
+      destination,
+      "--logLevel",
+      options.logLevel,
+      "--noBuildLock"
+    ],
+    {
+      cwd: themesDir,
+      env: commandEnv
+    }
+  )
+
+  if (options.serve) {
+    serveBuild({ outDir, baseUrl, port })
+  } else {
+    console.log("")
+    console.log(color.green("Prefixed course build complete."))
+    console.log(`Output root: ${outDir}`)
+    console.log(`Course:      ${destination}`)
+    console.log(
+      `Serve with:  python3 -m http.server --directory ${outDir} ${port}`
+    )
+    console.log(`Open:        http://localhost:${port}${baseUrl}/`)
+  }
+}
+
+main().catch(err => {
+  console.error(color.red(err instanceof Error ? err.message : err))
+  process.exit(1)
+})


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/11124.

### Description (What does it do?)
This PR adds a new `build:course-v3-prefixed` package script that builds a course-v3 site under a site-relative base URL prefix (e.g., `/courses/o/...`). This is useful for locally testing course-v3 deployments that serve courses under a path prefix rather than at the root. In particular, this can be used for testing work such as https://github.com/mitodl/ocw-hugo-themes/pull/1797. 

### How can this be tested?
Verify that the updated documentation in the repo README is clear. Try running the script with different flags, such as

```
yarn build:course-v3-prefixed --serve
yarn build:course-v3-prefixed 18.086-spring-2006 --serve
yarn build:course-v3-prefixed --base-url /courses/o/my-test-course --serve
yarn build:course-v3-prefixed --clean --serve
yarn build:course-v3-prefixed --skip-webpack --serve
```

Also, try running with a course repo that doesn't exist locally and verify that the script correctly fetches the repo.