### PR TITLE
Add department 21T (Theater Arts)

### DIFF
--- a/base-theme/data/departments.json
+++ b/base-theme/data/departments.json
@@ -59,6 +59,10 @@
     "title": "Music and Theater Arts",
     "id": "music-and-theater-arts"
   },
+  "21T": {
+    "title": "Theater Arts",
+    "id": "theater-arts"
+  },
   "PE": {
     "title": "Athletics, Physical Education and Recreation",
     "id": "athletics-physical-education-and-recreation"


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5616

### Description (What does it do?)
Adds the `21T` department mapping to `base-theme/data/departments.json`:

- title: `Theater Arts`
- id: `theater-arts`

Without this entry, published OCW pages and OCW search cannot resolve a name/slug for courses in the new department.

### How can this be tested?
Build a site whose course metadata includes `21T` in `department_numbers`. The rendered department name shows **Theater Arts** (linked via the `theater-arts` slug) instead of a blank/unknown department.
