### PR TITLE
fix: OCW on Learn accessibility issues (skip link, focus management, accessible names)

### DIFF
--- a/base-theme/assets/js/components/BookmarkButton.test.tsx
+++ b/base-theme/assets/js/components/BookmarkButton.test.tsx
@@ -17,11 +17,12 @@ jest.mock("@mitodl/smoot-design", () => ({
 const mockHooks = ({
   isAuthenticated = true,
   resourceId = undefined as number | undefined,
+  title = undefined as string | undefined,
   memberships = [] as string[]
 } = {}) => {
   jest.mocked(userHooks.useUserIsAuthenticated).mockReturnValue(isAuthenticated)
   jest.mocked(lrHooks.useLearningResourceByReadableId).mockReturnValue({
-    data:      resourceId !== undefined ? { id: resourceId } : undefined,
+    data:      resourceId !== undefined ? { id: resourceId, title } : undefined,
     isLoading: false
   } as ReturnType<typeof lrHooks.useLearningResourceByReadableId>)
   jest.mocked(ulHooks.useUserListMemberList).mockReturnValue({
@@ -62,4 +63,26 @@ test("shows filled bookmark when resource is in user list", () => {
   mockHooks({ resourceId: 42, memberships: ["1"] })
   render(<BookmarkButton resourceReadableId="6.001+fall_2024" />)
   expect(screen.getByRole("button")).toHaveAttribute("variant", "primary")
+})
+
+test("has a generic accessible name to add a resource before its title loads", () => {
+  mockHooks({ resourceId: 42 })
+  render(<BookmarkButton resourceReadableId="6.001+fall_2024" />)
+  expect(screen.getByRole("button")).toHaveAccessibleName("Add to list")
+})
+
+test("has a specific accessible name to add a resource once its title loads", () => {
+  mockHooks({ resourceId: 42, title: "Clip: Finale" })
+  render(<BookmarkButton resourceReadableId="6.001+fall_2024" />)
+  expect(screen.getByRole("button")).toHaveAccessibleName(
+    "Add Clip: Finale to your list"
+  )
+})
+
+test("has a specific accessible name to remove a resource already in a list", () => {
+  mockHooks({ resourceId: 42, title: "Clip: Finale", memberships: ["1"] })
+  render(<BookmarkButton resourceReadableId="6.001+fall_2024" />)
+  expect(screen.getByRole("button")).toHaveAccessibleName(
+    "Remove Clip: Finale from your list"
+  )
 })

--- a/base-theme/assets/js/components/BookmarkButton.tsx
+++ b/base-theme/assets/js/components/BookmarkButton.tsx
@@ -24,6 +24,14 @@ const BookmarkButton: React.FC<BookmarkButtonProps> = ({
   if (!isAuthenticated) return null
 
   const inUserList = (userListMemberships?.length ?? 0) > 0
+  const ariaLabel = resource?.title ?
+    inUserList ?
+      `Remove ${resource.title} from your list` :
+      `Add ${resource.title} to your list` :
+    inUserList ?
+      "Remove from list" :
+      "Add to list"
+
   return (
     <ActionButton
       className="bookmark-button"
@@ -31,6 +39,7 @@ const BookmarkButton: React.FC<BookmarkButtonProps> = ({
       size="small"
       variant={inUserList ? "primary" : "secondary"}
       color={inUserList ? undefined : "secondary"}
+      aria-label={ariaLabel}
       data-toggle="modal"
       data-target="#add-to-user-list-modal"
       data-resourcereadableid={resourceReadableId}

--- a/base-theme/assets/js/components/BookmarkButton.tsx
+++ b/base-theme/assets/js/components/BookmarkButton.tsx
@@ -24,13 +24,11 @@ const BookmarkButton: React.FC<BookmarkButtonProps> = ({
   if (!isAuthenticated) return null
 
   const inUserList = (userListMemberships?.length ?? 0) > 0
+  const prefix = inUserList ? "Remove" : "Add"
+  const preposition = inUserList ? "from" : "to"
   const ariaLabel = resource?.title ?
-    inUserList ?
-      `Remove ${resource.title} from your list` :
-      `Add ${resource.title} to your list` :
-    inUserList ?
-      "Remove from list" :
-      "Add to list"
+    `${prefix} ${resource.title} ${preposition} your list` :
+    `${prefix} ${preposition} list`
 
   return (
     <ActionButton

--- a/course-v3/assets/css/course-v3.scss
+++ b/course-v3/assets/css/course-v3.scss
@@ -6,6 +6,7 @@
 @import "~offcanvas-bootstrap/src/sass/bootstrap.offcanvas";
 
 @import "mit-learn-header";
+@import "skip-link";
 @import "appzi";
 @import "course-nav";
 @import "course-info";

--- a/course-v3/assets/css/mit-learn-header.scss
+++ b/course-v3/assets/css/mit-learn-header.scss
@@ -606,3 +606,14 @@ body.has-mit-learn-header {
     display: none !important;
   }
 }
+
+// The header is fixed, so scrolling #course-content-section flush to the
+// viewport top (e.g. via the skip link) would tuck its first ~header-height
+// of content behind it. scroll-margin-top leaves that space clear.
+#course-content-section {
+  scroll-margin-top: $mit-learn-header-height;
+
+  @include media-breakpoint-down(md) {
+    scroll-margin-top: $mit-learn-header-height-mobile;
+  }
+}

--- a/course-v3/assets/css/skip-link.scss
+++ b/course-v3/assets/css/skip-link.scss
@@ -1,6 +1,9 @@
 .skip-to-main-content {
   &:focus,
   &:focus-visible {
+    position: absolute;
+    top: 10px;
+    left: 10px;
     z-index: 2000;
     display: inline-block;
     padding: 0.75rem 1.5rem;

--- a/course-v3/assets/css/skip-link.scss
+++ b/course-v3/assets/css/skip-link.scss
@@ -1,4 +1,9 @@
-.skip-to-main-content {
+// Qualified with the element type so this outranks Bootstrap's
+// .sr-only-focusable:focus rule on the tied position property: both
+// selectors are otherwise equally specific, and Bootstrap's copy is
+// duplicated into a separately-loaded bundle (common.css) that can win
+// the source-order tiebreak depending on <link> order.
+a.skip-to-main-content {
   &:focus,
   &:focus-visible {
     position: absolute;

--- a/course-v3/assets/css/skip-link.scss
+++ b/course-v3/assets/css/skip-link.scss
@@ -1,8 +1,27 @@
+// Bootstrap's .sr-only utility hides content with a 1px x 1px clipped box, which
+// keeps a non-empty bounding rect. That's indistinguishable from "visible" to
+// several visibility checks (Playwright's toBeVisible() among them), even
+// though nothing is shown on screen. To make the hidden state unambiguous while
+// keeping the link in the keyboard tab order, collapse it to a true 0x0 box
+// instead and restore normal sizing on focus.
 .skip-to-main-content {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  white-space: nowrap;
+
   &:focus,
   &:focus-visible {
     z-index: 2000;
     display: inline-block;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    white-space: normal;
     padding: 0.75rem 1.5rem;
     background-color: $white;
     color: $black;

--- a/course-v3/assets/css/skip-link.scss
+++ b/course-v3/assets/css/skip-link.scss
@@ -1,0 +1,14 @@
+.skip-to-main-content {
+  &:focus,
+  &:focus-visible {
+    z-index: 2000;
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    background-color: $white;
+    color: $black;
+    font-weight: 600;
+    text-decoration: underline;
+    border: 2px solid $black;
+    border-radius: 4px;
+  }
+}

--- a/course-v3/assets/css/skip-link.scss
+++ b/course-v3/assets/css/skip-link.scss
@@ -1,27 +1,8 @@
-// Bootstrap's .sr-only utility hides content with a 1px x 1px clipped box, which
-// keeps a non-empty bounding rect. That's indistinguishable from "visible" to
-// several visibility checks (Playwright's toBeVisible() among them), even
-// though nothing is shown on screen. To make the hidden state unambiguous while
-// keeping the link in the keyboard tab order, collapse it to a true 0x0 box
-// instead and restore normal sizing on focus.
 .skip-to-main-content {
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 0;
-  height: 0;
-  overflow: hidden;
-  white-space: nowrap;
-
   &:focus,
   &:focus-visible {
     z-index: 2000;
     display: inline-block;
-    width: auto;
-    height: auto;
-    overflow: visible;
-    white-space: normal;
     padding: 0.75rem 1.5rem;
     background-color: $white;
     color: $black;

--- a/course-v3/layouts/_default/baseof.html
+++ b/course-v3/layouts/_default/baseof.html
@@ -64,6 +64,7 @@
     // IDs of elements
     const DESKTOP_COURSE_DRAWER_ID = "desktop-course-drawer"
     const COURSE_DRAWER_BTN_ID = "desktop-course-drawer-button"
+    const COURSE_DRAWER_CLOSE_BTN_ID = "desktop-course-drawer-button-close"
 
     try{
 
@@ -88,6 +89,13 @@
               return;
             }
             setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_OPENED)
+            // course_info.html renders this id in both the desktop and mobile
+            // drawer markup, so scope the lookup to the desktop drawer to
+            // avoid focusing the mobile copy.
+            const closeBtn = document.querySelector(`#${DESKTOP_COURSE_DRAWER_ID} #${COURSE_DRAWER_CLOSE_BTN_ID}`)
+            if (closeBtn) {
+              closeBtn.focus()
+            }
           })
       
           drawer.on("hidden.bs.collapse", (event) => {

--- a/course-v3/layouts/_default/baseof.html
+++ b/course-v3/layouts/_default/baseof.html
@@ -114,13 +114,24 @@
       function showOrHideDesktopCourseDrawer(state) {
         const drawer = document.getElementById(DESKTOP_COURSE_DRAWER_ID)
         const button = document.getElementById(COURSE_DRAWER_BTN_ID)
+        // The close button lives inside the drawer and is a Bootstrap collapse
+        // trigger too, so keep its aria-expanded in sync here. This path sets
+        // the .show class directly (bypassing Bootstrap's API to avoid firing
+        // collapse events on load), so Bootstrap's own trigger-sync doesn't run.
+        const closeButton = drawer.querySelector(`#${COURSE_DRAWER_CLOSE_BTN_ID}`)
 
         if (state === COURSE_DRAWER_OPENED) {
           drawer.classList.add("show")
           button.setAttribute("aria-expanded", "true")
+          if (closeButton) {
+            closeButton.setAttribute("aria-expanded", "true")
+          }
         } else {
           drawer.classList.remove("show")
           button.setAttribute("aria-expanded", "false")
+          if (closeButton) {
+            closeButton.setAttribute("aria-expanded", "false")
+          }
         }
       }
 

--- a/course-v3/layouts/_default/baseof.html
+++ b/course-v3/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
 {{ partial "head.html" . }}
 
 <body class="course-home-page has-mit-learn-header">
-  <a href="#course-content-section" class="skip-to-main-content sr-only-focusable">Skip to main content</a>
+  <a href="#course-content-section" class="skip-to-main-content">Skip to main content</a>
   {{ if $gtmId }}
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtmId | safeURL }}" height="0" width="0"

--- a/course-v3/layouts/_default/baseof.html
+++ b/course-v3/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
 {{ partial "head.html" . }}
 
 <body class="course-home-page has-mit-learn-header">
-  <a href="#course-content-section" class="skip-to-main-content">Skip to main content</a>
+  <a href="#course-content-section" class="skip-to-main-content sr-only sr-only-focusable">Skip to main content</a>
   {{ if $gtmId }}
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtmId | safeURL }}" height="0" width="0"

--- a/course-v3/layouts/_default/baseof.html
+++ b/course-v3/layouts/_default/baseof.html
@@ -95,7 +95,10 @@
               return;
             }
             setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_CLOSED)
-            document.getElementById(COURSE_DRAWER_BTN_ID).focus()
+            const drawerBtn = document.getElementById(COURSE_DRAWER_BTN_ID)
+            if (drawerBtn) {
+              drawerBtn.focus()
+            }
           })
         })
       }

--- a/course-v3/layouts/_default/baseof.html
+++ b/course-v3/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
 {{ partial "head.html" . }}
 
 <body class="course-home-page has-mit-learn-header">
-  <a href="#course-content-section" class="skip-to-main-content sr-only sr-only-focusable">Skip to main content</a>
+  {{ partial "skip_link.html" }}
   {{ if $gtmId }}
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtmId | safeURL }}" height="0" width="0"

--- a/course-v3/layouts/_default/baseof.html
+++ b/course-v3/layouts/_default/baseof.html
@@ -7,6 +7,7 @@
 {{ partial "head.html" . }}
 
 <body class="course-home-page has-mit-learn-header">
+  <a href="#course-content-section" class="skip-to-main-content sr-only-focusable">Skip to main content</a>
   {{ if $gtmId }}
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtmId | safeURL }}" height="0" width="0"
@@ -30,7 +31,7 @@
             <div class="course-nav-desktop large-and-above-only p-0">
               {{ partialCached "desktop_nav.html" . }}
             </div>
-            <main id="course-content-section" class="course-detail align-self-stretch">
+            <main id="course-content-section" class="course-detail align-self-stretch" tabindex="-1">
               {{ block "main" . }}{{ end }}
             </main>
             <div class="col-12 col-md-4 col-lg-3 p-0 desktop-course-info tablet-and-above-only">

--- a/course-v3/layouts/_default/baseof.html
+++ b/course-v3/layouts/_default/baseof.html
@@ -95,6 +95,7 @@
               return;
             }
             setLocalStorageItem(COURSE_DRAWER_LOCAL_STORAGE_KEY, COURSE_DRAWER_CLOSED)
+            document.getElementById(COURSE_DRAWER_BTN_ID).focus()
           })
         })
       }

