### PR TITLE
add download attribute to download video anchor tag

### DIFF
--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -30,7 +30,7 @@
     <ul>
       {{ if .downloadLink }}
         <li>
-          <a href="{{ .downloadLink }}" target="_blank" aria-label="Download video">Download video</a>
+          <a href="{{ .downloadLink }}" target="_blank" aria-label="Download video" download>Download video</a>
         </li>
       {{ end }}
       {{ if .transcriptLink }}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6995

### Description (What does it do?)
Adds the download attribute on the `Download Video` anchor tag to instruct browsers to download the videos instead of just opening them. Note that this only works for same origin videos and not cross-origin.



### How can this be tested?

#### Self Hosted Videos
1. Download the content repo for https://github.mit.edu/mitocwcontent/21h.151-fall-2024
2. Set `RESOURCE_BASE_URL=` in your .env file. We want it to be empty so that video urls are generated relative to localhost for testing purposes.
3. Build it `yarn start course <path_to_21h.151_content>`
4. Now go to <path_to_21h.151_content/public>. This is the hugo output. Here run `mkdir -p courses/21h-151-dynastic-china-fall-2024`
5. Inside the newly created directory, Download and save this video https://ocw.mit.edu/courses/21h-151-dynastic-china-fall-2024/mit21h_151f24_lec03_1080p_360p_16_9.mp4
6. Now visit localhost:3000
7. Go to Lecture Videos page
8. Go to Lecture 3
9. Try downloading the video. It should trigger the download instead of opening in a separate tab.

#### Archive videos
1. Download the content repo for https://github.mit.edu/mitocwcontent/9.13-spring-2019
2. Build it.
3. Visit localhost:3000 and open any video from the lecture videos page.
4. This is an archive video. Try downloading it. You should land on the archive.org video. You will have to trigger the download manually from the 3 dots.
