### PR TITLE
fix: v3 netlify resources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+env:
+  COURSE_V3_URL_SLUG: 15-s21-nuts-and-bolts-of-business-plans-january-iap-2014
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -76,7 +79,7 @@ jobs:
           RESOURCE_BASE_URL: ${{ secrets.RESOURCE_BASE_URL }}
 
       - name: Run the course v3 hugo build
-        run: (cd ../ocw-course; hugo --config $GITHUB_WORKSPACE/ocw-hugo-projects/ocw-course-v3/config.yaml --destination public-v3/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/ --baseURL /courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/ --themesDir ../ocw-hugo-themes)
+        run: (cd ../ocw-course; hugo --config $GITHUB_WORKSPACE/ocw-hugo-projects/ocw-course-v3/config.yaml --destination public-v3/courses/o/${{ env.COURSE_V3_URL_SLUG }}/ --baseURL /courses/o/${{ env.COURSE_V3_URL_SLUG }}/ --themesDir ../ocw-hugo-themes)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}
@@ -132,7 +135,7 @@ jobs:
       - name: Set comment body
         id: set-comment-body
         run: |
-          body=$(echo 'Netlify Deployments:<br>www: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v2: https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v3: https://ocw-hugo-themes-course-v3-pr-${{ github.event.number }}--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/')
+          body=$(echo 'Netlify Deployments:<br>www: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v2: https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v3: https://ocw-hugo-themes-course-v3-pr-${{ github.event.number }}--ocw-next.netlify.app/courses/o/${{ env.COURSE_V3_URL_SLUG }}/')
           echo "body=$body" >> $GITHUB_OUTPUT
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
@@ -193,7 +196,7 @@ jobs:
         with:
           branch: ${{ github.ref }}
           outputDirectory: ${{ github.workspace }}/tmp/artifacts
-          urls: "https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/,https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/search/,https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/,https://ocw-hugo-themes-course-v3-pr-${{ github.event.number }}--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/"
+          urls: "https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/,https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/search/,https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/,https://ocw-hugo-themes-course-v3-pr-${{ github.event.number }}--ocw-next.netlify.app/courses/o/${{ env.COURSE_V3_URL_SLUG }}/"
           sha: ${{ github.sha }}
           accessToken: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,13 +76,13 @@ jobs:
           RESOURCE_BASE_URL: ${{ secrets.RESOURCE_BASE_URL }}
 
       - name: Run the course v3 hugo build
-        run: (cd ../ocw-course; hugo --config $GITHUB_WORKSPACE/ocw-hugo-projects/ocw-course-v3/config.yaml  --destination public-v3 --themesDir ../ocw-hugo-themes)
+        run: (cd ../ocw-course; hugo --config $GITHUB_WORKSPACE/ocw-hugo-projects/ocw-course-v3/config.yaml --destination public-v3/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/ --baseURL /courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/ --themesDir ../ocw-hugo-themes)
         env:
           OCW_STUDIO_BASE_URL: ${{ secrets.OCW_STUDIO_BASE_URL }}
           SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}
           OCW_COURSE_STARTER_SLUG: ${{ secrets.OCW_COURSE_STARTER_SLUG }}
           STATIC_API_BASE_URL: ${{ secrets.STATIC_API_BASE_URL }}
-          RESOURCE_BASE_URL: ${{ secrets.RESOURCE_BASE_URL }}
+          RESOURCE_BASE_URL: ${{ secrets.RESOURCE_BASE_URL_V3 }}
 
       - name: Deploy www Preview to Netlify
         uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654 # v3.0
@@ -132,7 +132,7 @@ jobs:
       - name: Set comment body
         id: set-comment-body
         run: |
-          body=$(echo 'Netlify Deployments:<br>www: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v2: https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v3: https://ocw-hugo-themes-course-v3-pr-${{ github.event.number }}--ocw-next.netlify.app/')
+          body=$(echo 'Netlify Deployments:<br>www: https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v2: https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/ <br> Course v3: https://ocw-hugo-themes-course-v3-pr-${{ github.event.number }}--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/')
           echo "body=$body" >> $GITHUB_OUTPUT
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
@@ -193,7 +193,7 @@ jobs:
         with:
           branch: ${{ github.ref }}
           outputDirectory: ${{ github.workspace }}/tmp/artifacts
-          urls: "https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/,https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/search/,https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/,https://ocw-hugo-themes-course-v3-pr-${{ github.event.number }}--ocw-next.netlify.app/"
+          urls: "https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/,https://ocw-hugo-themes-www-pr-${{ github.event.number }}--ocw-next.netlify.app/search/,https://ocw-hugo-themes-course-v2-pr-${{ github.event.number }}--ocw-next.netlify.app/,https://ocw-hugo-themes-course-v3-pr-${{ github.event.number }}--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/"
           sha: ${{ github.sha }}
           accessToken: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11124

### Description (What does it do?)
The changes introduced in https://github.com/mitodl/ocw-hugo-themes/pull/1797 have broken our netlify v3 deploys(see any currently open PR) as now resource urls are not directly copied over from their values in the frontmatter content, but are calculated relatively to the deployed url.

The fix here is to serve the v3 site on a subdirectory `<netlify_domain>/courses/o/....` and change the resource base url to the rc learn deploy to ensure that the resources load correctly.


### How can this be tested?
Browse around the associated netlify [build](https://ocw-hugo-themes-course-v3-pr-1816--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/) and verify that resources (images, pdfs etc) load correctly.
