### PR TITLE
Fix MathJax loading for display equations

### DIFF
--- a/base-theme/layouts/partials/mathjax_if_necessary.html
+++ b/base-theme/layouts/partials/mathjax_if_necessary.html
@@ -1,6 +1,6 @@
 {{ $context := .context }}
 {{ $mathjax_url := partial "get_asset_webpack_url.html" "mathjax/tex-svg.js" }}
-{{ with findRE `\\\(.*?\\\)|\\[.*?\\]` .context.Page.Content 1 }}
+{{ with findRE `\\\(|\\\[` .context.Page.Content 1 }}
 <script>
   window.MathJax = {
       TeX: {


### PR DESCRIPTION
### What are the relevant tickets?
Fixes root cause of https://github.com/mitodl/hq/issues/11451.

### Description (What does it do?)
Currently, MathJax is only loaded for pages that have content matching a particular regular expression. This regular expression was not set up to correctly match display equations, only inline equations. However, the bug was rare in practice because typically pages would have both inline and display equations, so any inline equation would cause MathJax to load, thus properly rendering display equations as well. The reported issue concerned a resource that had only display, and not inline equations.

This PR fixes the root cause by instead finding the opening MathJax delimiters of inline or display equations (rather than the entire expression). This handles inline equations, single-line display equations, and also multi-line display equations. 

### How can this be tested?
Set `GIT_CONTENT_SOURCE` in the `.env` file to point at the production content repo, to fetch the latest content. Then, run `yarn start course RES.8-011-spring-2026` and navigate to `http://localhost:3000/resources/expectation-values-of-operators/`. Verify that the equations look correct.