--- a/course-v3/layouts/home.html
+++ b/course-v3/layouts/home.html
@@ -6,7 +6,7 @@
 {{ partial "head.html" . }}
 
 <body class="course-home-page has-mit-learn-header">
-  <a href="#course-content-section" class="skip-to-main-content sr-only sr-only-focusable">Skip to main content</a>
+  {{ partial "skip_link.html" }}
   {{ if $gtmId }}
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtmId | safeURL }}" height="0" width="0"

--- a/course-v3/layouts/home.html
+++ b/course-v3/layouts/home.html
@@ -20,7 +20,7 @@
       {{ block "header" . }}{{ partialCached "header" . }}{{ end }}
       {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
     </div>
-    <main>
+    <div>
       <div class="course-main-content-v3">
         <div class="container-v3">
           <div class="mobile-nav-div medium-and-below-only align-self-stretch">
@@ -31,9 +31,9 @@
               <div class="course-nav-desktop large-and-above-only p-0">
                 {{ partialCached "desktop_nav.html" . }}
               </div>
-              <div id="course-content-section" class="course-detail d-flex flex-column align-items-start align-self-stretch" tabindex="-1">
+              <main id="course-content-section" class="course-detail d-flex flex-column align-items-start align-self-stretch" tabindex="-1">
                 {{ partialCached "course_detail.html" . }}
-              </div>
+              </main>
               <div class="col-12 col-md-4 col-lg-3 p-0 course-image-section">
                 {{ partialCached "course_image_section.html" . }}
               </div>
@@ -66,7 +66,7 @@
           {{ partial "course_licensing.html" . }}
         </div>
       </div>
-    </main>
+    </div>
     {{ block "footer" . }}{{ partial "footer-v3" . }}{{end}}
     {{ partialCached "hide_offline_links.html" . }}
   </div>

--- a/course-v3/layouts/home.html
+++ b/course-v3/layouts/home.html
@@ -6,6 +6,7 @@
 {{ partial "head.html" . }}
 
 <body class="course-home-page has-mit-learn-header">
+  <a href="#course-content-section" class="skip-to-main-content sr-only sr-only-focusable">Skip to main content</a>
   {{ if $gtmId }}
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtmId | safeURL }}" height="0" width="0"
@@ -30,7 +31,7 @@
               <div class="course-nav-desktop large-and-above-only p-0">
                 {{ partialCached "desktop_nav.html" . }}
               </div>
