### PR TITLE
fix: department search links in v3

### DIFF
--- a/course-v3/data/search_query_keys.json
+++ b/course-v3/data/search_query_keys.json
@@ -1,0 +1,6 @@
+{
+  "instructors": "q",
+  "department_numbers": "department",
+  "level": "l",
+  "topic": "t"
+}

--- a/course-v3/layouts/partials/get_departments.html
+++ b/course-v3/layouts/partials/get_departments.html
@@ -2,7 +2,7 @@
 {{ range . }}
   {{ $department := index site.Data.departments . }}
   {{ if $department }}
-    {{ $department := merge $department (dict "url" (partial "get_search_url.html" (dict "key" "department_numbers" "value" $department.title))) }}
+    {{ $department := merge $department (dict "url" (partial "get_search_url.html" (dict "key" "department_numbers" "value" .))) }}
     {{ $departments = $departments | append $department }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11965

### Description (What does it do?)
Fixes the department search query params for v3


### Screenshots (if appropriate):
See netlify [build](https://ocw-hugo-themes-course-v3-pr-1827--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/)

### How can this be tested?
1. Build a course with v2 theme.
2. Verify that the departments on the course home page link to search with **`?d=<department_name>`** params
3. Build a course with v3 theme.
4. Verify that the departments on the course home page link to search with **`?department=<department_number>`** params


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
