### PR TITLE
fix: flaky test in ResourceCollection.test.tsx

### DIFF
--- a/www/assets/js/components/ResourceCollection.test.tsx
+++ b/www/assets/js/components/ResourceCollection.test.tsx
@@ -19,7 +19,7 @@ jest.mock("./SearchResult", () => ({
 
 function setup() {
   const data = [...Array(10)]
-    .map(makeResourceFileResult)
+    .map((_, index) => makeResourceFileResult({ id: index + 1 }))
     .map(searchResultToLearningResource)
 
   useResourceCollectionData.mockReturnValue(data)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
This PR fixes a flaky unit test in ResourceCollection.

The flake was caused by randomized fixture IDs in test data. When duplicate IDs were generated, the test could match the wrong DOM node and fail with a title mismatch. See https://github.com/mitodl/ocw-hugo-themes/actions/runs/25531534597/job/74938679470?pr=1797#logs for an example of such a failure

### How can this be tested?
1. Run the test many times e.g `for i in {0..100}; do yarn test www/asse
ts/js/components/ResourceCollection.test.tsx||exit 1; done`
2. Verify that the exit code is zero `echo $?`