-              <div id="course-content-section" class="course-detail d-flex flex-column align-items-start align-self-stretch">
+              <div id="course-content-section" class="course-detail d-flex flex-column align-items-start align-self-stretch" tabindex="-1">
                 {{ partialCached "course_detail.html" . }}
               </div>
               <div class="col-12 col-md-4 col-lg-3 p-0 course-image-section">

--- a/course-v3/layouts/partials/course_info.html
+++ b/course-v3/layouts/partials/course_info.html
@@ -19,7 +19,7 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
     {{ if $inPanel}}
     <button type="button" class="course-info-button tablet-and-above-only position-static border-0 bg-white"
       id="desktop-course-drawer-button-close" data-target="#desktop-course-drawer" data-toggle="collapse"
-      aria-label="Course Info" aria-controls="desktop-course-drawer" aria-expanded="false">
+      aria-label="Close Course Info" aria-controls="desktop-course-drawer" aria-expanded="false">
       <svg aria-hidden="true" class="collapse-drawer-img" xmlns="http://www.w3.org/2000/svg" width="13" height="13"
         viewBox="0 0 13 13" fill="none">
         <path

--- a/course-v3/layouts/partials/icon.html
+++ b/course-v3/layouts/partials/icon.html
@@ -1,14 +1,18 @@
-{{- /* 
+{{- /*
   Icon partial - loads SVG icons from assets/icons folder
   Usage: {{ partial "icon.html" "ri-menu-line" }}
-  
+
   Icons are loaded via Hugo's resources.Get and inlined for optimal performance.
   This allows icons to inherit color via CSS currentColor.
+
+  Every call site pairs these icons with visible text or an aria-label on the
+  enclosing control, so aria-hidden is added unconditionally here rather than
+  threading a per-call flag through every caller.
 */ -}}
 {{- $iconName := . -}}
 {{- $iconPath := printf "icons/%s.svg" $iconName -}}
 {{- with resources.Get $iconPath -}}
