### PR TITLE
Update header/footer links and MIT logos

### DIFF
--- a/base-theme/assets/images/mit-logo-black.svg
+++ b/base-theme/assets/images/mit-logo-black.svg
@@ -1,15 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-width="54px" height="28px" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" role="img" aria-labelledby="title">
-<title id="title">MIT small black logo</title>
-<g>
-        <rect x="39" fill="#231F20" width="15" height="6"/>
-        <rect x="9.75" fill="#231F20" width="6" height="18"/>
-        <rect x="19.5" fill="#231F20" width="6" height="28"/>
-        <rect fill="#231F20" width="6" height="28"/>
-        <rect x="39" y="10" fill="#231F20" width="6" height="18"/>
-        <rect x="29.25" fill="#231F20" width="6" height="6"/>
-        <rect x="29.25" y="10" fill="#231F20" width="6" height="18"/>
-</g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1360 720">
+  <!-- Generator: Adobe Illustrator 28.6.0, SVG Export Plug-In . SVG Version: 1.2.0 Build 709)  -->
+  <g>
+    <g id="Layer_1">
+      <g id="Layer_1-2" data-name="Layer_1">
+        <path d="M720,720h160V240h-160v480ZM960,160h400V0h-400v160ZM720,0h160v160h-160V0ZM480,720h160V0h-160v720ZM240,560h160V0h-160v560ZM0,720h160V0H0v720ZM960,720h160V240h-160v480Z"/>
+      </g>
+    </g>
+  </g>
 </svg>

