### PR TITLE
chore: fixed broken test in course-v3

### DIFF
--- a/tests-e2e/ocw-ci-test-course-v3-offline/external-resources-v3-offline.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3-offline/external-resources-v3-offline.spec.ts
@@ -127,13 +127,11 @@ test.describe("offline-v3 external resources", () => {
   }) => {
     await page.goto(offlineFileUrl(EXTERNAL_RESOURCES_PAGE))
 
-    // The first paragraph has: resource_link "this" (internal) then [this](https://google.com)
-    // Use the first "this" link which is the internal resource_link
+    // The first paragraph includes a resource_link to an internal course page.
     const link = page
       .locator("p")
-      .filter({ hasText: "this is an internal link" })
-      .getByRole("link", { name: "this" })
-      .first()
+      .filter({ hasText: "For reference" })
+      .getByRole("link", { name: "First Test Page (internal link)" })
 
     const href = await expectLocalPackageHref(link)
     // Internal resource should resolve inside the course package


### PR DESCRIPTION
### Description (What does it do?)
Fix a test with misisng external resource in course-v3 that affects many renovate and new branch runs 

### How can this be tested?
run `yarn test:e2e` locally an dnverify that Ci checks are completing