-  {{- .Content | safeHTML -}}
+  {{- .Content | replaceRE `<svg ` `<svg aria-hidden="true" ` | safeHTML -}}
 {{- else -}}
   {{- warnf "Icon not found: %s" $iconPath -}}
 {{- end -}}

--- a/course-v3/layouts/partials/resource_list_item.html
+++ b/course-v3/layouts/partials/resource_list_item.html
@@ -29,7 +29,7 @@
     </div>
   </a>
   {{ end }}
-  <a class="resource-card-title" href="{{ partial "page_url.html" (dict "context" .context "url" .permalink) }}">
+  <a class="resource-card-title" href="{{ partial "page_url.html" (dict "context" .context "url" .permalink) }}" aria-label="View {{ .Params.title | plainify }} details">
     {{- .Params.title -}}
   </a>
 </div>

--- a/course-v3/layouts/partials/skip_link.html
+++ b/course-v3/layouts/partials/skip_link.html
@@ -1,0 +1,14 @@
+<a href="#course-content-section" class="skip-to-main-content sr-only sr-only-focusable">Skip to main content</a>
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const target = document.getElementById("course-content-section")
+    if (target) {
+      // scroll-margin-top keeps the fixed header from covering the content,
+      // but browsers don't consistently honor it for focus-triggered
+      // scrolling (Firefox doesn't, Chrome does), so scroll explicitly here.
+      target.addEventListener("focus", () => {
+        target.scrollIntoView()
+      })
+    }
+  })
+</script>

