### PR TITLE
feat: line-based truncation for the course-v3 course description

### DIFF
--- a/course-v3/assets/css/course-home.scss
+++ b/course-v3/assets/css/course-home.scss
@@ -60,15 +60,10 @@
   }
 }
 
-#collapsed-description {
-  & p:last-of-type {
-    display: inline;
-  }
-}
+// Number of lines shown for the collapsed course description.
+$course-description-max-lines: 5;
 
-#collapsed-description,
-#expanded-description,
-#full-description {
+#course-description-text {
   color: #000;
 
   font-size: 0.875rem;
@@ -76,10 +71,27 @@
   font-weight: 400;
   line-height: 1.375rem;
 
-  button {
-    color: #a31f34;
-    line-height: inherit !important;
-    font-size: inherit !important;
-    border: none;
+  &.description-collapsed {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: $course-description-max-lines;
+    overflow: hidden;
   }
+
+  // Prevent a trailing block margin from registering as overflow
+  // (scrollHeight > clientHeight) when the text actually fits.
+  > :last-child {
+    margin-bottom: 0;
+  }
+}
+
+#toggle-description {
+  color: #a31f34;
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+  border: none;
+
+  // Pull the toggle closer to the description: the parent's 1rem flex gap
+  // is too roomy here, and a negative margin nets it down to 0.5rem.
+  margin-top: -0.5rem;
 }

--- a/course-v3/assets/css/course-v3.scss
+++ b/course-v3/assets/css/course-v3.scss
@@ -540,12 +540,6 @@ pre {
   gap: 1.5rem;
 }
 
