### PR TITLE
Add resource description to v3 theme

### DIFF
--- a/base-theme/layouts/partials/resource_body_v3.html
+++ b/base-theme/layouts/partials/resource_body_v3.html
@@ -4,8 +4,8 @@
     <div class="resource-single-content">
       {{- if .Content -}}
         <div class="resource-description">
-          <strong>Description:</strong>
-          {{ .Content }}
+          <strong class="resource-description-label">Description:</strong>
+          <div class="resource-description-content">{{ .Content }}</div>
         </div>
       {{- end -}}
       {{- if .Params.learning_resource_types -}}

--- a/base-theme/layouts/partials/resource_body_v3.html
+++ b/base-theme/layouts/partials/resource_body_v3.html
@@ -2,6 +2,12 @@
 <div class="resource-page-container w-100">
   {{- if ne .Params.resourcetype "Video" }}
     <div class="resource-single-content">
+      {{- if .Content -}}
+        <div class="resource-description">
+          <strong>Description:</strong>
+          {{ .Content }}
+        </div>
+      {{- end -}}
       {{- if .Params.learning_resource_types -}}
         <div class="resource-type-field">
           <span class="resource-type-label">Resource Type:</span>

--- a/course-v3/assets/css/course-resources.scss
+++ b/course-v3/assets/css/course-resources.scss
@@ -312,6 +312,29 @@ $resource-card-text-primary: #212326; // Text Primary
   }
 }
 
+.resource-description {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+  line-height: 18px;
+  color: $black;
+
+  .resource-description-label {
+    font-weight: 500;
+  }
+
+  .resource-description-content {
+    p {
+      margin: 0;
+
+      & + p {
+        margin-top: 8px;
+      }
+    }
+  }
+}
+
 .resource-single-card {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12326.

### Description (What does it do?)
This PR fixes an omission in the v3 theme where the resource description field was not being rendered.

### How can this be tested?
Run `yarn build:course-v3-prefixed 15.014-spring-2016`, serve the course locally, and then navigate to `http://localhost:8000/courses/o/15-014-applied-macro-and-international-economics-ii-spring-2016/resources/mit15_014s16_chap1-12and14/`. Verify that the Description field appears. Verify this for other courses and resources as well.