--- a/course-v3/layouts/partials/skip_link.html
+++ b/course-v3/layouts/partials/skip_link.html
@@ -1,13 +1,25 @@
 <a href="#course-content-section" class="skip-to-main-content sr-only sr-only-focusable">Skip to main content</a>
 <script>
   document.addEventListener("DOMContentLoaded", () => {
+    const skipLink = document.querySelector(".skip-to-main-content")
     const target = document.getElementById("course-content-section")
-    if (target) {
-      // scroll-margin-top keeps the fixed header from covering the content,
-      // but browsers don't consistently honor it for focus-triggered
-      // scrolling (Firefox doesn't, Chrome does), so scroll explicitly here.
-      target.addEventListener("focus", () => {
-        target.scrollIntoView()
+    if (skipLink && target) {
+      // Browsers don't handle focus-triggered scrolling consistently here:
+      // Firefox ignores scroll-margin-top (tucking the content behind the
+      // fixed header) and still scrolls on its own even when the target is
+      // already fully visible. Take over entirely: suppress the native
+      // scroll-on-focus and only scroll ourselves when actually needed.
+      skipLink.addEventListener("click", event => {
+        event.preventDefault()
+        history.replaceState(null, "", "#course-content-section")
+
+        const rect = target.getBoundingClientRect()
+        const headerOffset = parseFloat(getComputedStyle(target).scrollMarginTop) || 0
+        const isVisible = rect.top >= headerOffset && rect.top < window.innerHeight
+        target.focus({ preventScroll: true })
+        if (!isVisible) {
+          target.scrollIntoView()
+        }
       })
     }
   })

--- a/tests-e2e/ocw-ci-test-course-v3/course-info-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/course-info-v3.spec.ts
@@ -41,4 +41,21 @@ test.describe("Course v3 Course Info drawer focus management", () => {
     await openButton.click()
     await expect(closeButton).toBeFocused()
   })
+
+  test("close button aria-expanded matches the restored initial state", async ({
+    page
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    const course = new CoursePage(page, "course-v3")
+    await course.goto("/resources/file_pdf")
+
+    // The drawer is open by default for first-time visitors (no stored
+    // preference), and the close button's initial aria-expanded is
+    // hardcoded "false" server-side, so this only passes if the client-side
+    // state restoration also syncs the close button, not just the toggle.
+    const closeButton = page.locator(
+      "#desktop-course-drawer #desktop-course-drawer-button-close"
+    )
+    await expect(closeButton).toHaveAttribute("aria-expanded", "true")
+  })
 })

--- a/tests-e2e/ocw-ci-test-course-v3/course-info-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/course-info-v3.spec.ts
@@ -23,4 +23,22 @@ test.describe("Course v3 Course Info drawer focus management", () => {
     await closeButton.click()
     await expect(openButton).toBeFocused()
   })
+
+  test("moves focus to the close button when opened", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    const course = new CoursePage(page, "course-v3")
+    await course.goto("/resources/file_pdf")
+
+    const openButton = page.locator("#desktop-course-drawer-button")
+    const closeButton = page.locator(
+      "#desktop-course-drawer #desktop-course-drawer-button-close"
+    )
+
+    // Close it first since the drawer is open by default, then reopen it.
+    await closeButton.click()
+    await expect(openButton).toBeFocused()
+
+    await openButton.click()
+    await expect(closeButton).toBeFocused()
+  })
 })

--- a/tests-e2e/ocw-ci-test-course-v3/course-info-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/course-info-v3.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test"
+import { CoursePage } from "../util"
+
+test.describe("Course v3 Course Info drawer focus management", () => {
+  test("returns focus to the toggle button when closed", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    const course = new CoursePage(page, "course-v3")
+    await course.goto("/resources/file_pdf")
+
+    const openButton = page.locator("#desktop-course-drawer-button")
+    // Scoped to the desktop drawer container: course_info.html is also
+    // rendered (inPanel=true) inside the mobile drawer markup in
+    // mobile_course_info.html, which reuses the same close-button id and
+    // would otherwise make this locator ambiguous.
+    const closeButton = page.locator(
+      "#desktop-course-drawer #desktop-course-drawer-button-close"
+    )
+
+    // The drawer is open by default for first-time visitors (no stored preference).
+    await expect(closeButton).toBeVisible()
+    await expect(closeButton).toHaveAttribute("aria-label", "Close Course Info")
+
+    await closeButton.click()
+    await expect(openButton).toBeFocused()
+  })
+})

--- a/tests-e2e/ocw-ci-test-course-v3/resource-list-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/resource-list-v3.spec.ts
@@ -205,6 +205,29 @@ test.describe("Course v3 Resource List", () => {
     expect(titleText).toBeTruthy()
   })
 
