### PR TITLE
fix: prevent double-path gallery image URLs from Fastly base URL resolution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 env:
-  COURSE_V3_URL_SLUG: 3-a04-modern-blacksmithing-and-physical-metallurgy-fall-2008
+  COURSE_V3_URL_SLUG: 15-s21-nuts-and-bolts-of-business-plans-january-iap-2014
 
 jobs:
   build:
@@ -38,7 +38,7 @@ jobs:
         run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/ocw-www.git ocw-www)
 
       - name: Clone ocw-course for content
-        run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/3.A04-fall-2008.git ocw-course)
+        run: (cd ..; git clone git@github.mit.edu:umarh8/15.s21-january-iap-2014.git ocw-course)
 
       - name: Clone ocw-hugo-projects for config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/ocw-www.git ocw-www)
 
       - name: Clone ocw-course for content
-        run: (cd ..; git clone git@github.mit.edu:umarh8/3.A04-fall-2008.git ocw-course)
+        run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/3.A04-fall-2008.git ocw-course)
 
       - name: Clone ocw-hugo-projects for config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 env:
-  COURSE_V3_URL_SLUG: 15-s21-nuts-and-bolts-of-business-plans-january-iap-2014
+  COURSE_V3_URL_SLUG: 3-a04-modern-blacksmithing-and-physical-metallurgy-fall-2008
 
 jobs:
   build:
@@ -38,7 +38,7 @@ jobs:
         run: (cd ..; git clone git@github.mit.edu:ocw-content-rc/ocw-www.git ocw-www)
 
       - name: Clone ocw-course for content
-        run: (cd ..; git clone git@github.mit.edu:umarh8/15.s21-january-iap-2014.git ocw-course)
+        run: (cd ..; git clone git@github.mit.edu:umarh8/3.A04-fall-2008.git ocw-course)
 
       - name: Clone ocw-hugo-projects for config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/base-theme/assets/js/utils.ts