--- a/base-theme/assets/images/mit-logo-white.svg
+++ b/base-theme/assets/images/mit-logo-white.svg
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1360 720" role="img" aria-labelledby="title">
-  <title id="title">MIT logo white</title>
-  <path fill="#FFFFFF" d="M720,720h160V240h-160v480ZM960,160h400V0h-400v160ZM720,0h160v160h-160V0ZM480,720h160V0h-160v720ZM240,560h160V0h-160v560ZM0,720h160V0H0v720ZM960,720h160V240h-160v480Z"/>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1360 720">
+  <!-- Generator: Adobe Illustrator 28.6.0, SVG Export Plug-In . SVG Version: 1.2.0 Build 709)  -->
+	<style type="text/css">
+		.st0{fill:#FFFFFF;}
+	</style>
+  <g>
+    <g id="Layer_1">
+      <g id="Layer_1-2" data-name="Layer_1">
+        <path class="st0" d="M720,720h160V240h-160v480ZM960,160h400V0h-400v160ZM720,0h160v160h-160V0ZM480,720h160V0h-160v720ZM240,560h160V0h-160v560ZM0,720h160V0H0v720ZM960,720h160V240h-160v480Z"/>
+      </g>
+    </g>
+  </g>
 </svg>

--- a/base-theme/assets/images/mit-logo-white.svg
+++ b/base-theme/assets/images/mit-logo-white.svg
@@ -1,15 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-width="72px" height="38px" viewBox="0 0 72 38" enable-background="new 0 0 72 38" xml:space="preserve" role="img" aria-labelledby="title">
-<title id="title">MIT logo white</title>
-<g>
-	<rect x="52" fill="#FFFFFF" width="20" height="8"/>
-	<rect x="13" fill="#FFFFFF" width="8" height="26"/>
-	<rect x="26" fill="#FFFFFF" width="8" height="38"/>
-	<rect fill="#FFFFFF" width="8" height="38"/>
-	<rect x="52" y="13" fill="#FFFFFF" width="8" height="25"/>
-	<rect x="39" fill="#FFFFFF" width="8" height="8"/>
-	<rect x="39" y="13" fill="#FFFFFF" width="8" height="25"/>
-</g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1360 720" role="img" aria-labelledby="title">
+  <title id="title">MIT logo white</title>
+  <path fill="#FFFFFF" d="M720,720h160V240h-160v480ZM960,160h400V0h-400v160ZM720,0h160v160h-160V0ZM480,720h160V0h-160v720ZM240,560h160V0h-160v560ZM0,720h160V0H0v720ZM960,720h160V240h-160v480Z"/>
 </svg>

--- a/base-theme/layouts/partials/footer-v3.html
+++ b/base-theme/layouts/partials/footer-v3.html
@@ -58,7 +58,7 @@ we want to use this new footer in other themes (www, course-offline etc)
     
     <!-- Help Link -->
     <div class="d-flex align-items-start footer-link">
-      <a href="https://support.learn.mit.edu/" class="fw-normal text-center text-decoration-none" target="_blank" rel="noopener noreferrer">
+      <a href="https://support.learn.mit.edu/" class="fw-normal text-center text-decoration-none" rel="noopener noreferrer">
         Help
       </a>
     </div>

--- a/base-theme/layouts/partials/footer-v3.html
+++ b/base-theme/layouts/partials/footer-v3.html
@@ -56,10 +56,10 @@ we want to use this new footer in other themes (www, course-offline etc)
       </a>
     </div>
     
-    <!-- Contact Us Link -->
+    <!-- Help Link -->
     <div class="d-flex align-items-start footer-link">
-      <a href="https://mitocw.zendesk.com/hc/en-us/requests/new" class="fw-normal text-center text-decoration-none">
-        Contact Us
+      <a href="https://support.learn.mit.edu/" class="fw-normal text-center text-decoration-none" target="_blank" rel="noopener noreferrer">
+        Help
       </a>
     </div>
   </div>
@@ -67,7 +67,7 @@ we want to use this new footer in other themes (www, course-offline etc)
   <!-- Copyright Container -->
   <div class="d-flex align-items-end justify-content-center copyright-container">
     <span>
-      &copy; 2025 Massachusetts Institute of Technology
+      &copy; {{ now.Format "2006" }} Massachusetts Institute of Technology
     </span>
   </div>
 </div>

--- a/course-v3/assets/css/mit-learn-header.scss
+++ b/course-v3/assets/css/mit-learn-header.scss
@@ -149,7 +149,7 @@ $mit-learn-font-weight-bold: 700;
 
 .mit-learn-menu-button-text {
   @include mit-learn-subtitle2;
-  font-weight: $mit-learn-font-weight-roman;
+  font-weight: $mit-learn-font-weight-medium;
   color: $mit-learn-white;
 
   @include media-breakpoint-down(md) {

--- a/course-v3/layouts/partials/header.html
+++ b/course-v3/layouts/partials/header.html
@@ -1,5 +1,4 @@
 {{ $homeUrl := partial "home_url.html" }}
-{{ $searchUrl := "https://rc.learn.mit.edu" }}
 
 <header id="mit-learn-header" class="mit-learn-header" role="banner">
   <div class="mit-learn-header-bar">
@@ -30,7 +29,7 @@
       </div>
       {{/* Right side: RightSide (from Figma) */}}
       <div class="mit-learn-header-right">
-        <a href="{{ $searchUrl }}/search" class="mit-learn-search-button" aria-label="Search">
+        <a href="/search" class="mit-learn-search-button" aria-label="Search">
           {{- partial "icon.html" "ri-search-line" -}}
         </a>
         {{/* User menu container - React will render UserMenu here if learn integration is enabled */}}
@@ -69,7 +68,7 @@
         />
       </a>
       <div class="mit-learn-header-spacer"></div>
-      <a href="{{ $searchUrl }}/search" class="mit-learn-search-button" aria-label="Search">
+      <a href="/search" class="mit-learn-search-button" aria-label="Search">
         {{- partial "icon.html" "ri-search-line" -}}
       </a>
       <div class="mit-learn-user-menu-container"></div>
@@ -101,7 +100,7 @@
           </button>
         </div>
         <div class="mit-learn-nav-items">
-          <a href="{{ $searchUrl }}/search?resource_type=course" class="mit-learn-nav-item">
+          <a href="/search?resource_type=course" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container with-description">
               {{- partial "icon.html" "ri-school-fill" -}}
             </div>
@@ -110,7 +109,7 @@
               <span class="mit-learn-nav-item-description">Single courses on a specific subject, taught by MIT instructors</span>
             </div>
           </a>
-          <a href="{{ $searchUrl }}/search?resource_type=program" class="mit-learn-nav-item">
+          <a href="/search?resource_type=program" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container with-description">
               {{- partial "icon.html" "ri-stack-line" -}}
             </div>
@@ -119,7 +118,7 @@
               <span class="mit-learn-nav-item-description">A series of courses for in-depth learning across a range of topics</span>
             </div>
           </a>
-          <a href="{{ $searchUrl }}/search?resource_type=learning_material" class="mit-learn-nav-item">
+          <a href="/search?resource_type=learning_material" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container with-description">
               {{- partial "icon.html" "ri-book-2-line" -}}
             </div>
@@ -137,7 +136,7 @@
           <span>BROWSE</span>
         </div>
         <div class="mit-learn-nav-items">
-          <a href="{{ $searchUrl }}/topics" class="mit-learn-nav-item">
+          <a href="/topics" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container">
               {{- partial "icon.html" "ri-slideshow-3-line" -}}
             </div>
@@ -145,7 +144,7 @@
               <span class="mit-learn-nav-item-title">By Topic</span>
             </div>
           </a>
-          <a href="{{ $searchUrl }}/departments" class="mit-learn-nav-item">
+          <a href="/departments" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container">
               {{- partial "icon.html" "ri-layout-column-line" -}}
             </div>
@@ -153,7 +152,7 @@
               <span class="mit-learn-nav-item-title">By Department</span>
             </div>
           </a>
-          <a href="{{ $searchUrl }}/units" class="mit-learn-nav-item">
+          <a href="/units" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container">
               {{- partial "icon.html" "ri-verified-badge-fill" -}}
             </div>
@@ -170,7 +169,7 @@
           <span>DISCOVER LEARNING RESOURCES</span>
         </div>
         <div class="mit-learn-nav-items">
-          <a href="{{ $searchUrl }}/search?sortby=new" class="mit-learn-nav-item">
+          <a href="/search?sortby=new" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container">
               {{- partial "icon.html" "ri-file-add-line" -}}
             </div>
@@ -178,7 +177,7 @@
               <span class="mit-learn-nav-item-title">Recently Added</span>
             </div>
           </a>
-          <a href="{{ $searchUrl }}/search?sortby=-views" class="mit-learn-nav-item">
+          <a href="/search?sortby=-views" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container">
               {{- partial "icon.html" "ri-thumb-up-line" -}}
             </div>
@@ -186,7 +185,7 @@
               <span class="mit-learn-nav-item-title">Popular</span>
             </div>
           </a>
-          <a href="{{ $searchUrl }}/search?sortby=upcoming" class="mit-learn-nav-item">
+          <a href="/search?sortby=upcoming" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container">
               {{- partial "icon.html" "ri-time-line" -}}
             </div>
@@ -194,7 +193,7 @@
               <span class="mit-learn-nav-item-title">Upcoming</span>
             </div>
           </a>
-          <a href="{{ $searchUrl }}/search?free=true" class="mit-learn-nav-item">
+          <a href="/search?free=true" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container">
               {{- partial "icon.html" "ri-price-tag-3-line" -}}
             </div>
@@ -202,7 +201,7 @@
               <span class="mit-learn-nav-item-title">Free</span>
             </div>
           </a>
-          <a href="{{ $searchUrl }}/search?certification=true" class="mit-learn-nav-item">
+          <a href="/search?certification=true" class="mit-learn-nav-item">
             <div class="mit-learn-nav-icon-container">
               {{- partial "icon.html" "ri-bookmark-line" -}}
             </div>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11895
https://github.com/mitodl/hq/issues/11896
https://github.com/mitodl/hq/issues/11890

### Description (What does it do?)
Updates the v3 header/footer chrome and MIT logo assets:

- **Footer (`base-theme/layouts/partials/footer-v3.html`)**
  - Replaces the "Contact Us" link (which pointed to the legacy Zendesk request form `mitocw.zendesk.com`) with a "Help" link pointing to `https://support.learn.mit.edu/`.
  - Makes the copyright year dynamic via `{{ now.Format "2006" }}` instead of the hardcoded `2025`.

- **Header (`course-v3/layouts/partials/header.html`)**
  - Removes the hardcoded `$searchUrl := "https://rc.learn.mit.edu"` variable and switches all search / browse / discover links to relative paths (`/search`, `/topics`, `/departments`, `/units`, etc.) so they resolve against the current host instead of the RC environment.

- **Logos (`base-theme/assets/images/mit-logo-black.svg`, `mit-logo-white.svg`)**
  - Replaces the logo artwork with refreshed single-path SVGs (viewBox `0 0 1360 720`).

### Screenshots (if appropriate):
- See the netlify [build](https://ocw-hugo-themes-course-v3-pr-1823--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/)

### How can this be tested?
- See the netlify [build](https://ocw-hugo-themes-course-v3-pr-1823--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/) and match the header and footer with [learn](https://learn.mit.edu/). There should be no difference. Also go through the issues and verify they have been resolved