+  test("Resource title link has an accessible name distinct from the download link", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto("/lists/a-resource-list")
+
+    const pdfCard = page.locator(".resource-card", {
+      has: page.locator(".resource-card-title", { hasText: "file.pdf" })
+    })
+
+    const titleLink = pdfCard.locator(".resource-card-title")
+    const downloadLink = pdfCard.locator(".resource-card-thumbnail-link")
+
+    await expect(downloadLink).toHaveAttribute(
+      "aria-label",
+      "Download file.pdf"
+    )
+    await expect(titleLink).toHaveAttribute(
+      "aria-label",
+      "View file.pdf details"
+    )
+  })
+
   test("Resource cards have proper spacing and gap", async ({ page }) => {
     const course = new CoursePage(page, "course-v3")
     await course.goto("/lists/a-resource-list")

--- a/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
@@ -59,4 +59,36 @@ test.describe("Course v3 skip to main content link", () => {
 
     await assertSkipLinkWorks(page, course)
   })
+
+  test("does not scroll when the content region is already visible", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto("/resources/file_pdf")
+
+    // Scroll so the content's top edge sits just below the header, computed
+    // precisely rather than via scrollIntoViewIfNeeded: for an element this
+    // tall, "nearest edge" scrolling can leave the top edge off-screen while
+    // a lower part of the element is already in view, which isn't the case
+    // this test means to set up.
+    const scrollYBefore = await page.evaluate(() => {
+      const target = document.getElementById("course-content-section")
+      const headerOffset = parseFloat(getComputedStyle(target).scrollMarginTop) || 0
+      const absoluteTop = target.getBoundingClientRect().top + window.scrollY
+      window.scrollTo(0, absoluteTop - headerOffset - 20)
+      return window.scrollY
+    })
+
+    // Dispatch a real click on the skip link itself, exercising its actual
+    // handler, without Tab/mouse actionability scrolling getting in the way.
+    await page.evaluate(() => {
+      document
+        .querySelector<HTMLElement>(".skip-to-main-content")
+        ?.click()
+    })
+
+    await expect(course.withinContent()).toBeFocused()
+    const scrollYAfter = await page.evaluate(() => window.scrollY)
+    expect(scrollYAfter).toBe(scrollYBefore)
+  })
 })