+++ b/base-theme/assets/js/utils.ts
@@ -58,7 +58,7 @@ export function fastlyOptimizedUrl(
   url: string,
   params: Record<string, string>
 ): string {
-  if (!url || (!/^https?:\/\//.test(url) && !url.startsWith("/"))) return url
+  if (!url || (!/^https?:\/\//i.test(url) && !url.startsWith("/"))) return url
   const separator = url.includes("?") ? "&" : "?"
   const qs = new URLSearchParams(params).toString()
   return `${url}${separator}${qs}`
@@ -75,8 +75,8 @@ export function fastlyOptimizedGalleryUrl(
 ): string {
   let resolvedUrl = url
 
-  if (url && !/^https?:\/\//.test(url) && !url.startsWith("/")) {
-    if (/^https?:\/\//.test(baseUrl)) {
+  if (url && !/^https?:\/\//i.test(url) && !url.startsWith("/")) {
+    if (/^https?:\/\//i.test(baseUrl)) {
       resolvedUrl = new URL(
         url,
         baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`

--- a/base-theme/layouts/partials/image_resource.html
+++ b/base-theme/layouts/partials/image_resource.html
@@ -12,7 +12,7 @@
     <a href="{{- $imageHref -}}" target="_blank">
 {{- end -}}
 {{- $metadata := .resource.Params.image_metadata | default dict -}}
-{{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" .context "url" .resource.Params.file)) "alt" (index $metadata "image-alt" | default "")) }}
+{{ partial "picture_element.html" (dict "src" (partial "resource_url.html" (dict "context" .context "url" .resource.Params.file)) "alt" (index $metadata "image-alt" | default "") "sizes" "(min-width: 992px) 55vw, 100vw") }}
 {{- if $imageHref -}}
     </a>
 {{- end -}}

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -30,7 +30,7 @@ export function initImageGalleriesFromMarkup() {
     // root-relative (online). Passing itemsBaseURL in that case causes nanogallery2
     // to prepend it again, producing double-path URLs. Only pass it for relative
     // (offline) base URLs where items are left unresolved.
-    const isOnlineBase = /^https?:\/\//.test(baseUrl) || baseUrl.startsWith("/")
+    const isOnlineBase = /^https?:\/\//i.test(baseUrl) || baseUrl.startsWith("/")
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -30,7 +30,8 @@ export function initImageGalleriesFromMarkup() {
     // root-relative (online). Passing itemsBaseURL in that case causes nanogallery2
     // to prepend it again, producing double-path URLs. Only pass it for relative
     // (offline) base URLs where items are left unresolved.
-    const isOnlineBase = /^https?:\/\//i.test(baseUrl) || baseUrl.startsWith("/")
+    const isOnlineBase =
+      /^https?:\/\//i.test(baseUrl) || baseUrl.startsWith("/")
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -30,8 +30,7 @@ export function initImageGalleriesFromMarkup() {
     // root-relative (online). Passing itemsBaseURL in that case causes nanogallery2
     // to prepend it again, producing double-path URLs. Only pass it for relative
     // (offline) base URLs where items are left unresolved.
-    const isOnlineBase =
-      /^https?:\/\//.test(baseUrl) || baseUrl.startsWith("/")
+    const isOnlineBase = /^https?:\/\//.test(baseUrl) || baseUrl.startsWith("/")
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/course-v2/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v2/assets/js/init_image_galleries_from_markup.ts
@@ -26,10 +26,17 @@ export function initImageGalleriesFromMarkup() {
       }
     })
 
+    // fastlyOptimizedGalleryUrl pre-resolves items when baseUrl is absolute or
+    // root-relative (online). Passing itemsBaseURL in that case causes nanogallery2
+    // to prepend it again, producing double-path URLs. Only pass it for relative
+    // (offline) base URLs where items are left unresolved.
+    const isOnlineBase =
+      /^https?:\/\//.test(baseUrl) || baseUrl.startsWith("/")
+
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL:    baseUrl,
+      ...(isOnlineBase ? {} : { itemsBaseURL: baseUrl }),
       items:           items,
       allowHTMLinData: true
     })

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -29,8 +29,7 @@ export function initImageGalleriesFromMarkup() {
     // root-relative (online). Passing itemsBaseURL in that case causes nanogallery2
     // to prepend it again, producing double-path URLs. Only pass it for relative
     // (offline) base URLs where items are left unresolved.
-    const isOnlineBase =
-      /^https?:\/\//.test(baseUrl) || baseUrl.startsWith("/")
+    const isOnlineBase = /^https?:\/\//.test(baseUrl) || baseUrl.startsWith("/")
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -29,7 +29,8 @@ export function initImageGalleriesFromMarkup() {
     // root-relative (online). Passing itemsBaseURL in that case causes nanogallery2
     // to prepend it again, producing double-path URLs. Only pass it for relative
     // (offline) base URLs where items are left unresolved.
-    const isOnlineBase = /^https?:\/\//i.test(baseUrl) || baseUrl.startsWith("/")
+    const isOnlineBase =
+      /^https?:\/\//i.test(baseUrl) || baseUrl.startsWith("/")
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -29,7 +29,7 @@ export function initImageGalleriesFromMarkup() {
     // root-relative (online). Passing itemsBaseURL in that case causes nanogallery2
     // to prepend it again, producing double-path URLs. Only pass it for relative
     // (offline) base URLs where items are left unresolved.
-    const isOnlineBase = /^https?:\/\//.test(baseUrl) || baseUrl.startsWith("/")
+    const isOnlineBase = /^https?:\/\//i.test(baseUrl) || baseUrl.startsWith("/")
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/course-v3/assets/js/init_image_galleries_from_markup.ts
+++ b/course-v3/assets/js/init_image_galleries_from_markup.ts
@@ -25,10 +25,17 @@ export function initImageGalleriesFromMarkup() {
       }
     })
 
+    // fastlyOptimizedGalleryUrl pre-resolves items when baseUrl is absolute or
+    // root-relative (online). Passing itemsBaseURL in that case causes nanogallery2
+    // to prepend it again, producing double-path URLs. Only pass it for relative
+    // (offline) base URLs where items are left unresolved.
+    const isOnlineBase =
+      /^https?:\/\//.test(baseUrl) || baseUrl.startsWith("/")
+
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.jQuery(gallery).nanogallery2({
-      itemsBaseURL:    baseUrl,
+      ...(isOnlineBase ? {} : { itemsBaseURL: baseUrl }),
       items:           items,
       allowHTMLinData: true
     })


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12183

### Description (What does it do?)
Fixes a regression from #1791 where gallery image URLs could double up the base path (e.g. `.../course-slug//course-slug/image.jpg?format=auto...`). `init_image_galleries_from_markup.ts` pre-resolves item URLs via `fastlyOptimizedGalleryUrl` but was also passing `itemsBaseURL` to nanogallery2, which prepended the same base again. `itemsBaseURL` is now only passed when `baseUrl` is a relative (offline) path that was left unresolved. Also restores the `sizes` attribute on `image_resource.html`, dropped by a prior lint pass.

### Netlify 
[course-v2](https://ocw-hugo-themes-course-v2-pr-1828--ocw-next.netlify.app/pages/projects/)
[course-v3](https://ocw-hugo-themes-course-v3-pr-1828--ocw-next.netlify.app/courses/o/3-a04-modern-blacksmithing-and-physical-metallurgy-fall-2008/pages/projects/)

### How can this be tested?
1. Visit image galleries on Netlify builds [course-v2](https://ocw-hugo-themes-course-v2-pr-1828--ocw-next.netlify.app/pages/projects/) and [course-v3](https://ocw-hugo-themes-course-v3-pr-1828--ocw-next.netlify.app/courses/o/3-a04-modern-blacksmithing-and-physical-metallurgy-fall-2008/pages/projects/)
2. Open DevTools → **Network** tab → filter **Img**
3. Gallery image request URLs should be a single path, not doubled (e.g. no `//course-slug/` repeated).