### PR TITLE
fix: set posthog cookie on site domain, not mit.edu

### DIFF
--- a/base-theme/assets/js/posthog.ts
+++ b/base-theme/assets/js/posthog.ts
@@ -21,6 +21,10 @@ export function initPostHog(): typeof posthog {
       capture_pageview:             true,
       autocapture:                  true,
       opt_out_capturing_by_default: false,
+      // Scope the posthog cookie to this site's exact domain. Posthog defaults
+      // this to true, which sets the cookie on the root domain (e.g. mit.edu),
+      // sharing it with every other site there.
+      cross_subdomain_cookie:       false,
       persistence:                  "localStorage+cookie",
       person_profiles:              "always",
       loaded:                       function() {


### PR DESCRIPTION
### What are the relevant tickets?
For
- https://github.com/mitodl/hq/issues/11158

### Description (What does it do?)
Set the posthog cookie on the site domain (`ocw.mit.edu`, or `learn.mit.edu` for
course-v3 pages) not the MIT domain.

This lands in the shared `initPostHog()` in `base-theme`, so it applies to the
`www`, `course-v2`, and `course-v3` themes. Scoping only the course themes would
leave www and course-v2 — which are served from the same origin — writing the
same cookie name at two different scopes, which is worse than either consistent
choice.

### How can this be tested?
1. With Posthog enabled locally, you should see a `ph_PROJECT_TOKEN_posthog` cookie set on the site domain exactly, not on the parent domain
    - No visible change if testing with localhost
    - Need to serve from something like ocw.odl.local:3000 via etc hosts, or trust this pr in analogy with the others


### Additional Context
Setting the cookie on the site domain loses our ability to track **anonymous**
(unauthenticated) users across sites within the same project, unless we do
special setup like pass distinct_ids via query params in URLs, but that is deemed
acceptable.

Companion PRs, same change elsewhere:
- MIT Learn: https://github.com/mitodl/mit-learn/pull/3680
- Keycloak login pages: https://github.com/mitodl/ol-keycloakify/pull/176

mitxonline and ocw-studio already do this:
- https://github.com/mitodl/mitxonline/blob/80c2a512f1e3d2a93c06bb4270ba87976cf369ef/frontend/public/src/lib/util.js#L44
- https://github.com/mitodl/ocw-studio/blob/77e76e573b0d9262189937e9830fc51582540c02/static/js/lib/util.ts#L17