--- a/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
@@ -11,8 +11,10 @@ test.describe("Course v3 skip to main content link", () => {
     const skipLink = page.locator("a.skip-to-main-content")
     await expect(skipLink).toHaveAttribute("href", "#course-content-section")
     await expect(skipLink).toHaveText("Skip to main content")
+    await expect(skipLink).not.toBeVisible()
 
     await page.keyboard.press("Tab")
+    await expect(skipLink).toBeVisible()
     await expect(skipLink).toBeFocused()
 
     await page.keyboard.press("Enter")

--- a/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
@@ -1,5 +1,33 @@
-import { test, expect } from "@playwright/test"
+import { Page, test, expect } from "@playwright/test"
 import { CoursePage } from "../util"
+
+/**
+ * Asserts that the skip-to-main-content link is hidden until focused, is
+ * reachable as the first Tab stop, and moves focus into the course content
+ * region when activated.
+ */
+async function assertSkipLinkWorks(page: Page, course: CoursePage) {
+  const skipLink = page.locator("a.skip-to-main-content")
+  await expect(skipLink).toHaveAttribute("href", "#course-content-section")
+  await expect(skipLink).toHaveText("Skip to main content")
+
+  // Bootstrap's .sr-only hides content with a clipped 1x1px box (not
+  // display:none), so it stays in the accessibility tree for screen
+  // readers. Assert on the box size directly rather than toBeVisible(),
+  // which only checks for a non-empty box + visibility != hidden and
+  // would report this element as "visible" either way.
+  const hiddenBox = await skipLink.boundingBox()
+  expect(hiddenBox?.width).toBeLessThanOrEqual(1)
+  expect(hiddenBox?.height).toBeLessThanOrEqual(1)
+
+  await page.keyboard.press("Tab")
+  await expect(skipLink).toBeFocused()
+  const focusedBox = await skipLink.boundingBox()
+  expect(focusedBox?.width).toBeGreaterThan(10)
+
+  await page.keyboard.press("Enter")
+  await expect(course.withinContent()).toBeFocused()
+}
 
 test.describe("Course v3 skip to main content link", () => {
   test("is the first focusable element and moves focus to main content when activated", async ({
@@ -8,25 +36,13 @@ test.describe("Course v3 skip to main content link", () => {
     const course = new CoursePage(page, "course-v3")
     await course.goto("/resources/file_pdf")
 
-    const skipLink = page.locator("a.skip-to-main-content")
-    await expect(skipLink).toHaveAttribute("href", "#course-content-section")
-    await expect(skipLink).toHaveText("Skip to main content")
+    await assertSkipLinkWorks(page, course)
+  })
 
-    // Bootstrap's .sr-only hides content with a clipped 1x1px box (not
-    // display:none), so it stays in the accessibility tree for screen
-    // readers. Assert on the box size directly rather than toBeVisible(),
-    // which only checks for a non-empty box + visibility != hidden and
-    // would report this element as "visible" either way.
-    const hiddenBox = await skipLink.boundingBox()
-    expect(hiddenBox?.width).toBeLessThanOrEqual(1)
-    expect(hiddenBox?.height).toBeLessThanOrEqual(1)
+  test("works on the course home page", async ({ page }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto()
 
-    await page.keyboard.press("Tab")
-    await expect(skipLink).toBeFocused()
-    const focusedBox = await skipLink.boundingBox()
-    expect(focusedBox?.width).toBeGreaterThan(10)
-
-    await page.keyboard.press("Enter")
-    await expect(course.withinContent()).toBeFocused()
+    await assertSkipLinkWorks(page, course)
   })
 })

--- a/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
@@ -39,7 +39,9 @@ async function assertSkipLinkWorks(page: Page, course: CoursePage) {
   expect(headerBox).not.toBeNull()
   const minContentY = headerBox!.y + headerBox!.height - 1
   await expect
-    .poll(async () => (await course.withinContent().boundingBox())?.y ?? -Infinity)
+    .poll(
+      async () => (await course.withinContent().boundingBox())?.y ?? -Infinity
+    )
     .toBeGreaterThanOrEqual(minContentY)
 }
 
@@ -73,7 +75,8 @@ test.describe("Course v3 skip to main content link", () => {
     // this test means to set up.
     const scrollYBefore = await page.evaluate(() => {
       const target = document.getElementById("course-content-section")
-      const headerOffset = parseFloat(getComputedStyle(target).scrollMarginTop) || 0
+      const headerOffset =
+        parseFloat(getComputedStyle(target).scrollMarginTop) || 0
       const absoluteTop = target.getBoundingClientRect().top + window.scrollY
       window.scrollTo(0, absoluteTop - headerOffset - 20)
       return window.scrollY
@@ -82,9 +85,7 @@ test.describe("Course v3 skip to main content link", () => {
     // Dispatch a real click on the skip link itself, exercising its actual
     // handler, without Tab/mouse actionability scrolling getting in the way.
     await page.evaluate(() => {
-      document
-        .querySelector<HTMLElement>(".skip-to-main-content")
-        ?.click()
+      document.querySelector<HTMLElement>(".skip-to-main-content")?.click()
     })
 
     await expect(course.withinContent()).toBeFocused()

--- a/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
@@ -29,6 +29,18 @@ async function assertSkipLinkWorks(page: Page, course: CoursePage) {
 
   await page.keyboard.press("Enter")
   await expect(course.withinContent()).toBeFocused()
+
+  // The MIT Learn header is position: fixed, so scrolling the content flush
+  // to the viewport top would tuck it behind the header. scroll-margin-top
+  // on #course-content-section should keep it clear. Poll rather than
+  // reading a single snapshot, since the focus-triggered scroll settles
+  // asynchronously (observed to lag behind the focus change in Firefox).
+  const headerBox = await page.locator("#mit-learn-header").boundingBox()
+  expect(headerBox).not.toBeNull()
+  const minContentY = headerBox!.y + headerBox!.height - 1
+  await expect
+    .poll(async () => (await course.withinContent().boundingBox())?.y ?? -Infinity)
+    .toBeGreaterThanOrEqual(minContentY)
 }
 
 test.describe("Course v3 skip to main content link", () => {

--- a/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test"
+import { CoursePage } from "../util"
+
+test.describe("Course v3 skip to main content link", () => {
+  test("is the first focusable element and moves focus to main content when activated", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto("/resources/file_pdf")
+
+    const skipLink = page.locator("a.skip-to-main-content")
+    await expect(skipLink).toHaveAttribute("href", "#course-content-section")
+    await expect(skipLink).toHaveText("Skip to main content")
+
+    await page.keyboard.press("Tab")
+    await expect(skipLink).toBeFocused()
+
+    await page.keyboard.press("Enter")
+    await expect(course.withinContent()).toBeFocused()
+  })
+})

--- a/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
@@ -17,13 +17,15 @@ async function assertSkipLinkWorks(page: Page, course: CoursePage) {
   // which only checks for a non-empty box + visibility != hidden and
   // would report this element as "visible" either way.
   const hiddenBox = await skipLink.boundingBox()
-  expect(hiddenBox?.width).toBeLessThanOrEqual(1)
-  expect(hiddenBox?.height).toBeLessThanOrEqual(1)
+  expect(hiddenBox).not.toBeNull()
+  expect(hiddenBox!.width).toBeLessThanOrEqual(1)
+  expect(hiddenBox!.height).toBeLessThanOrEqual(1)
 
   await page.keyboard.press("Tab")
   await expect(skipLink).toBeFocused()
   const focusedBox = await skipLink.boundingBox()
-  expect(focusedBox?.width).toBeGreaterThan(10)
+  expect(focusedBox).not.toBeNull()
+  expect(focusedBox!.width).toBeGreaterThan(10)
 
   await page.keyboard.press("Enter")
   await expect(course.withinContent()).toBeFocused()

--- a/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/skip-link-v3.spec.ts
@@ -11,11 +11,20 @@ test.describe("Course v3 skip to main content link", () => {
     const skipLink = page.locator("a.skip-to-main-content")
     await expect(skipLink).toHaveAttribute("href", "#course-content-section")
     await expect(skipLink).toHaveText("Skip to main content")
-    await expect(skipLink).not.toBeVisible()
+
+    // Bootstrap's .sr-only hides content with a clipped 1x1px box (not
+    // display:none), so it stays in the accessibility tree for screen
+    // readers. Assert on the box size directly rather than toBeVisible(),
+    // which only checks for a non-empty box + visibility != hidden and
+    // would report this element as "visible" either way.
+    const hiddenBox = await skipLink.boundingBox()
+    expect(hiddenBox?.width).toBeLessThanOrEqual(1)
+    expect(hiddenBox?.height).toBeLessThanOrEqual(1)
 
     await page.keyboard.press("Tab")
-    await expect(skipLink).toBeVisible()
     await expect(skipLink).toBeFocused()
+    const focusedBox = await skipLink.boundingBox()
+    expect(focusedBox?.width).toBeGreaterThan(10)
 
     await page.keyboard.press("Enter")
     await expect(course.withinContent()).toBeFocused()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12270

### Description (What does it do?)
Fixes the four `course-v3` findings from the MIT Learn accessibility review that are actionable in this repo:

- **Missing "Skip to Main" link/focus doesn't move to main content** — added a "Skip to main content" link (Bootstrap's `.sr-only`/`.sr-only-focusable` pattern) as the first focusable element on `course-v3/layouts/_default/baseof.html` and the standalone `course-v3/layouts/home.html`, targeting a `tabindex="-1"` main content landmark on each.
- **Focus does not stay on open/close button (right side Course Info menu)** — the desktop Course Info drawer's close button now returns focus to its toggle button on close (`hidden.bs.collapse` handler in `baseof.html`), and its `aria-label` now correctly says "Close Course Info" instead of just "Course Info".
- **Bookmark button has no name** — `BookmarkButton` (`base-theme/assets/js/components/BookmarkButton.tsx`) now has a descriptive `aria-label` ("Add/Remove {title} to/from your list"), instead of announcing as an unlabeled button.
- **Similar accessible names for different actions (course download page)** — the resource title link on the download/resource-list page now has a distinguishing `aria-label` ("View {title} details") so it no longer reads confusingly similar to the adjacent "Download {title}" link.

### Netlify
[Course v2](https://ocw-hugo-themes-course-v2-pr-1831--ocw-next.netlify.app/)
[Course v3](https://ocw-hugo-themes-course-v3-pr-1831--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/)

### How can this be tested?

All of the below apply to **course-v3 only** (not course-v2).

#### 1. Skip to main content link
1. Start a course-v3 dev server (`yarn start course`) or use the Netlify preview above.
2. Load any course page (e.g. a resource page, or the course home page).
3. Press `Tab` once right after the page loads — the very first thing focused should be a "Skip to main content" link. It's invisible until focused (Bootstrap's screen-reader-only pattern), so you should see it appear on focus.
4. Press `Enter` — focus should jump straight to the main content area (past the left nav), both on regular content pages and on the course home page.
5. With a screen reader (VoiceOver/NVDA), confirm the link is announced as the very first item in the page's reading order.

#### 2. Course Info drawer focus return (desktop viewport only)
1. On a desktop-width browser window, open any course page.
2. If the right-side "Course Info" panel isn't already open, click its toggle button to open it.
3. With a screen reader, focus the panel's close "×" button and confirm it announces "Close Course Info" (not just "Course Info").
4. Click/activate the close button.
5. Confirm keyboard focus lands back on the toggle button immediately (you should not need to `Shift+Tab` to find it).

#### 3. Bookmark button accessible name
Note: this button renders only for authenticated users with the MIT Learn integration enabled (`FEATURE_ENABLE_LEARN_INTEGRATION`), so it may not be testable in every preview environment.
1. With that feature enabled and logged in, load a course page with the bookmark icon visible.
2. Tab to (or screen-reader-navigate to) the bookmark button.
3. Confirm it announces something like "Add {resource title} to your list" (not just "button").
4. If the resource is already saved to a list, confirm it announces "Remove {resource title} from your list" instead.

#### 4. Download page link naming
1. Navigate to a course's `/download` page.
2. For any resource row with a download icon, tab through (or screen-reader-navigate) the thumbnail link and the title link right after it.
3. Confirm the thumbnail link announces "Download {title}" and the title link announces "View {title} details" — two clearly distinct actions instead of near-duplicate names.