### PR TITLE
fix: level search links in v3

### DIFF
--- a/course-v3/data/search_query_keys.json
+++ b/course-v3/data/search_query_keys.json
@@ -1,6 +1,6 @@
 {
   "instructors": "q",
   "department_numbers": "department",
-  "level": "l",
+  "level": "level",
   "topic": "t"
 }

--- a/course-v3/layouts/partials/course_info.html
+++ b/course-v3/layouts/partials/course_info.html
@@ -76,12 +76,15 @@ $isDesktopCourseDrawer := .isDesktopCourseDrawer | default false }}
             Level
           </h3>
           <div class="{{ if $inPanel }}panel-course-info-text{{ end }}">
+            {{ $levelValueMap := dict "Undergraduate" "undergraduate" "Graduate" "graduate" "Non-Credit" "noncredit" "High School" "high_school" }}
             {{ if eq (printf "%T" $courseData.level) "string" }} {{
-            $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $courseData.level) }}
+            $levelValue := index $levelValueMap $courseData.level | default $courseData.level }} {{
+            $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $levelValue) }}
             {{- partial "link.html" (dict "href" $levelSearchUrl "text" $courseData.level "stripLinkOffline" true) -}}
             {{ else }}
             {{ range $courseData.level }}
-            {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" .) }}
+            {{ $levelValue := index $levelValueMap . | default . }}
+            {{ $levelSearchUrl := partial "get_search_url.html" (dict "key" "level" "value" $levelValue) }}
             {{- partial "link.html" (dict "href" $levelSearchUrl "text" . "stripLinkOffline" true) -}}<br />
             {{ end }}
             {{ end }}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12334

### Description (What does it do?)
Fixes the level search query params for v3


### Screenshots (if appropriate):
See netlify [build](https://ocw-hugo-themes-course-v3-pr-1835--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/)

### How can this be tested?
1. Build a course with v2 theme.
2. Verify that the levels in the side drawer link to search with **`?l=<level_name>`** params
3. Build a course with v3 theme.
4. Verify that the levels in the side drawer link to search with **`?level=<level_code>`** params


