### PR TITLE
Rename Music and Theater Arts department to Music (+ facet aliasing)

### DIFF
--- a/base-theme/data/departments.json
+++ b/base-theme/data/departments.json
@@ -56,8 +56,8 @@
     "id": "earth-atmospheric-and-planetary-sciences"
   },
   "21M": {
-    "title": "Music and Theater Arts",
-    "id": "music-and-theater-arts"
+    "title": "Music",
+    "id": "music"
   },
   "PE": {
     "title": "Athletics, Physical Education and Recreation",

--- a/www/assets/js/components/SearchPage.test.tsx
+++ b/www/assets/js/components/SearchPage.test.tsx
@@ -349,6 +349,52 @@ describe("SearchPage component", () => {
     expect(searchResults.length).toBe(DEFAULT_UI_PAGE_SIZE)
   })
 
+  test("expands aliased department facets in the search query", async () => {
+    const searchString = serializeSearchParams({
+      activeFacets: { department_name: ["Music"] }
+    })
+    renderComponent(searchString)
+    await resolveSearch()
+
+    expect(spySearch.mock.calls[0][0].activeFacets?.department_name).toEqual([
+      "Music",
+      "Music and Theater Arts"
+    ])
+  })
+
+  test("merges aliased department buckets into a single facet count", async () => {
+    renderComponent()
+    await resolveSearch({
+      aggregations: {
+        department_name: {
+          buckets: [
+            { key: "Mathematics", doc_count: 10 },
+            { key: "Music", doc_count: 5 },
+            { key: "Music and Theater Arts", doc_count: 3 }
+          ]
+        }
+      }
+    })
+
+    const departmentFacet = screen
+      .getByText("Departments")
+      .closest(".facets") as HTMLElement
+    expect(departmentFacet).toBeInTheDocument()
+
+    // the alias itself should not be shown
+    expect(
+      within(departmentFacet).queryByText("Music and Theater Arts")
+    ).toBeNull()
+
+    // the canonical department should show the combined count (5 + 3)
+    const canonicalItem = within(departmentFacet)
+      .getByText("Music")
+      .closest(".facet-visible") as HTMLElement
+    expect(
+      within(canonicalItem).getByText("8", { selector: ".facet-count" })
+    ).toBeInTheDocument()
+  })
+
   test("should render filterable facets", async () => {
     renderComponent()
     await resolveSearch()

--- a/www/assets/js/components/SearchPage.tsx
+++ b/www/assets/js/components/SearchPage.tsx
@@ -17,6 +17,7 @@ import Loading, { Spinner } from "./Loading"
 
 import { search } from "../lib/api"
 import { searchResultToLearningResource } from "../lib/search"
+import { expandFacetAliases, mergeAliasedAggregations } from "../lib/facets"
 import {
   COURSENUM_SORT_FIELD,
   CONTACT_URL,
@@ -86,7 +87,7 @@ export default function SearchPage(props: SearchPageProps) {
       const newResults = await search({
         text,
         from,
-        activeFacets,
+        activeFacets: expandFacetAliases(activeFacets),
         size:         pageSize,
         sort:         sort,
         aggregations: allowedAggregations
@@ -119,7 +120,11 @@ export default function SearchPage(props: SearchPageProps) {
         setSuggestions([])
       }
 
-      setAggregations(new Map(Object.entries(newResults.aggregations ?? {})))
+      setAggregations(
+        new Map(
+          Object.entries(mergeAliasedAggregations(newResults.aggregations))
+        )
+      )
 
       setSearchResults(results =>
         from === 0 ?

--- a/www/assets/js/lib/constants.ts
+++ b/www/assets/js/lib/constants.ts
@@ -477,4 +477,23 @@ export const FACET_OPTIONS: Facets = {
   resource_type:       RESOURCE_TYPES
 }
 
+/**
+ * Some facet values are returned by the search API but are not modeled as their
+ * own option in OCW. Each entry folds such an "alias" value into a canonical
+ * value: the alias's aggregation count is merged into the canonical bucket (so
+ * only the canonical value is shown in the UI), and selecting the canonical
+ * facet also filters the search by the alias value.
+ *
+ * Keyed by facet group, then alias value -> canonical value. For example,
+ * "Music and Theater Arts" is returned by the API but folded into the "Music"
+ * department.
+ */
+export const FACET_ALIASES: Partial<
+  Record<keyof Facets, Record<string, string>>
+> = {
+  department_name: {
+    "Music and Theater Arts": "Music"
+  }
+}
+
 export const STATIC_THUMBNAIL_PATH_PREFIX = "/static_shared/images"

--- a/www/assets/js/lib/facets.test.ts
+++ b/www/assets/js/lib/facets.test.ts
@@ -1,0 +1,162 @@
+// import { Aggregation, Facets } from "@mitodl/course-search-utils"
+
+// import { expandFacetAliases, mergeAliasedAggregations } from "./facets"
+
+// describe("expandFacetAliases", () => {
+//   it("adds the alias value when the canonical value is selected", () => {
+//     const activeFacets: Facets = {
+//       department_name: ["Music and Theater Arts"]
+//     }
+
+//     const result = expandFacetAliases(activeFacets)
+
+//     expect(result.department_name).toEqual([
+//       "Music and Theater Arts",
+//       "Theatrics"
+//     ])
+//   })
+
+//   it("preserves other selected values and other facet groups", () => {
+//     const activeFacets: Facets = {
+//       department_name: ["Mathematics", "Music and Theater Arts"],
+//       topics:          ["Calculus"]
+//     }
+
+//     const result = expandFacetAliases(activeFacets)
+
+//     expect(result.department_name).toEqual([
+//       "Mathematics",
+//       "Music and Theater Arts",
+//       "Theatrics"
+//     ])
+//     expect(result.topics).toEqual(["Calculus"])
+//   })
+
+//   it("does not add the alias when the canonical value is not selected", () => {
+//     const activeFacets: Facets = {
+//       department_name: ["Mathematics"]
+//     }
+
+//     const result = expandFacetAliases(activeFacets)
+
+//     expect(result.department_name).toEqual(["Mathematics"])
+//   })
+
+//   it("does not duplicate the alias if it is already present", () => {
+//     const activeFacets: Facets = {
+//       department_name: ["Music and Theater Arts", "Theatrics"]
+//     }
+
+//     const result = expandFacetAliases(activeFacets)
+
+//     expect(result.department_name).toEqual([
+//       "Music and Theater Arts",
+//       "Theatrics"
+//     ])
+//   })
+
+//   it("does not mutate the input", () => {
+//     const activeFacets: Facets = {
+//       department_name: ["Music and Theater Arts"]
+//     }
+
+//     expandFacetAliases(activeFacets)
+
+//     expect(activeFacets.department_name).toEqual(["Music and Theater Arts"])
+//   })
+// })
+
+// describe("mergeAliasedAggregations", () => {
+//   it("merges the alias bucket count into the canonical bucket and drops the alias", () => {
+//     const aggregations: Record<string, Aggregation> = {
+//       department_name: {
+//         buckets: [
+//           { key: "Mathematics", doc_count: 10 },
+//           { key: "Music and Theater Arts", doc_count: 5 },
+//           { key: "Theatrics", doc_count: 3 }
+//         ]
+//       }
+//     }
+
+//     const result = mergeAliasedAggregations(aggregations)
+
+//     expect(result.department_name.buckets).toEqual([
+//       { key: "Mathematics", doc_count: 10 },
+//       { key: "Music and Theater Arts", doc_count: 8 }
+//     ])
+//   })
+
+//   it("creates the canonical bucket from the alias when only the alias is present", () => {
+//     const aggregations: Record<string, Aggregation> = {
+//       department_name: {
+//         buckets: [
+//           { key: "Mathematics", doc_count: 10 },
+//           { key: "Theatrics", doc_count: 3 }
+//         ]
+//       }
+//     }
+
+//     const result = mergeAliasedAggregations(aggregations)
+
+//     expect(result.department_name.buckets).toEqual([
+//       { key: "Mathematics", doc_count: 10 },
+//       { key: "Music and Theater Arts", doc_count: 3 }
+//     ])
+//   })
+
+//   it("re-sorts buckets by descending count after merging", () => {
+//     const aggregations: Record<string, Aggregation> = {
+//       department_name: {
+//         buckets: [
+//           { key: "Music and Theater Arts", doc_count: 5 },
+//           { key: "Mathematics", doc_count: 10 },
+//           { key: "Theatrics", doc_count: 8 }
+//         ]
+//       }
+//     }
+
+//     const result = mergeAliasedAggregations(aggregations)
+
+//     expect(result.department_name.buckets).toEqual([
+//       { key: "Music and Theater Arts", doc_count: 13 },
+//       { key: "Mathematics", doc_count: 10 }
+//     ])
+//   })
+
+//   it("leaves the group untouched when no alias bucket is present", () => {
+//     const aggregations: Record<string, Aggregation> = {
+//       department_name: {
+//         buckets: [{ key: "Mathematics", doc_count: 10 }]
+//       }
+//     }
+
+//     const result = mergeAliasedAggregations(aggregations)
+
+//     expect(result.department_name.buckets).toEqual([
+//       { key: "Mathematics", doc_count: 10 }
+//     ])
+//   })
+
+//   it("does not mutate the input aggregations or buckets", () => {
+//     const aggregations: Record<string, Aggregation> = {
+//       department_name: {
+//         buckets: [
+//           { key: "Music and Theater Arts", doc_count: 5 },
+//           { key: "Theatrics", doc_count: 3 }
+//         ]
+//       }
+//     }
+
+//     mergeAliasedAggregations(aggregations)
+
+//     expect(aggregations.department_name.buckets).toEqual([
+//       { key: "Music and Theater Arts", doc_count: 5 },
+//       { key: "Theatrics", doc_count: 3 }
+//     ])
+//   })
+
+//   it("returns an empty object for null/undefined input", () => {
+//     expect(mergeAliasedAggregations(null)).toEqual({})
+//     expect(mergeAliasedAggregations(undefined)).toEqual({})
+//   })
+// })

--- a/www/assets/js/lib/facets.test.ts
+++ b/www/assets/js/lib/facets.test.ts
@@ -1,162 +1,156 @@
-// import { Aggregation, Facets } from "@mitodl/course-search-utils"
+import { Aggregation, Facets } from "@mitodl/course-search-utils"
 
-// import { expandFacetAliases, mergeAliasedAggregations } from "./facets"
+import { expandFacetAliases, mergeAliasedAggregations } from "./facets"
 
-// describe("expandFacetAliases", () => {
-//   it("adds the alias value when the canonical value is selected", () => {
-//     const activeFacets: Facets = {
-//       department_name: ["Music and Theater Arts"]
-//     }
+describe("expandFacetAliases", () => {
+  it("adds the alias value when the canonical value is selected", () => {
+    const activeFacets: Facets = {
+      department_name: ["Music"]
+    }
 
-//     const result = expandFacetAliases(activeFacets)
+    const result = expandFacetAliases(activeFacets)
 
-//     expect(result.department_name).toEqual([
-//       "Music and Theater Arts",
-//       "Theatrics"
-//     ])
-//   })
+    expect(result.department_name).toEqual(["Music", "Music and Theater Arts"])
+  })
 
-//   it("preserves other selected values and other facet groups", () => {
-//     const activeFacets: Facets = {
-//       department_name: ["Mathematics", "Music and Theater Arts"],
-//       topics:          ["Calculus"]
-//     }
+  it("preserves other selected values and other facet groups", () => {
+    const activeFacets: Facets = {
+      department_name: ["Mathematics", "Music"],
+      topics:          ["Calculus"]
+    }
 
-//     const result = expandFacetAliases(activeFacets)
+    const result = expandFacetAliases(activeFacets)
 
-//     expect(result.department_name).toEqual([
-//       "Mathematics",
-//       "Music and Theater Arts",
-//       "Theatrics"
-//     ])
-//     expect(result.topics).toEqual(["Calculus"])
-//   })
+    expect(result.department_name).toEqual([
+      "Mathematics",
+      "Music",
+      "Music and Theater Arts"
+    ])
+    expect(result.topics).toEqual(["Calculus"])
+  })
 
-//   it("does not add the alias when the canonical value is not selected", () => {
-//     const activeFacets: Facets = {
-//       department_name: ["Mathematics"]
-//     }
+  it("does not add the alias when the canonical value is not selected", () => {
+    const activeFacets: Facets = {
+      department_name: ["Mathematics"]
+    }
 
-//     const result = expandFacetAliases(activeFacets)
+    const result = expandFacetAliases(activeFacets)
 
-//     expect(result.department_name).toEqual(["Mathematics"])
-//   })
+    expect(result.department_name).toEqual(["Mathematics"])
+  })
 
-//   it("does not duplicate the alias if it is already present", () => {
-//     const activeFacets: Facets = {
-//       department_name: ["Music and Theater Arts", "Theatrics"]
-//     }
+  it("does not duplicate the alias if it is already present", () => {
+    const activeFacets: Facets = {
+      department_name: ["Music", "Music and Theater Arts"]
+    }
 
-//     const result = expandFacetAliases(activeFacets)
+    const result = expandFacetAliases(activeFacets)
 
-//     expect(result.department_name).toEqual([
-//       "Music and Theater Arts",
-//       "Theatrics"
-//     ])
-//   })
+    expect(result.department_name).toEqual(["Music", "Music and Theater Arts"])
+  })
 
-//   it("does not mutate the input", () => {
-//     const activeFacets: Facets = {
-//       department_name: ["Music and Theater Arts"]
-//     }
+  it("does not mutate the input", () => {
+    const activeFacets: Facets = {
+      department_name: ["Music"]
+    }
 
-//     expandFacetAliases(activeFacets)
+    expandFacetAliases(activeFacets)
 
-//     expect(activeFacets.department_name).toEqual(["Music and Theater Arts"])
-//   })
-// })
+    expect(activeFacets.department_name).toEqual(["Music"])
+  })
+})
 
-// describe("mergeAliasedAggregations", () => {
-//   it("merges the alias bucket count into the canonical bucket and drops the alias", () => {
-//     const aggregations: Record<string, Aggregation> = {
-//       department_name: {
-//         buckets: [
-//           { key: "Mathematics", doc_count: 10 },
-//           { key: "Music and Theater Arts", doc_count: 5 },
-//           { key: "Theatrics", doc_count: 3 }
-//         ]
-//       }
-//     }
+describe("mergeAliasedAggregations", () => {
+  it("merges the alias bucket count into the canonical bucket and drops the alias", () => {
+    const aggregations: Record<string, Aggregation> = {
+      department_name: {
+        buckets: [
+          { key: "Mathematics", doc_count: 10 },
+          { key: "Music", doc_count: 5 },
+          { key: "Music and Theater Arts", doc_count: 3 }
+        ]
+      }
+    }
 
-//     const result = mergeAliasedAggregations(aggregations)
+    const result = mergeAliasedAggregations(aggregations)
 
-//     expect(result.department_name.buckets).toEqual([
-//       { key: "Mathematics", doc_count: 10 },
-//       { key: "Music and Theater Arts", doc_count: 8 }
-//     ])
-//   })
+    expect(result.department_name.buckets).toEqual([
+      { key: "Mathematics", doc_count: 10 },
+      { key: "Music", doc_count: 8 }
+    ])
+  })
 
-//   it("creates the canonical bucket from the alias when only the alias is present", () => {
-//     const aggregations: Record<string, Aggregation> = {
-//       department_name: {
-//         buckets: [
-//           { key: "Mathematics", doc_count: 10 },
-//           { key: "Theatrics", doc_count: 3 }
-//         ]
-//       }
-//     }
+  it("creates the canonical bucket from the alias when only the alias is present", () => {
+    const aggregations: Record<string, Aggregation> = {
+      department_name: {
+        buckets: [
+          { key: "Mathematics", doc_count: 10 },
+          { key: "Music and Theater Arts", doc_count: 3 }
+        ]
+      }
+    }
 
-//     const result = mergeAliasedAggregations(aggregations)
+    const result = mergeAliasedAggregations(aggregations)
 
-//     expect(result.department_name.buckets).toEqual([
-//       { key: "Mathematics", doc_count: 10 },
-//       { key: "Music and Theater Arts", doc_count: 3 }
-//     ])
-//   })
+    expect(result.department_name.buckets).toEqual([
+      { key: "Mathematics", doc_count: 10 },
+      { key: "Music", doc_count: 3 }
+    ])
+  })
 
-//   it("re-sorts buckets by descending count after merging", () => {
-//     const aggregations: Record<string, Aggregation> = {
-//       department_name: {
-//         buckets: [
-//           { key: "Music and Theater Arts", doc_count: 5 },
-//           { key: "Mathematics", doc_count: 10 },
-//           { key: "Theatrics", doc_count: 8 }
-//         ]
-//       }
-//     }
+  it("re-sorts buckets by descending count after merging", () => {
+    const aggregations: Record<string, Aggregation> = {
+      department_name: {
+        buckets: [
+          { key: "Music", doc_count: 5 },
+          { key: "Mathematics", doc_count: 10 },
+          { key: "Music and Theater Arts", doc_count: 8 }
+        ]
+      }
+    }
 
-//     const result = mergeAliasedAggregations(aggregations)
+    const result = mergeAliasedAggregations(aggregations)
 
-//     expect(result.department_name.buckets).toEqual([
-//       { key: "Music and Theater Arts", doc_count: 13 },
-//       { key: "Mathematics", doc_count: 10 }
-//     ])
-//   })
+    expect(result.department_name.buckets).toEqual([
+      { key: "Music", doc_count: 13 },
+      { key: "Mathematics", doc_count: 10 }
+    ])
+  })
 
-//   it("leaves the group untouched when no alias bucket is present", () => {
-//     const aggregations: Record<string, Aggregation> = {
-//       department_name: {
-//         buckets: [{ key: "Mathematics", doc_count: 10 }]
-//       }
-//     }
+  it("leaves the group untouched when no alias bucket is present", () => {
+    const aggregations: Record<string, Aggregation> = {
+      department_name: {
+        buckets: [{ key: "Mathematics", doc_count: 10 }]
+      }
+    }
 
-//     const result = mergeAliasedAggregations(aggregations)
+    const result = mergeAliasedAggregations(aggregations)
 
-//     expect(result.department_name.buckets).toEqual([
-//       { key: "Mathematics", doc_count: 10 }
-//     ])
-//   })
+    expect(result.department_name.buckets).toEqual([
+      { key: "Mathematics", doc_count: 10 }
+    ])
+  })
 
-//   it("does not mutate the input aggregations or buckets", () => {
-//     const aggregations: Record<string, Aggregation> = {
-//       department_name: {
-//         buckets: [
-//           { key: "Music and Theater Arts", doc_count: 5 },
-//           { key: "Theatrics", doc_count: 3 }
-//         ]
-//       }
-//     }
+  it("does not mutate the input aggregations or buckets", () => {
+    const aggregations: Record<string, Aggregation> = {
+      department_name: {
+        buckets: [
+          { key: "Music", doc_count: 5 },
+          { key: "Music and Theater Arts", doc_count: 3 }
+        ]
+      }
+    }
 
-//     mergeAliasedAggregations(aggregations)
+    mergeAliasedAggregations(aggregations)
 
-//     expect(aggregations.department_name.buckets).toEqual([
-//       { key: "Music and Theater Arts", doc_count: 5 },
-//       { key: "Theatrics", doc_count: 3 }
-//     ])
-//   })
+    expect(aggregations.department_name.buckets).toEqual([
+      { key: "Music", doc_count: 5 },
+      { key: "Music and Theater Arts", doc_count: 3 }
+    ])
+  })
 
-//   it("returns an empty object for null/undefined input", () => {
-//     expect(mergeAliasedAggregations(null)).toEqual({})
-//     expect(mergeAliasedAggregations(undefined)).toEqual({})
-//   })
-// })
+  it("returns an empty object for null/undefined input", () => {
+    expect(mergeAliasedAggregations(null)).toEqual({})
+    expect(mergeAliasedAggregations(undefined)).toEqual({})
+  })
+})

--- a/www/assets/js/lib/facets.ts
+++ b/www/assets/js/lib/facets.ts
@@ -1,107 +1,107 @@
-// import { Aggregation, Facets } from "@mitodl/course-search-utils"
+import { Aggregation, Facets } from "@mitodl/course-search-utils"
 
-// import { FACET_ALIASES } from "./constants"
+import { FACET_ALIASES } from "./constants"
 
-// /**
-//  * Returns a copy of `activeFacets` in which, for every configured facet group,
-//  * any selected canonical value also includes its alias value(s).
-//  *
-//  * This lets a search filter by both the canonical value and the alias term(s)
-//  * that the search API still returns for it. For example, selecting the "Music
-//  * and Theater Arts" department also filters by "Theatrics".
-//  *
-//  * The returned object is a shallow copy; the input is not mutated.
-//  */
-// export function expandFacetAliases(activeFacets: Facets): Facets {
-//   const expanded: Facets = { ...activeFacets }
+/**
+ * Returns a copy of `activeFacets` in which, for every configured facet group,
+ * any selected canonical value also includes its alias value(s).
+ *
+ * This lets a search filter by both the canonical value and the alias term(s)
+ * that the search API still returns for it. For example, selecting the "Music"
+ * department also filters by "Music and Theater Arts".
+ *
+ * The returned object is a shallow copy; the input is not mutated.
+ */
+export function expandFacetAliases(activeFacets: Facets): Facets {
+  const expanded: Facets = { ...activeFacets }
 
-//   for (const [group, aliases] of Object.entries(FACET_ALIASES)) {
-//     if (!aliases) {
-//       continue
-//     }
-//     const key = group as keyof Facets
-//     const selected = expanded[key]
-//     if (!selected || selected.length === 0) {
-//       continue
-//     }
+  for (const [group, aliases] of Object.entries(FACET_ALIASES)) {
+    if (!aliases) {
+      continue
+    }
+    const key = group as keyof Facets
+    const selected = expanded[key]
+    if (!selected || selected.length === 0) {
+      continue
+    }
 
-//     const values = new Set(selected)
-//     for (const [alias, canonical] of Object.entries(aliases)) {
-//       if (values.has(canonical)) {
-//         values.add(alias)
-//       }
-//     }
-//     expanded[key] = Array.from(values)
-//   }
+    const values = new Set(selected)
+    for (const [alias, canonical] of Object.entries(aliases)) {
+      if (values.has(canonical)) {
+        values.add(alias)
+      }
+    }
+    expanded[key] = Array.from(values)
+  }
 
-//   return expanded
-// }
+  return expanded
+}
 
-// /**
-//  * Returns a copy of the raw search API `aggregations` object in which, for every
-//  * configured facet group, each alias bucket is merged into its canonical bucket:
-//  * the doc counts are summed, the alias bucket is dropped, and the group's buckets
-//  * are re-sorted by count.
-//  *
-//  * This shows a single canonical facet with a combined count. For example, the
-//  * "Theatrics" bucket is folded into the "Music and Theater Arts" department. If
-//  * a canonical bucket is not present but its alias is, the canonical bucket is
-//  * created from the alias so the canonical value is still shown.
-//  *
-//  * The returned object is a copy; neither the input object nor its buckets are
-//  * mutated.
-//  */
-// export function mergeAliasedAggregations(
-//   aggregations: Record<string, Aggregation> | null | undefined
-// ): Record<string, Aggregation> {
-//   if (!aggregations) {
-//     return {}
-//   }
+/**
+ * Returns a copy of the raw search API `aggregations` object in which, for every
+ * configured facet group, each alias bucket is merged into its canonical bucket:
+ * the doc counts are summed, the alias bucket is dropped, and the group's buckets
+ * are re-sorted by count.
+ *
+ * This shows a single canonical facet with a combined count. For example, the
+ * "Music and Theater Arts" bucket is folded into the "Music" department. If
+ * a canonical bucket is not present but its alias is, the canonical bucket is
+ * created from the alias so the canonical value is still shown.
+ *
+ * The returned object is a copy; neither the input object nor its buckets are
+ * mutated.
+ */
+export function mergeAliasedAggregations(
+  aggregations: Record<string, Aggregation> | null | undefined
+): Record<string, Aggregation> {
+  if (!aggregations) {
+    return {}
+  }
 
-//   const merged: Record<string, Aggregation> = { ...aggregations }
+  const merged: Record<string, Aggregation> = { ...aggregations }
 
-//   for (const [group, aliases] of Object.entries(FACET_ALIASES)) {
-//     if (!aliases) {
-//       continue
-//     }
-//     const aggregation = merged[group]
-//     if (!aggregation || !aggregation.buckets) {
-//       continue
-//     }
+  for (const [group, aliases] of Object.entries(FACET_ALIASES)) {
+    if (!aliases) {
+      continue
+    }
+    const aggregation = merged[group]
+    if (!aggregation || !aggregation.buckets) {
+      continue
+    }
 
-//     // clone buckets so we never mutate the API response objects
-//     const bucketsByKey = new Map(
-//       aggregation.buckets.map(bucket => [bucket.key, { ...bucket }])
-//     )
+    // clone buckets so we never mutate the API response objects
+    const bucketsByKey = new Map(
+      aggregation.buckets.map(bucket => [bucket.key, { ...bucket }])
+    )
 
-//     let changed = false
-//     for (const [alias, canonical] of Object.entries(aliases)) {
-//       const aliasBucket = bucketsByKey.get(alias)
-//       if (!aliasBucket) {
-//         continue
-//       }
-//       const canonicalBucket = bucketsByKey.get(canonical)
-//       if (canonicalBucket) {
-//         canonicalBucket.doc_count += aliasBucket.doc_count
-//       } else {
-//         bucketsByKey.set(canonical, {
-//           key:       canonical,
-//           doc_count: aliasBucket.doc_count
-//         })
-//       }
-//       bucketsByKey.delete(alias)
-//       changed = true
-//     }
+    let changed = false
+    for (const [alias, canonical] of Object.entries(aliases)) {
+      const aliasBucket = bucketsByKey.get(alias)
+      if (!aliasBucket) {
+        continue
+      }
+      const canonicalBucket = bucketsByKey.get(canonical)
+      if (canonicalBucket) {
+        canonicalBucket.doc_count += aliasBucket.doc_count
+      } else {
+        bucketsByKey.set(canonical, {
+          key:       canonical,
+          doc_count: aliasBucket.doc_count
+        })
+      }
+      bucketsByKey.delete(alias)
+      changed = true
+    }
 
-//     if (changed) {
-//       merged[group] = {
-//         ...aggregation,
-//         buckets: Array.from(bucketsByKey.values()).sort(
-//           (a, b) => b.doc_count - a.doc_count
-//         )
-//       }
-//     }
-//   }
+    if (changed) {
+      merged[group] = {
+        ...aggregation,
+        buckets: Array.from(bucketsByKey.values()).sort(
+          (a, b) => b.doc_count - a.doc_count
+        )
+      }
+    }
+  }
 
-//   return merged
-// }
+  return merged
+}

--- a/www/assets/js/lib/facets.ts
+++ b/www/assets/js/lib/facets.ts
@@ -1,0 +1,107 @@
+// import { Aggregation, Facets } from "@mitodl/course-search-utils"
+
+// import { FACET_ALIASES } from "./constants"
+
+// /**
+//  * Returns a copy of `activeFacets` in which, for every configured facet group,
+//  * any selected canonical value also includes its alias value(s).
+//  *
+//  * This lets a search filter by both the canonical value and the alias term(s)
+//  * that the search API still returns for it. For example, selecting the "Music
+//  * and Theater Arts" department also filters by "Theatrics".
+//  *
+//  * The returned object is a shallow copy; the input is not mutated.
+//  */
+// export function expandFacetAliases(activeFacets: Facets): Facets {
+//   const expanded: Facets = { ...activeFacets }
+
+//   for (const [group, aliases] of Object.entries(FACET_ALIASES)) {
+//     if (!aliases) {
+//       continue
+//     }
+//     const key = group as keyof Facets
+//     const selected = expanded[key]
+//     if (!selected || selected.length === 0) {
+//       continue
+//     }
+
+//     const values = new Set(selected)
+//     for (const [alias, canonical] of Object.entries(aliases)) {
+//       if (values.has(canonical)) {
+//         values.add(alias)
+//       }
+//     }
+//     expanded[key] = Array.from(values)
+//   }
+
+//   return expanded
+// }
+
+// /**
+//  * Returns a copy of the raw search API `aggregations` object in which, for every
+//  * configured facet group, each alias bucket is merged into its canonical bucket:
+//  * the doc counts are summed, the alias bucket is dropped, and the group's buckets
+//  * are re-sorted by count.
+//  *
+//  * This shows a single canonical facet with a combined count. For example, the
+//  * "Theatrics" bucket is folded into the "Music and Theater Arts" department. If
+//  * a canonical bucket is not present but its alias is, the canonical bucket is
+//  * created from the alias so the canonical value is still shown.
+//  *
+//  * The returned object is a copy; neither the input object nor its buckets are
+//  * mutated.
+//  */
+// export function mergeAliasedAggregations(
+//   aggregations: Record<string, Aggregation> | null | undefined
+// ): Record<string, Aggregation> {
+//   if (!aggregations) {
+//     return {}
+//   }
+
+//   const merged: Record<string, Aggregation> = { ...aggregations }
+
+//   for (const [group, aliases] of Object.entries(FACET_ALIASES)) {
+//     if (!aliases) {
+//       continue
+//     }
+//     const aggregation = merged[group]
+//     if (!aggregation || !aggregation.buckets) {
+//       continue
+//     }
+
+//     // clone buckets so we never mutate the API response objects
+//     const bucketsByKey = new Map(
+//       aggregation.buckets.map(bucket => [bucket.key, { ...bucket }])
+//     )
+
+//     let changed = false
+//     for (const [alias, canonical] of Object.entries(aliases)) {
+//       const aliasBucket = bucketsByKey.get(alias)
+//       if (!aliasBucket) {
+//         continue
+//       }
+//       const canonicalBucket = bucketsByKey.get(canonical)
+//       if (canonicalBucket) {
+//         canonicalBucket.doc_count += aliasBucket.doc_count
+//       } else {
+//         bucketsByKey.set(canonical, {
+//           key:       canonical,
+//           doc_count: aliasBucket.doc_count
+//         })
+//       }
+//       bucketsByKey.delete(alias)
+//       changed = true
+//     }
+
+//     if (changed) {
+//       merged[group] = {
+//         ...aggregation,
+//         buckets: Array.from(bucketsByKey.values()).sort(
+//           (a, b) => b.doc_count - a.doc_count
+//         )
+//       }
+//     }
+//   }
+
+//   return merged
+// }


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5616

### Description (What does it do?)
Two related changes for renaming department 21M:

1. **Rename** `21M` from "Music and Theater Arts" to **Music** (title and id → `music`) in `base-theme/data/departments.json`.
2. **Department facet aliasing** (`www/assets/js/lib/facets.ts`, `FACET_ALIASES`, wired into `SearchPage`): while the search index is being updated, both the new `Music` and the old `Music and Theater Arts` department facet values can be returned at once. The alias folds the old bucket into the canonical `Music` bucket (combined count, single facet shown) and expands a `Music` selection to also filter by the old value. 

_The second change is temporary and will be removed once we are sure that the indexes have been completely updated on the open side_.

### How can this be tested?
- Build the homepage `yarn start www`
- Go to localhost:3000/search
- Currently, the page does not load results because of cors issues. To circumvent that, you'll have to disable security features temporarily. On a mac, you can do that with chrome `open -na "Google Chrome" --args --disable-web-security --user-data-dir="/tmp/ocw-dev-chrome" ` 
- Verify that the Music and Theater Arts facet does not show. The Music facet does show and it has ~65 results. Selecting on it works. Also verify other functionality of the search page as you feel appropriate.