-#expand-description,
-#collapse-description {
-  color: $highlight-red;
-  margin-top: 0.5rem;
-}
-
 .course-detail-title {
   min-height: 35px;
   display: flex;

--- a/course-v3/assets/js/course_expander.test.ts
+++ b/course-v3/assets/js/course_expander.test.ts
@@ -152,8 +152,7 @@ describe("initCourseDescriptionExpander", () => {
 
     // jsdom does not implement ResizeObserver, so stub it to exercise the
     // primary (non-fallback) code path and capture its callback/target.
-    let resizeCallback
-    let observedTarget
+    let resizeCallback, observedTarget
     global.ResizeObserver = class {
       constructor(callback) {
         resizeCallback = callback
@@ -161,7 +160,9 @@ describe("initCourseDescriptionExpander", () => {
       observe(target) {
         observedTarget = target
       }
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       unobserve() {}
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       disconnect() {}
     }
 

--- a/course-v3/assets/js/course_expander.test.ts
+++ b/course-v3/assets/js/course_expander.test.ts
@@ -151,7 +151,7 @@ describe("initCourseDescriptionExpander", () => {
     setHeights(description, { scrollHeight: 80, clientHeight: 80 })
     Object.defineProperty(document, "fonts", {
       configurable: true,
-      value:        { ready: Promise.resolve(), addEventListener: () => {} }
+      value:        { ready: Promise.resolve(), addEventListener: jest.fn() }
     })
 
     initCourseDescriptionExpander(document)

--- a/course-v3/assets/js/course_expander.test.ts
+++ b/course-v3/assets/js/course_expander.test.ts
@@ -1,6 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { initCourseInfoExpander } from "./course_expander"
+import {
+  initCourseInfoExpander,
+  initCourseDescriptionExpander
+} from "./course_expander"
 
 describe("initCourseInfoExpander", () => {
   beforeEach(() => {
@@ -72,5 +75,127 @@ describe("initCourseInfoExpander", () => {
         assertExpanded(otherButton, false)
       })
     })
+  })
+})
+
+describe("initCourseDescriptionExpander", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+    <div id="course-description">
+      <div id="course-description-text" class="description description-collapsed">
+        <p>A long course description.</p>
+      </div>
+      <button id="toggle-description" class="d-none align-items-center" aria-expanded="false">Show more</button>
+    </div>
+    `
+  })
+
+  const assertToggleVisible = (toggle, visible) => {
+    expect(toggle.classList.contains("d-none")).toBe(!visible)
+    expect(toggle.classList.contains("d-flex")).toBe(visible)
+  }
+
+  const setHeights = (element, { scrollHeight, clientHeight }) => {
+    Object.defineProperty(element, "scrollHeight", {
+      configurable: true,
+      value:        scrollHeight
+    })
+    Object.defineProperty(element, "clientHeight", {
+      configurable: true,
+      value:        clientHeight
+    })
+  }
+
+  it("shows the toggle button and expands/collapses when the text overflows", () => {
+    const description = document.getElementById("course-description-text")
+    const toggle = document.getElementById("toggle-description")
+    setHeights(description, { scrollHeight: 200, clientHeight: 110 })
+
+    initCourseDescriptionExpander(document)
+    assertToggleVisible(toggle, true)
+
+    toggle.click()
+    expect(description.classList.contains("description-collapsed")).toBe(false)
+    expect(toggle.textContent).toBe("Show less")
+    expect(toggle.getAttribute("aria-expanded")).toBe("true")
+    assertToggleVisible(toggle, true)
+
+    toggle.click()
+    expect(description.classList.contains("description-collapsed")).toBe(true)
+    expect(toggle.textContent).toBe("Show more")
+    expect(toggle.getAttribute("aria-expanded")).toBe("false")
+    assertToggleVisible(toggle, true)
+  })
+
+  it("keeps the toggle button hidden when the text fits", () => {
+    const description = document.getElementById("course-description-text")
+    const toggle = document.getElementById("toggle-description")
+    setHeights(description, { scrollHeight: 80, clientHeight: 80 })
+
+    initCourseDescriptionExpander(document)
+    assertToggleVisible(toggle, false)
+  })
+
+  it("treats sub-pixel rounding overflow as fitting", () => {
+    const description = document.getElementById("course-description-text")
+    const toggle = document.getElementById("toggle-description")
+    setHeights(description, { scrollHeight: 82, clientHeight: 80 })
+
+    initCourseDescriptionExpander(document)
+    assertToggleVisible(toggle, false)
+  })
+
+  it("re-checks overflow once webfonts are ready", async () => {
+    const description = document.getElementById("course-description-text")
+    const toggle = document.getElementById("toggle-description")
+    setHeights(description, { scrollHeight: 80, clientHeight: 80 })
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value:        { ready: Promise.resolve(), addEventListener: () => {} }
+    })
+
+    initCourseDescriptionExpander(document)
+    assertToggleVisible(toggle, false)
+
+    // Simulate the font swap reflowing the text into overflow without a
+    // height change (the case the ResizeObserver cannot detect)
+    setHeights(description, { scrollHeight: 200, clientHeight: 110 })
+    await document.fonts.ready
+    assertToggleVisible(toggle, true)
+
+    delete document.fonts
+  })
+
+  it("re-checks overflow when fonts load after fonts.ready has resolved", () => {
+    const description = document.getElementById("course-description-text")
+    const toggle = document.getElementById("toggle-description")
+    setHeights(description, { scrollHeight: 80, clientHeight: 80 })
+    const fontListeners = {}
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value:        {
+        ready:            Promise.resolve(),
+        addEventListener: (type, listener) => {
+          fontListeners[type] = listener
+        }
+      }
+    })
+
+    initCourseDescriptionExpander(document)
+    assertToggleVisible(toggle, false)
+
+    // A stylesheet injected after init (the Typekit fetch in extrahead.html)
+    // starts new font loads, so loadingdone can fire long after the ready
+    // promise grabbed at init has resolved
+    setHeights(description, { scrollHeight: 200, clientHeight: 110 })
+    fontListeners.loadingdone()
+    assertToggleVisible(toggle, true)
+
+    delete document.fonts
+  })
+
+  it("does nothing when the description elements are missing", () => {
+    document.body.innerHTML = ""
+    expect(() => initCourseDescriptionExpander(document)).not.toThrow()
   })
 })

--- a/course-v3/assets/js/course_expander.test.ts
+++ b/course-v3/assets/js/course_expander.test.ts
@@ -145,6 +145,56 @@ describe("initCourseDescriptionExpander", () => {
     assertToggleVisible(toggle, false)
   })
 
+  it("re-checks overflow when the ResizeObserver fires", () => {
+    const description = document.getElementById("course-description-text")
+    const toggle = document.getElementById("toggle-description")
+    setHeights(description, { scrollHeight: 80, clientHeight: 80 })
+
+    // jsdom does not implement ResizeObserver, so stub it to exercise the
+    // primary (non-fallback) code path and capture its callback/target.
+    let resizeCallback
+    let observedTarget
+    global.ResizeObserver = class {
+      constructor(callback) {
+        resizeCallback = callback
+      }
+      observe(target) {
+        observedTarget = target
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+
+    initCourseDescriptionExpander(document)
+    assertToggleVisible(toggle, false)
+    expect(observedTarget).toBe(description)
+
+    // A layout change grows the clamped element past its clamp; the observer
+    // callback must re-check and reveal the toggle.
+    setHeights(description, { scrollHeight: 200, clientHeight: 110 })
+    resizeCallback()
+    assertToggleVisible(toggle, true)
+
+    delete global.ResizeObserver
+  })
+
+  it("re-checks overflow on window resize when ResizeObserver is unavailable", () => {
+    // jsdom provides no ResizeObserver, so init takes the window-resize
+    // fallback branch.
+    expect(typeof ResizeObserver).toBe("undefined")
+
+    const description = document.getElementById("course-description-text")
+    const toggle = document.getElementById("toggle-description")
+    setHeights(description, { scrollHeight: 80, clientHeight: 80 })
+
+    initCourseDescriptionExpander(document)
+    assertToggleVisible(toggle, false)
+
+    setHeights(description, { scrollHeight: 200, clientHeight: 110 })
+    window.dispatchEvent(new Event("resize"))
+    assertToggleVisible(toggle, true)
+  })
+
   it("re-checks overflow once webfonts are ready", async () => {
     const description = document.getElementById("course-description-text")
     const toggle = document.getElementById("toggle-description")

--- a/course-v3/assets/js/course_expander.ts
+++ b/course-v3/assets/js/course_expander.ts
@@ -41,32 +41,64 @@ const initCourseInfoExpander = document => {
   }
 }
 
+const COLLAPSED_CLASS = "description-collapsed"
+
+// Absorbs sub-pixel rounding: scrollHeight and clientHeight are rounded to
+// integers independently, so at fractional zoom levels they can disagree by
+// a pixel with nothing actually clipped. Genuine clamp overflow is at least
+// one line box (~22px), far above this tolerance.
+const OVERFLOW_TOLERANCE_PX = 2
+
 const initCourseDescriptionExpander = document => {
-  const courseDescription = document.getElementById("course-description")
-  if (courseDescription) {
-    const collapsedDescription = courseDescription.querySelector(
-      "#collapsed-description"
-    )
-    const expandedDescription = courseDescription?.querySelector(
-      "#expanded-description"
-    )
-    if (collapsedDescription && expandedDescription) {
-      const expandLink = collapsedDescription.querySelector(
-        "#expand-description"
-      )
-      const collapseLink = expandedDescription.querySelector(
-        "#collapse-description"
-      )
-      expandLink.addEventListener("click", () => {
-        collapsedDescription.classList.add("d-none")
-        expandedDescription.classList.remove("d-none")
-      })
-      collapseLink.addEventListener("click", () => {
-        collapsedDescription.classList.remove("d-none")
-        expandedDescription.classList.add("d-none")
-      })
+  const description = document.getElementById("course-description-text")
+  const toggleButton = document.getElementById("toggle-description")
+  if (!description || !toggleButton) {
+    return
+  }
+
+  const updateToggleVisibility = () => {
+    // Only auto-hide while collapsed; when expanded the button must
+    // stay visible so the user can collapse again.
+    if (description.classList.contains(COLLAPSED_CLASS)) {
+      const isOverflowing =
+        description.scrollHeight - description.clientHeight >
+        OVERFLOW_TOLERANCE_PX
+      // d-flex must be swapped together with d-none: both are !important
+      // display utilities and .d-flex overrides .d-none in Bootstrap 4's
+      // source order, so an element with both classes stays visible.
+      toggleButton.classList.toggle("d-none", !isOverflowing)
+      toggleButton.classList.toggle("d-flex", isOverflowing)
     }
   }
+
+  toggleButton.addEventListener("click", () => {
+    const collapsed = description.classList.toggle(COLLAPSED_CLASS)
+    toggleButton.textContent = collapsed ? "Show more" : "Show less"
+    toggleButton.setAttribute("aria-expanded", String(!collapsed))
+    updateToggleVisibility()
+  })
+
+  if (typeof ResizeObserver !== "undefined") {
+    new ResizeObserver(updateToggleVisibility).observe(description)
+  } else {
+    description.ownerDocument.defaultView.addEventListener(
+      "resize",
+      updateToggleVisibility
+    )
+  }
+  // A webfont swap can change the wrapped line count without changing the
+  // clamped element's height (e.g. six fallback-font lines becoming exactly
+  // five), which the ResizeObserver cannot see — re-check once fonts land.
+  // `ready` alone is not enough: the Typekit stylesheet is fetched and
+  // injected by script (extrahead.html), so its faces can start loading
+  // after `ready` has already resolved. `loadingdone` fires for every
+  // completed batch of font loads, whenever it happens.
+  // document.fonts is absent in jsdom, hence the guard.
+  if (document.fonts) {
+    document.fonts.ready.then(updateToggleVisibility)
+    document.fonts.addEventListener("loadingdone", updateToggleVisibility)
+  }
+  updateToggleVisibility()
 }
 
 export { initCourseInfoExpander, initCourseDescriptionExpander }

--- a/course-v3/layouts/home.html
+++ b/course-v3/layouts/home.html
@@ -36,6 +36,27 @@
               <div class="col-12 col-md-4 col-lg-3 p-0 course-image-section">
                 {{ partialCached "course_image_section.html" . }}
               </div>
+              <script>
+                // Pre-paint overflow check. This mirrors updateToggleVisibility in
+                // course-v3/assets/js/course_expander.ts (which owns all interaction
+                // and keeps re-checking on resize/font load) so the toggle is part
+                // of the first painted frame instead of popping in when the bundle
+                // runs. Body scripts execute after earlier stylesheets apply, so the
+                // clamp is measurable here. The 2px tolerance absorbs sub-pixel
+                // rounding.
+                (function () {
+                  var description = document.getElementById("course-description-text")
+                  var toggle = document.getElementById("toggle-description")
+                  if (
+                    description &&
+                    toggle &&
+                    description.scrollHeight - description.clientHeight > 2
+                  ) {
+                    toggle.classList.remove("d-none")
+                    toggle.classList.add("d-flex")
+                  }
+                })()
+              </script>
             </div>
             <div class="bottom-download-button align-self-stretch">
               {{ partial "download_course_link_button.html" (dict "context" . "inPanel" false) }}

--- a/course-v3/layouts/partials/course_description.html
+++ b/course-v3/layouts/partials/course_description.html
@@ -1,26 +1,10 @@
 {{ $courseData := .context.Site.Data.course }}
-{{ $shouldCollapseDescription := false }}
-{{ with $courseData.course_description }}
-  <!-- This matches the text inside the square brackets and keeps it, removing the actual link part. -->
-  {{ $plainDescription := . | replaceRE `\[(.*?)\]\(.*?\)` `$1` }}
-  {{ $shouldCollapseDescription = gt (len $plainDescription) 320 }}
-{{ end }}
 <div id="course-description" class="d-flex flex-column align-self-stretch align-items-start">
   <h2 class="course-section-heading align-self-stretch m-0">
     Course Description
   </h2>
-  {{ if $shouldCollapseDescription }}
-  <div id="collapsed-description" class="description">
-    {{- truncate 320 "" (.context.RenderString $courseData.course_description) -}}
-    {{- partial "link_button.html" (dict "text" "Show more" "id" "expand-description")  -}}
-  </div>
-  <div id="expanded-description" class="description d-none">
-    {{- .context.RenderString $courseData.course_description -}}
-    {{- partial "link_button.html" (dict "text" "Show less" "id" "collapse-description")  -}}
-  </div>
-  {{ else }}
-  <div id="full-description" class="description">
+  <div id="course-description-text" class="description description-collapsed">
     {{- .context.RenderString $courseData.course_description -}}
   </div>
-  {{ end }}
+  {{ partial "link_button.html" (dict "text" "Show more" "id" "toggle-description" "displayClass" "d-none" "ariaExpanded" "false" "ariaControls" "course-description-text") }}
 </div>

--- a/course-v3/layouts/partials/link_button.html
+++ b/course-v3/layouts/partials/link_button.html
@@ -1,1 +1,1 @@
-<button id="{{ .id }}" type="button" class="btn btn-link link-button p-0 d-flex align-items-center">{{ .text }}</button>
+<button id="{{ .id }}" type="button" class="btn btn-link link-button p-0 {{ .displayClass | default "d-flex" }} align-items-center{{ with .class }} {{ . }}{{ end }}"{{ with .ariaExpanded }} aria-expanded="{{ . }}"{{ end }}{{ with .ariaControls }} aria-controls="{{ . }}"{{ end }}>{{ .text }}</button>

--- a/tests-e2e/ocw-ci-test-course-v3/course-home-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/course-home-v3.spec.ts
@@ -66,4 +66,52 @@ test.describe("Course description", () => {
     })
     await expect(toggle).toBeVisible()
   })
+
+  test("re-checks overflow when a webfont finishes loading", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto("/")
+
+    const description = page.locator("#course-description-text")
+    const toggle = page.locator("#toggle-description")
+
+    // Baseline: the default description overflows its 5-line clamp, so the
+    // toggle is shown.
+    await expect(toggle).toBeVisible()
+    expect(
+      await description.evaluate(el => el.scrollHeight - el.clientHeight > 2)
+    ).toBe(true)
+
+    // Force the toggle into a stale (hidden) state while the text still
+    // overflows. This isolates the font listener: nothing else can restore
+    // the toggle — we never click, and the ResizeObserver stays silent because
+    // #course-description-text has a fixed `line-height`, so its collapsed
+    // clientHeight is pinned at 5 line-boxes and does not change. The only
+    // thing that can heal the toggle is the document.fonts "loadingdone"
+    // re-check. This is the exact case a webfont swap creates in production:
+    // the wrapped line count changes without the clamped element's height
+    // changing, which the ResizeObserver cannot observe.
+    await toggle.evaluate(el => {
+      el.classList.add("d-none")
+      el.classList.remove("d-flex")
+    })
+    await expect(toggle).toBeHidden()
+
+    // Trigger a genuine webfont load. A 724-byte real woff2 embedded as a
+    // data URI keeps this self-contained (no hashed asset path, no CORS): it
+    // loads successfully in every browser/mode and drives document.fonts
+    // through loading -> loadingdone for real.
+    const FONT_DATA_URI =
+      "url(data:font/woff2;base64,d09GMk9UVE8AAALUAAoAAAAABiQAAAKMAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAADYMLHGYGYAB4ATYCJAM8BAYFg2wHIBtwBSCeBXbDdRHKYBOdMKFlPEuOQ2mh6Pfb3vuIa9cE0z2phEIp1EjIEBJD5EAv7wHUQmpr8zZ0ZFIT1W7vp/FCzzBKJA2EP+Dn/5p8LXj9/B/g4SFmgCX287sFRdF8hqNhJcrEJjKnAeFsXlvsfJtEqo9XE4tesRWKsvVBckmSU1pC5Rl8YySf2NzG8njFJdy4icZ/b68cMikUYmOISSifQ9uU+OiYB4TI62ukFSblO2/S3T8B0IOJQCHpgqUwriL4CuItQLgYwdx48uDFXaxoPqKE8hNHITjbLSM7r7CkvKq2obmts6d/aHRiem5xZX1r9+D4DBtjY2NYOBYu+omRyyqrSpW+hxeoIxb7/lNWFhdWldAXZbVyoUxR1fzWEd0cH99MNBIfj6T/LZ3cKKKPb2XRfGbCTIRcREJddaZSeVNDealsMPr8RFltWC6fUGRjY/1OEPCoMYXfnv7hwD4pZQXAZgO8062bl50JVCgyNjZALq8iQrYP2COExMYpgi2CwU0kjljogx2TmgDQSABNTo1H2ghKe5CVxxCIziG6A1xcDDip6f9/wEnK+PL+N4D4AhxwAHAJExHgE2JKocvC87N4hRBlUAS4OaRJcCTIwwHhc9v3TuLYv7ssA8CXczwIwC90wB4ADAOwGABCQoQQ1qaCd1yAPMBpi0DDDRzBkpeWRN4IePKWozHeZuCFt+tEF3K8IhHcFCpSrUS2TFnKKDNlzIQNZV4KwUx5EMr8QTeGlLnIi5SFGjqlijMRpRAlKiDSGQqQogyiRLYURi0faQoVAFioXIF0oXSmcnnLKWlqsA1TpgyIjjVoU+FMaVvGjN+XOXOGzFiyYsOclYPhwEbvzsAgxAxWJ2AAAA==)"
+    await page.evaluate(async fontSrc => {
+      const face = new FontFace("e2e-fontcheck-probe", fontSrc)
+      document.fonts.add(face)
+      await face.load()
+    }, FONT_DATA_URI)
+
+    // The document.fonts "loadingdone" listener re-ran the overflow check and
+    // restored the toggle.
+    await expect(toggle).toBeVisible()
+  })
 })

--- a/tests-e2e/ocw-ci-test-course-v3/course-home-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/course-home-v3.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test"
+import { CoursePage } from "../util"
+
+test.describe("Course description", () => {
+  test("clamps to a fixed number of lines with a working toggle", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto("/")
+
+    const description = page.locator("#course-description-text")
+    const toggle = page.locator("#toggle-description")
+
+    // Collapsed by default: clamped, overflowing, toggle visible.
+    // The toggle must carry d-flex and not d-none: both are !important
+    // Bootstrap display utilities and d-flex wins over d-none, so the JS
+    // swaps them as a pair.
+    await expect(description).toHaveCSS("-webkit-line-clamp", "5")
+    await expect(toggle).toBeVisible()
+    await expect(toggle).toHaveClass(/d-flex/)
+    await expect(toggle).not.toHaveClass(/d-none/)
+    await expect(toggle).toHaveText("Show more")
+    await expect(toggle).toHaveAttribute("aria-expanded", "false")
+    expect(
+      await description.evaluate(el => el.scrollHeight > el.clientHeight)
+    ).toBe(true)
+
+    // Expand
+    await toggle.click()
+    await expect(description).toHaveCSS("-webkit-line-clamp", "none")
+    await expect(toggle).toHaveText("Show less")
+    await expect(toggle).toHaveAttribute("aria-expanded", "true")
+    expect(
+      await description.evaluate(el => el.scrollHeight > el.clientHeight)
+    ).toBe(false)
+
+    // Collapse again
+    await toggle.click()
+    await expect(description).toHaveCSS("-webkit-line-clamp", "5")
+    await expect(toggle).toHaveText("Show more")
+    await expect(toggle).toHaveAttribute("aria-expanded", "false")
+  })
+
+  test("hides the toggle when the description does not overflow", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto("/")
+
+    const description = page.locator("#course-description-text")
+    const toggle = page.locator("#toggle-description")
+    await expect(toggle).toBeVisible()
+
+    // Shrink the content in-page so the clamped element no longer overflows;
+    // the ResizeObserver re-check must hide the toggle. Asserting rendered
+    // visibility (not class state) guards against the Bootstrap 4 pitfall
+    // where d-flex overrides d-none and the button stays visible.
+    await description.evaluate(element => {
+      element.textContent = "A short description."
+    })
+    await expect(toggle).toBeHidden()
+
+    // Make it overflow again: the toggle must come back.
+    await description.evaluate(element => {
+      element.textContent = "More text than fits in five lines. ".repeat(50)
+    })
+    await expect(toggle).toBeVisible()
+  })
+})


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11894

### Description (What does it do?)
Switches the course-v3 home page course description from character-based to line-based truncation.

**Before:** the template decided to collapse when the (link-stripped) markdown source exceeded 320 characters, then rendered two copies of the description — one cut with `truncate 320 ""` and one full, hidden with `d-none` — and JS swapped the two divs.

**After:**
- The description is rendered and clamped to 5 lines with `-webkit-line-clamp` (native ellipsis). The line count lives in one SCSS variable, `$course-description-max-lines`.
- JS (`initCourseDescriptionExpander`) shows the Show more / Show less toggle only when the text actually overflows the clamp (`scrollHeight > clientHeight`), and re-checks via `ResizeObserver` as the viewport changes, so the button appears/disappears as the text re-wraps.
- The toggle updates `aria-expanded`, and the button is rendered with `aria-controls` pointing at the description.
- Hiding the button swaps `d-flex` together with `d-none`

### Screenshots (if appropriate):
See the netlify v3 [build](https://ocw-hugo-themes-course-v3-pr-1826--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/)

### How can this be tested?
- Run a local build of any v3 course `yarn build:course-v3-prefixed <content-repo-directory> --serve`
- Verify that the course description is truncated based on the number of lines and shows an ellipsis. Toggling the show more button works as expected
- For the course you just built, in the content data.json file, change the description to something that'd fit in less than 5 lines. Build the course again and verify that the description renders properly and the show more button is hidden.

### Additional Context
- The value for $course-description-max-lines has been chosen somewhat arbitrarily and will be confirmed with appropriate stakeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)