### PR TITLE
fix: hide video download button when there is nothing to download

### DIFF
--- a/base-offline/layouts/partials/video.html
+++ b/base-offline/layouts/partials/video.html
@@ -12,19 +12,13 @@
 {{ if gt (len $transcriptLinks) 0 }}
   {{ $transcriptPdfLocation = (index $transcriptLinks 0).href }}
 {{ end }}
-{{ $downloadLink := .Params.file }}
+{{ $downloadLink := partial "get_video_download_link.html" (dict "context" . "resource" .) }}
 {{ $relatedResourses := .Params.related_resources_text | default "" }}
 {{ $optionalTabTitle := .Params.optional_tab_title | default "" }}
 {{ $optionalTabContent := .Params.optional_text | default ""}}
 {{ $startTime := .Params.start_time | default "" }}
 {{ $endTime := .Params.end_time | default "" }}
 {{ $context := . }}
-
-{{ if (eq $downloadLink nil) }}
-{{ $downloadLink = .Params.video_files.archive_url }}
-{{ else }}
-{{ $downloadLink =  partial "resource_url.html" (dict "context" . "url" $downloadLink) }}
-{{ end }}
 
 <div class="video-page">
   	<div class="description">

--- a/base-theme/assets/js/video_download_popup.test.ts
+++ b/base-theme/assets/js/video_download_popup.test.ts
@@ -35,8 +35,9 @@ const render = (...sections: SectionSpec[]) => {
 
 describe("initVideoDownloadPopup", () => {
   it("opens the popup in the clicked icon's own section", () => {
-    // A tab that has a popup but no download button comes first, so pairing by
-    // document index would open the wrong popup.
+    // A tab with a popup but no download button comes first. The templates do not
+    // currently emit this order, so this guards the ordering assumption rather than
+    // reproducing a live bug: pairing by document index would open the wrong popup.
     const { icons, popups } = render(
       { icon: false, popup: true },
       { icon: true, popup: true }

--- a/base-theme/assets/js/video_download_popup.test.ts
+++ b/base-theme/assets/js/video_download_popup.test.ts
@@ -1,0 +1,93 @@
+import { initVideoDownloadPopup } from "./video_download_popup"
+
+type SectionSpec = { icon: boolean; popup: boolean }
+
+/**
+ * Mirrors the structure video_expandable_tab.html emits: one
+ * .video-tab-toggle-section per tab, with the download button inside
+ * .video-tab-header and the popup as a following sibling.
+ */
+const section = ({ icon, popup }: SectionSpec) => `
+  <div class="video-tab-toggle-section">
+    <div class="video-tab-header">
+      ${
+  icon ?
+    '<button class="video-download-icons" aria-expanded="false"></button>' :
+    ""
+}
+    </div>
+    ${popup ? '<div class="video-tab-download-popup hidden"></div>' : ""}
+  </div>
+`
+
+const render = (...sections: SectionSpec[]) => {
+  document.body.innerHTML = sections.map(section).join("")
+  initVideoDownloadPopup()
+  return {
+    icons: Array.from(
+      document.querySelectorAll<HTMLElement>(".video-download-icons")
+    ),
+    popups: Array.from(
+      document.querySelectorAll<HTMLElement>(".video-tab-download-popup")
+    )
+  }
+}
+
+describe("initVideoDownloadPopup", () => {
+  it("opens the popup in the clicked icon's own section", () => {
+    // A tab that has a popup but no download button comes first, so pairing by
+    // document index would open the wrong popup.
+    const { icons, popups } = render(
+      { icon: false, popup: true },
+      { icon: true, popup: true }
+    )
+
+    icons[0].click()
+
+    expect(popups[1].classList.contains("hidden")).toBe(false)
+    expect(popups[0].classList.contains("hidden")).toBe(true)
+    expect(icons[0].getAttribute("aria-expanded")).toBe("true")
+  })
+
+  it("closes the popup when its icon is clicked again", () => {
+    const { icons, popups } = render({ icon: true, popup: true })
+
+    icons[0].click()
+    expect(popups[0].classList.contains("hidden")).toBe(false)
+
+    icons[0].click()
+    expect(popups[0].classList.contains("hidden")).toBe(true)
+    expect(icons[0].getAttribute("aria-expanded")).toBe("false")
+  })
+
+  it("closes the previously open popup when another icon is clicked", () => {
+    const { icons, popups } = render(
+      { icon: true, popup: true },
+      { icon: true, popup: true }
+    )
+
+    icons[0].click()
+    icons[1].click()
+
+    expect(popups[0].classList.contains("hidden")).toBe(true)
+    expect(icons[0].getAttribute("aria-expanded")).toBe("false")
+    expect(popups[1].classList.contains("hidden")).toBe(false)
+    expect(icons[1].getAttribute("aria-expanded")).toBe("true")
+  })
+
+  it("resets a popup to its main menu view when it is closed", () => {
+    const { icons, popups } = render({ icon: true, popup: true })
+
+    icons[0].click()
+    popups[0].setAttribute("data-view", "submenu")
+    icons[0].click()
+
+    expect(popups[0].hasAttribute("data-view")).toBe(false)
+  })
+
+  it("ignores an icon whose section has no popup", () => {
+    const { icons } = render({ icon: true, popup: false })
+
+    expect(() => icons[0].click()).not.toThrow()
+  })
+})

--- a/base-theme/assets/js/video_download_popup.test.ts
+++ b/base-theme/assets/js/video_download_popup.test.ts
@@ -35,9 +35,8 @@ const render = (...sections: SectionSpec[]) => {
 
 describe("initVideoDownloadPopup", () => {
   it("opens the popup in the clicked icon's own section", () => {
-    // A tab with a popup but no download button comes first. The templates do not
-    // currently emit this order, so this guards the ordering assumption rather than
-    // reproducing a live bug: pairing by document index would open the wrong popup.
+    // A tab with a popup but no download button comes first, so pairing by
+    // document index would open the wrong popup.
     const { icons, popups } = render(
       { icon: false, popup: true },
       { icon: true, popup: true }

--- a/base-theme/assets/js/video_download_popup.ts
+++ b/base-theme/assets/js/video_download_popup.ts
@@ -18,9 +18,7 @@ export const initVideoDownloadPopup = () => {
   }
 
   downloadIcons.forEach(downloadIcon => {
-    // Resolve the popup from the icon's own tab section. Matching icons to popups
-    // by document index only held because icon-bearing tabs happen to be rendered
-    // first; resolving from the section removes that ordering dependency.
+    // Resolve the popup from the icon's own tab section, not by document index.
     const popup = downloadIcon
       .closest(".video-tab-toggle-section")
       ?.querySelector(".video-tab-download-popup") as HTMLElement | null

--- a/base-theme/assets/js/video_download_popup.ts
+++ b/base-theme/assets/js/video_download_popup.ts
@@ -2,38 +2,39 @@ export const initVideoDownloadPopup = () => {
   const downloadIcons = document.querySelectorAll(".video-download-icons")
   const popups = document.querySelectorAll(".video-tab-download-popup")
   let activePopup: HTMLElement | null = null
-  let activePopupDownloadIconIndex = -1
+  let activeIcon: Element | null = null
 
   function resetPopupToMainMenu(popup: HTMLElement) {
     popup.removeAttribute("data-view")
   }
 
-  downloadIcons.forEach((downloadIcon, index) => {
-    const popup = popups[index] as HTMLElement
+  function closeActivePopup() {
+    if (!activePopup) return
+    activeIcon?.setAttribute("aria-expanded", "false")
+    activePopup.classList.add("hidden")
+    resetPopupToMainMenu(activePopup)
+    activePopup = null
+    activeIcon = null
+  }
+
+  downloadIcons.forEach(downloadIcon => {
+    // Resolve the popup from the icon's own tab section. Matching icons to popups
+    // by document index breaks as soon as a tab renders one without the other.
+    const popup = downloadIcon
+      .closest(".video-tab-toggle-section")
+      ?.querySelector(".video-tab-download-popup") as HTMLElement | null
+    if (!popup) return
+
     downloadIcon.addEventListener("click", event => {
       event.stopPropagation()
-      if (popup === activePopup) {
-        // Clicked on the same download button, toggle the popup
-        downloadIcon.setAttribute("aria-expanded", "false")
-        popup.classList.toggle("hidden")
-        resetPopupToMainMenu(popup)
-        activePopup = null
-      } else {
-        // Clicked on a different download button, close previous popup (if any) and toggle open new popup
-        if (activePopup) {
-          downloadIcons[activePopupDownloadIconIndex].setAttribute(
-            "aria-expanded",
-            "false"
-          )
-          activePopup.classList.add("hidden")
-          resetPopupToMainMenu(activePopup)
-        }
-        // Show the clicked popup
-        downloadIcon.setAttribute("aria-expanded", "true")
-        popup.classList.remove("hidden")
-        activePopup = popup
-        activePopupDownloadIconIndex = index
-      }
+      const wasActive = popup === activePopup
+      closeActivePopup()
+      // Clicking the open popup's own button just closes it
+      if (wasActive) return
+      downloadIcon.setAttribute("aria-expanded", "true")
+      popup.classList.remove("hidden")
+      activePopup = popup
+      activeIcon = downloadIcon
     })
   })
 
@@ -99,15 +100,7 @@ export const initVideoDownloadPopup = () => {
 
   // Click anywhere on page: close active popup and any open transcript dropdowns
   document.addEventListener("click", () => {
-    if (activePopup) {
-      downloadIcons[activePopupDownloadIconIndex].setAttribute(
-        "aria-expanded",
-        "false"
-      )
-      activePopup.classList.add("hidden")
-      resetPopupToMainMenu(activePopup)
-      activePopup = null
-    }
+    closeActivePopup()
     transcriptLangBtns.forEach(btn => {
       const htmlBtn = btn as HTMLElement
       const dropdown = btn.closest(".transcript-lang-dropdown") as HTMLElement

--- a/base-theme/assets/js/video_download_popup.ts
+++ b/base-theme/assets/js/video_download_popup.ts
@@ -19,7 +19,8 @@ export const initVideoDownloadPopup = () => {
 
   downloadIcons.forEach(downloadIcon => {
     // Resolve the popup from the icon's own tab section. Matching icons to popups
-    // by document index breaks as soon as a tab renders one without the other.
+    // by document index only held because icon-bearing tabs happen to be rendered
+    // first; resolving from the section removes that ordering dependency.
     const popup = downloadIcon
       .closest(".video-tab-toggle-section")
       ?.querySelector(".video-tab-download-popup") as HTMLElement | null

--- a/base-theme/layouts/partials/get_video_download_link.html
+++ b/base-theme/layouts/partials/get_video_download_link.html
@@ -1,0 +1,30 @@
+{{/*
+  get_video_download_link.html
+
+  Returns the download URL for a video resource, or "" when the video has nothing
+  downloadable.
+
+  Prefers the resource's own file and falls back to the external archive_url. Both
+  an absent and an empty file fall through to the fallback.
+
+  Input: dict with:
+    - "context"  : the page the link is rendered on. Used for URL resolution; the
+                   offline resource_url.html override needs it to compute the path
+                   back to the package root.
+    - "resource" : the video resource page.
+
+  On a video resource page these are the same page. They differ for a video
+  embedded in another page through the `resource` shortcode, where the link has to
+  be relative to the embedding page.
+
+  Returns: string
+*/}}
+{{- $context := .context -}}
+{{- $resource := .resource -}}
+{{- $downloadLink := "" -}}
+{{- with $resource.Params.file -}}
+  {{- $downloadLink = partial "resource_url.html" (dict "context" $context "url" .) -}}
+{{- else -}}
+  {{- $downloadLink = $resource.Params.video_files.archive_url | default "" -}}
+{{- end -}}
+{{- return $downloadLink -}}

--- a/base-theme/layouts/partials/get_video_download_link.html
+++ b/base-theme/layouts/partials/get_video_download_link.html
@@ -1,21 +1,17 @@
 {{/*
   get_video_download_link.html
 
-  Returns the download URL for a video resource, or "" when the video has nothing
-  downloadable.
-
-  Prefers the resource's own file and falls back to the external archive_url. Both
-  an absent and an empty file fall through to the fallback.
+  Returns the download URL for a video resource, or "" when there is nothing
+  downloadable. Prefers the resource's own file, falling back to the external
+  archive_url when the file is absent or empty.
 
   Input: dict with:
-    - "context"  : the page the link is rendered on. Used for URL resolution; the
-                   offline resource_url.html override needs it to compute the path
-                   back to the package root.
+    - "context"  : the page the link is rendered on. The offline resource_url.html
+                   override needs it to compute the path back to the package root.
     - "resource" : the video resource page.
 
-  On a video resource page these are the same page. They differ for a video
-  embedded in another page through the `resource` shortcode, where the link has to
-  be relative to the embedding page.
+  These are the same page on a video resource page, and differ for a video embedded
+  through the `resource` shortcode, where the link is relative to the embedding page.
 
   Returns: string
 */}}

--- a/base-theme/layouts/partials/video.html
+++ b/base-theme/layouts/partials/video.html
@@ -12,19 +12,13 @@
 {{ if gt (len $transcriptLinks) 0 }}
   {{ $transcriptPdfLocation = (index $transcriptLinks 0).href }}
 {{ end }}
-{{ $downloadLink := .Params.file }}
+{{ $downloadLink := partial "get_video_download_link.html" (dict "context" . "resource" .) }}
 {{ $relatedResourses := .Params.related_resources_text | default "" }}
 {{ $optionalTabTitle := .Params.optional_tab_title | default "" }}
 {{ $optionalTabContent := .Params.optional_text | default ""}}
 {{ $startTime := .Params.start_time | default "" }}
 {{ $endTime := .Params.end_time | default "" }}
 {{ $context := . }}
-
-{{ if (eq $downloadLink nil) }}
-{{ $downloadLink = .Params.video_files.archive_url }}
-{{ else }}
-{{ $downloadLink =  partial "resource_url.html" (dict "context" . "url" $downloadLink) }}
-{{ end }}
 
 <div class="video-page">
   	<div class="description">

--- a/base-theme/layouts/partials/video_embed.html
+++ b/base-theme/layouts/partials/video_embed.html
@@ -11,18 +11,12 @@
 {{ $uid := $resource.Params.uid }}
 {{ $startTime := $resource.Params.start_time | default "" }}
 {{ $endTime := $resource.Params.end_time | default "" }}
-{{ $downloadLink := $resource.Params.file }}
+{{ $downloadLink := partial "get_video_download_link.html" (dict "context" $context "resource" $resource) }}
 {{ $transcriptSource := $resource.Params.video_files.video_transcript_resources }}
 {{ $transcriptLinks := partial "video_transcript_links.html" (dict "context" $context "transcriptFile" $transcriptSource) }}
 {{ $transcriptPdfLocation := "" }}
 {{ if gt (len $transcriptLinks) 0 }}
   {{ $transcriptPdfLocation = (index $transcriptLinks 0).href }}
-{{ end }}
-
-{{ if (eq $downloadLink nil) }}
-{{ $downloadLink = $resource.Params.video_files.archive_url }}
-{{ else }}
-{{ $downloadLink =  partial "resource_url.html" (dict "context" $context "url" $downloadLink) }}
 {{ end }}
 
 <div class="video-embed video-player-wrapper">

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -1,16 +1,9 @@
 {{ $isEmbedVideo := eq .tabTitle "View video page" }}
 {{ $videoHasTranscript := eq .tabTitle "Transcript" }}
 {{ $hasTranscriptLinks := and $videoHasTranscript .transcriptLinks (gt (len .transcriptLinks) 0) }}
-{{/*  The download menu is only meaningful when there is something to download.
-  Without this gate the button opens an empty popup, which is what embedded videos
-  OCW did not produce look like: no file, no archive_url and no transcripts.
-  See https://github.com/mitodl/hq/issues/4188
-
-  The three terms below must mirror the item conditions in the popup body further
-  down (downloadLink, transcriptLinks, transcriptLink), so that the button appears
-  exactly when the popup would render at least one entry. transcriptLink is unused
-  by every current caller, but keep it here as long as the popup still branches on
-  it, otherwise the button and the menu can disagree.  */}}
+{{/*  These terms mirror the popup's item conditions below, so the button appears
+  exactly when the popup would render at least one entry. transcriptLink is unused by
+  current callers; keep it while the popup still branches on it.  */}}
 {{ $hasDownloads := or .downloadLink .transcriptLinks .transcriptLink }}
 {{ $showDownloads := and $hasDownloads (or $videoHasTranscript $isEmbedVideo (eq .tabTitle "")) }}
 <div class="video-tab-toggle-section pointer">

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -1,6 +1,12 @@
 {{ $isEmbedVideo := eq .tabTitle "View video page" }}
 {{ $videoHasTranscript := eq .tabTitle "Transcript" }}
 {{ $hasTranscriptLinks := and $videoHasTranscript .transcriptLinks (gt (len .transcriptLinks) 0) }}
+{{/*  The download menu is only meaningful when there is something to download.
+  Without this gate the button opens an empty popup, which is what embedded videos
+  OCW did not produce look like: no file, no archive_url and no transcripts.
+  See https://github.com/mitodl/hq/issues/4188  */}}
+{{ $hasDownloads := or .downloadLink .transcriptLinks .transcriptLink }}
+{{ $showDownloads := and $hasDownloads (or $videoHasTranscript $isEmbedVideo (eq .tabTitle "")) }}
 <div class="video-tab-toggle-section pointer">
   <div class="video-tab-header d-flex">
     {{ if .tabTitle }}
@@ -16,9 +22,9 @@
         {{ end }}
       </span>
     {{ end }}
-    {{/*  If we have transcript or the video is embed video, show download button on those tabs.
-      Otherwise show download button in a standalone tab bar  */}}
-    {{ if or ($videoHasTranscript) ($isEmbedVideo) (eq .tabTitle "") }}
+    {{/*  The download button lives on the transcript and embed video tabs, or in a
+      standalone tab bar when there is no tab title  */}}
+    {{ if $showDownloads }}
       <div class="ml-auto">
         <button class="video-download-icons" aria-label="Show Downloads" aria-expanded="false">
           <img class="video-download-icon" src="{{ partial "get_asset_webpack_url.html" "images/videojs_download.svg" }}" aria-hidden="true"/>
@@ -27,6 +33,7 @@
       </div>
     {{ end }}
   </div>
+  {{ if $showDownloads }}
   <div class="video-tab-download-popup hidden">
     {{/* Main menu view */}}
     <div class="download-menu-main">
@@ -67,6 +74,7 @@
     </div>
     {{ end }}
   </div>
+  {{ end }}
 </div>
 {{ if $hasTranscriptLinks }}
 {{- $defaultLabel := "" -}}

--- a/base-theme/layouts/partials/video_expandable_tab.html
+++ b/base-theme/layouts/partials/video_expandable_tab.html
@@ -4,7 +4,13 @@
 {{/*  The download menu is only meaningful when there is something to download.
   Without this gate the button opens an empty popup, which is what embedded videos
   OCW did not produce look like: no file, no archive_url and no transcripts.
-  See https://github.com/mitodl/hq/issues/4188  */}}
+  See https://github.com/mitodl/hq/issues/4188
+
+  The three terms below must mirror the item conditions in the popup body further
+  down (downloadLink, transcriptLinks, transcriptLink), so that the button appears
+  exactly when the popup would render at least one entry. transcriptLink is unused
+  by every current caller, but keep it here as long as the popup still branches on
+  it, otherwise the button and the menu can disagree.  */}}
 {{ $hasDownloads := or .downloadLink .transcriptLinks .transcriptLink }}
 {{ $showDownloads := and $hasDownloads (or $videoHasTranscript $isEmbedVideo (eq .tabTitle "")) }}
 <div class="video-tab-toggle-section pointer">

--- a/course-v3/layouts/partials/video_v3.html
+++ b/course-v3/layouts/partials/video_v3.html
@@ -12,19 +12,13 @@
 {{ if gt (len $transcriptLinks) 0 }}
   {{ $transcriptPdfLocation = (index $transcriptLinks 0).href }}
 {{ end }}
-{{ $downloadLink := .Params.file }}
+{{ $downloadLink := partial "get_video_download_link.html" (dict "context" . "resource" .) }}
 {{ $relatedResourses := .Params.related_resources_text | default "" }}
 {{ $optionalTabTitle := .Params.optional_tab_title | default "" }}
 {{ $optionalTabContent := .Params.optional_text | default ""}}
 {{ $startTime := .Params.start_time | default "" }}
 {{ $endTime := .Params.end_time | default "" }}
 {{ $context := . }}
-
-{{ if (eq $downloadLink nil) }}
-{{ $downloadLink = .Params.video_files.archive_url }}
-{{ else }}
-{{ $downloadLink = partial "resource_url.html" (dict "context" . "url" $downloadLink) }}
-{{ end }}
 
 <div class="video-page">
   <div class="video-player-wrapper">

--- a/test-sites/ocw-ci-test-course/config/_default/menus.yaml
+++ b/test-sites/ocw-ci-test-course/config/_default/menus.yaml
@@ -31,6 +31,10 @@ leftnav:
   name: External Resources
   pageRef: /pages/external-resources-page
   weight: 80
+- identifier: 1b43a97c-d5c0-43b5-b555-588ebaff3378
+  name: Video Without Downloads
+  pageRef: /pages/video-without-downloads
+  weight: 90
 - identifier: d1f35266-366e-45f1-bfc2-bcd46eb6c4a4
   name: Subsection 1a Menu Title
   pageRef: /pages/subsection-1a

--- a/test-sites/ocw-ci-test-course/content/pages/video-without-downloads.md
+++ b/test-sites/ocw-ci-test-course/content/pages/video-without-downloads.md
@@ -1,0 +1,18 @@
+---
+content_type: page
+description: Videos that have no downloadable file, archive URL, or transcript.
+learning_resource_types: []
+ocw_type: SupplementalResourceSection
+title: Video Without Downloads
+uid: 1b43a97c-d5c0-43b5-b555-588ebaff3378
+---
+
+{{< resource a2d0bd0e-b77f-4c8e-9f7a-a7bd61d6a6df >}}
+
+{{< resource 5130cc14-34ed-4413-bd12-ede6fefe09fc >}}
+
+The two videos above have no downloadable file, no archive URL, and no transcript, so the player must not offer a download menu.
+
+{{< resource a626ea0a-9852-4e47-9cdc-18ad6e32b542 >}}
+
+The video above has an empty `file` but a valid `archive_url`, so it must still offer a download.

--- a/test-sites/ocw-ci-test-course/content/resources/video-archive-url-only.md
+++ b/test-sites/ocw-ci-test-course/content/resources/video-archive-url-only.md
@@ -1,0 +1,27 @@
+---
+body: ''
+content_type: resource
+draft: false
+file: ''
+file_size: ''
+file_type: ''
+image_metadata:
+  caption: ''
+  credit: ''
+  image-alt: ''
+learning_resource_types: []
+license: https://creativecommons.org/licenses/by-nc-sa/4.0/
+resourcetype: Video
+title: Video With Only An Archive URL
+uid: a626ea0a-9852-4e47-9cdc-18ad6e32b542
+video_files:
+  archive_url: http://www.archive.org/download/MIT18.06S05_MP4/01.mp4
+  video_captions_file: null
+  video_thumbnail_file: https://img.youtube.com/vi/ljxssJgODlE/default.jpg
+  video_transcript_file: null
+video_metadata:
+  video_speakers: ''
+  video_tags: ''
+  youtube_description: ''
+  youtube_id: ljxssJgODlE
+---

--- a/test-sites/ocw-ci-test-course/content/resources/video-archive-url-only.md
+++ b/test-sites/ocw-ci-test-course/content/resources/video-archive-url-only.md
@@ -17,11 +17,11 @@ uid: a626ea0a-9852-4e47-9cdc-18ad6e32b542
 video_files:
   archive_url: http://www.archive.org/download/MIT18.06S05_MP4/01.mp4
   video_captions_file: null
-  video_thumbnail_file: https://img.youtube.com/vi/ljxssJgODlE/default.jpg
+  video_thumbnail_file: https://img.youtube.com/vi/YWyHAlAuRL0/default.jpg
   video_transcript_file: null
 video_metadata:
   video_speakers: ''
   video_tags: ''
   youtube_description: ''
-  youtube_id: ljxssJgODlE
+  youtube_id: YWyHAlAuRL0
 ---

--- a/test-sites/ocw-ci-test-course/content/resources/video-captions-only.md
+++ b/test-sites/ocw-ci-test-course/content/resources/video-captions-only.md
@@ -19,11 +19,11 @@ video_files:
   video_captions_resources:
     - file: /courses/ocw-ci-test-course/917263bef37857bd94ef67692405bcc9_erlp_sbca1s.vtt
       language: en
-  video_thumbnail_file: https://img.youtube.com/vi/O0r3MpHd_mU/default.jpg
+  video_thumbnail_file: https://img.youtube.com/vi/YWyHAlAuRL0/default.jpg
   video_transcript_file: null
 video_metadata:
   video_speakers: ''
   video_tags: ''
   youtube_description: ''
-  youtube_id: O0r3MpHd_mU
+  youtube_id: YWyHAlAuRL0
 ---

--- a/test-sites/ocw-ci-test-course/content/resources/video-captions-only.md
+++ b/test-sites/ocw-ci-test-course/content/resources/video-captions-only.md
@@ -1,0 +1,29 @@
+---
+body: ''
+content_type: resource
+draft: false
+file: null
+file_size: ''
+file_type: ''
+image_metadata:
+  caption: ''
+  credit: ''
+  image-alt: ''
+learning_resource_types: []
+license: https://creativecommons.org/licenses/by-nc-sa/4.0/
+resourcetype: Video
+title: Video With Captions But No Downloads
+uid: 5130cc14-34ed-4413-bd12-ede6fefe09fc
+video_files:
+  archive_url: null
+  video_captions_resources:
+    - file: /courses/ocw-ci-test-course/917263bef37857bd94ef67692405bcc9_erlp_sbca1s.vtt
+      language: en
+  video_thumbnail_file: https://img.youtube.com/vi/O0r3MpHd_mU/default.jpg
+  video_transcript_file: null
+video_metadata:
+  video_speakers: ''
+  video_tags: ''
+  youtube_description: ''
+  youtube_id: O0r3MpHd_mU
+---

--- a/test-sites/ocw-ci-test-course/content/resources/video-no-downloads.md
+++ b/test-sites/ocw-ci-test-course/content/resources/video-no-downloads.md
@@ -1,0 +1,27 @@
+---
+body: ''
+content_type: resource
+draft: false
+file: null
+file_size: ''
+file_type: ''
+image_metadata:
+  caption: ''
+  credit: ''
+  image-alt: ''
+learning_resource_types: []
+license: https://creativecommons.org/licenses/by-nc-sa/4.0/
+resourcetype: Video
+title: Video With No Downloads
+uid: a2d0bd0e-b77f-4c8e-9f7a-a7bd61d6a6df
+video_files:
+  archive_url: null
+  video_captions_file: null
+  video_thumbnail_file: https://img.youtube.com/vi/7ecTUbUOiFw/default.jpg
+  video_transcript_file: null
+video_metadata:
+  video_speakers: ''
+  video_tags: ''
+  youtube_description: ''
+  youtube_id: 7ecTUbUOiFw
+---

--- a/test-sites/ocw-ci-test-course/content/resources/video-no-downloads.md
+++ b/test-sites/ocw-ci-test-course/content/resources/video-no-downloads.md
@@ -17,11 +17,11 @@ uid: a2d0bd0e-b77f-4c8e-9f7a-a7bd61d6a6df
 video_files:
   archive_url: null
   video_captions_file: null
-  video_thumbnail_file: https://img.youtube.com/vi/7ecTUbUOiFw/default.jpg
+  video_thumbnail_file: https://img.youtube.com/vi/YWyHAlAuRL0/default.jpg
   video_transcript_file: null
 video_metadata:
   video_speakers: ''
   video_tags: ''
   youtube_description: ''
-  youtube_id: 7ecTUbUOiFw
+  youtube_id: YWyHAlAuRL0
 ---

--- a/tests-e2e/ocw-ci-test-course-v3/video-tabs-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/video-tabs-v3.spec.ts
@@ -218,10 +218,7 @@ const ARCHIVE_URL = "http://www.archive.org/download/MIT18.06S05_MP4/01.mp4"
 
 /**
  * These tests assert on server-rendered markup, so they navigate with
- * `domcontentloaded` rather than waiting on the embedded YouTube iframes. The
- * download popup's click behaviour is covered by the Jest tests in
- * base-theme/assets/js/video_download_popup.test.ts and by the interaction tests
- * above.
+ * `domcontentloaded` rather than waiting on the embedded YouTube iframes.
  */
 test.describe("Course v3 video download button visibility", () => {
   test("embedded videos with nothing to download have no download button", async ({
@@ -241,8 +238,7 @@ test.describe("Course v3 video download button visibility", () => {
       page.getByRole("link", { name: "View video page" })
     ).toHaveCount(3)
 
-    // Popups are gated on the same condition as the button, so the counts stay
-    // 1:1. video_download_popup.ts depends on finding a popup for every button.
+    // Buttons and popups stay 1:1.
     await expect(page.locator(".video-download-icons")).toHaveCount(1)
     await expect(page.locator(".video-tab-download-popup")).toHaveCount(1)
   })
@@ -254,8 +250,7 @@ test.describe("Course v3 video download button visibility", () => {
     await course.goto(NO_DOWNLOADS_PAGE, { waitUntil: "domcontentloaded" })
     const video = new VideoElement(page, 2)
 
-    // This resource has an empty `file` and a valid archive_url, so the fallback
-    // in get_video_download_link.html has to fire for it.
+    // Empty `file`, valid archive_url.
     await expect(video.downloadButton()).toHaveCount(1)
     await expect(video.downloadVideoLink()).toHaveAttribute("href", ARCHIVE_URL)
   })

--- a/tests-e2e/ocw-ci-test-course-v3/video-tabs-v3.spec.ts
+++ b/tests-e2e/ocw-ci-test-course-v3/video-tabs-v3.spec.ts
@@ -208,3 +208,98 @@ test.describe("Course v3 video tab language selector", () => {
     expect(Number(activeFontWeight)).toBeLessThanOrEqual(400)
   })
 })
+
+const NO_DOWNLOADS_PAGE = "/pages/video-without-downloads"
+const NO_DOWNLOADS_RESOURCE = "/resources/video-no-downloads"
+const CAPTIONS_ONLY_RESOURCE = "/resources/video-captions-only"
+const DOWNLOADABLE_RESOURCE =
+  "/resources/ocw_test_course_mit8_01f16_l01v01_360p"
+const ARCHIVE_URL = "http://www.archive.org/download/MIT18.06S05_MP4/01.mp4"
+
+/**
+ * These tests assert on server-rendered markup, so they navigate with
+ * `domcontentloaded` rather than waiting on the embedded YouTube iframes. The
+ * download popup's click behaviour is covered by the Jest tests in
+ * base-theme/assets/js/video_download_popup.test.ts and by the interaction tests
+ * above.
+ */
+test.describe("Course v3 video download button visibility", () => {
+  test("embedded videos with nothing to download have no download button", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto(NO_DOWNLOADS_PAGE, { waitUntil: "domcontentloaded" })
+
+    // Three embedded videos: two with nothing downloadable, one with only an
+    // archive_url.
+    await expect(new VideoElement(page).container).toHaveCount(3)
+    await expect(new VideoElement(page, 0).downloadButton()).toHaveCount(0)
+    await expect(new VideoElement(page, 1).downloadButton()).toHaveCount(0)
+
+    // The tab itself still renders, linking through to the video's own page.
+    await expect(
+      page.getByRole("link", { name: "View video page" })
+    ).toHaveCount(3)
+
+    // Popups are gated on the same condition as the button, so the counts stay
+    // 1:1. video_download_popup.ts depends on finding a popup for every button.
+    await expect(page.locator(".video-download-icons")).toHaveCount(1)
+    await expect(page.locator(".video-tab-download-popup")).toHaveCount(1)
+  })
+
+  test("an embedded video with only an archive_url still offers a download", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto(NO_DOWNLOADS_PAGE, { waitUntil: "domcontentloaded" })
+    const video = new VideoElement(page, 2)
+
+    // This resource has an empty `file` and a valid archive_url, so the fallback
+    // in get_video_download_link.html has to fire for it.
+    await expect(video.downloadButton()).toHaveCount(1)
+    await expect(video.downloadVideoLink()).toHaveAttribute("href", ARCHIVE_URL)
+  })
+
+  test("resource page for a video with nothing to download has no Transcript tab or download button", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto(NO_DOWNLOADS_RESOURCE, { waitUntil: "domcontentloaded" })
+    const video = new VideoElement(page)
+
+    await expect(video.container).toHaveCount(1)
+    await expect(video.tab({ name: /Transcript/i, exact: false })).toHaveCount(
+      0
+    )
+    await expect(video.downloadButton()).toHaveCount(0)
+  })
+
+  test("captions-only resource page shows the Transcript tab but no download button", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto(CAPTIONS_ONLY_RESOURCE, { waitUntil: "domcontentloaded" })
+    const video = new VideoElement(page)
+
+    // Captions drive the in-page transcript panel, so the tab must still render.
+    await expect(video.tab({ name: /Transcript/i, exact: false })).toHaveCount(
+      1
+    )
+    // There is no transcript file and no video file, so nothing to download.
+    await expect(video.downloadButton()).toHaveCount(0)
+  })
+
+  test("video with a downloadable file still shows the download button", async ({
+    page
+  }) => {
+    const course = new CoursePage(page, "course-v3")
+    await course.goto(DOWNLOADABLE_RESOURCE, { waitUntil: "domcontentloaded" })
+    const video = new VideoElement(page)
+
+    await expect(video.downloadButton()).toHaveCount(1)
+    await expect(video.downloadVideoLink()).toHaveAttribute(
+      "href",
+      /ocw_test_course_mit8_01f16_l01v01_360p_360p_16_9\.mp4$/
+    )
+  })
+})

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -394,10 +394,7 @@ test("Language selector active option is not bold (consistent with menu styling)
 
 /**
  * The tests below assert on server-rendered markup, so they navigate with
- * `domcontentloaded` rather than waiting on the embedded YouTube iframes. The
- * download popup's click behaviour is covered by the Jest tests in
- * base-theme/assets/js/video_download_popup.test.ts and by the interaction tests
- * above.
+ * `domcontentloaded` rather than waiting on the embedded YouTube iframes.
  */
 test("that embedded videos with nothing to download have no download button", async ({
   page
@@ -408,8 +405,7 @@ test("that embedded videos with nothing to download have no download button", as
   })
 
   // Three embedded videos: two with nothing downloadable, one with only an
-  // archive_url. Only the last renders a button, and popups are gated on the
-  // same condition so the counts stay 1:1.
+  // archive_url. Buttons and popups stay 1:1.
   await expect(new VideoElement(page).container).toHaveCount(3)
   await expect(new VideoElement(page, 0).downloadButton()).toHaveCount(0)
   await expect(new VideoElement(page, 1).downloadButton()).toHaveCount(0)
@@ -426,8 +422,7 @@ test("that an embedded video with only an archive_url still offers a download", 
   })
   const video = new VideoElement(page, 2)
 
-  // Empty `file` plus a valid archive_url: the fallback in
-  // get_video_download_link.html has to fire for it.
+  // Empty `file`, valid archive_url.
   await expect(video.downloadButton()).toHaveCount(1)
   await expect(video.downloadVideoLink()).toHaveAttribute(
     "href",

--- a/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
+++ b/tests-e2e/ocw-ci-test-course/video-tabs.spec.ts
@@ -391,3 +391,73 @@ test("Language selector active option is not bold (consistent with menu styling)
     .evaluate(el => window.getComputedStyle(el).fontWeight)
   expect(Number(activeFontWeight)).toBeLessThanOrEqual(400)
 })
+
+/**
+ * The tests below assert on server-rendered markup, so they navigate with
+ * `domcontentloaded` rather than waiting on the embedded YouTube iframes. The
+ * download popup's click behaviour is covered by the Jest tests in
+ * base-theme/assets/js/video_download_popup.test.ts and by the interaction tests
+ * above.
+ */
+test("that embedded videos with nothing to download have no download button", async ({
+  page
+}) => {
+  const coursePage = new CoursePage(page, "course")
+  await coursePage.goto("pages/video-without-downloads/", {
+    waitUntil: "domcontentloaded"
+  })
+
+  // Three embedded videos: two with nothing downloadable, one with only an
+  // archive_url. Only the last renders a button, and popups are gated on the
+  // same condition so the counts stay 1:1.
+  await expect(new VideoElement(page).container).toHaveCount(3)
+  await expect(new VideoElement(page, 0).downloadButton()).toHaveCount(0)
+  await expect(new VideoElement(page, 1).downloadButton()).toHaveCount(0)
+  await expect(page.locator(".video-download-icons")).toHaveCount(1)
+  await expect(page.locator(".video-tab-download-popup")).toHaveCount(1)
+})
+
+test("that an embedded video with only an archive_url still offers a download", async ({
+  page
+}) => {
+  const coursePage = new CoursePage(page, "course")
+  await coursePage.goto("pages/video-without-downloads/", {
+    waitUntil: "domcontentloaded"
+  })
+  const video = new VideoElement(page, 2)
+
+  // Empty `file` plus a valid archive_url: the fallback in
+  // get_video_download_link.html has to fire for it.
+  await expect(video.downloadButton()).toHaveCount(1)
+  await expect(video.downloadVideoLink()).toHaveAttribute(
+    "href",
+    "http://www.archive.org/download/MIT18.06S05_MP4/01.mp4"
+  )
+})
+
+test("that a video resource page with nothing to download has no download button", async ({
+  page
+}) => {
+  const coursePage = new CoursePage(page, "course")
+  await coursePage.goto("resources/video-no-downloads/", {
+    waitUntil: "domcontentloaded"
+  })
+  const video = new VideoElement(page)
+
+  await expect(video.container).toHaveCount(1)
+  await expect(video.tab({ name: /Transcript/i, exact: false })).toHaveCount(0)
+  await expect(video.downloadButton()).toHaveCount(0)
+})
+
+test("that a captions-only video shows the Transcript tab without a download button", async ({
+  page
+}) => {
+  const coursePage = new CoursePage(page, "course")
+  await coursePage.goto("resources/video-captions-only/", {
+    waitUntil: "domcontentloaded"
+  })
+  const video = new VideoElement(page)
+
+  await expect(video.tab({ name: /Transcript/i, exact: false })).toHaveCount(1)
+  await expect(video.downloadButton()).toHaveCount(0)
+})

--- a/tests-e2e/util/CoursePage.ts
+++ b/tests-e2e/util/CoursePage.ts
@@ -20,9 +20,20 @@ class CoursePage {
     this.siteAlias = site
   }
 
-  async goto(route = ""): Promise<Response | null> {
+  /**
+   * Navigate to a route on this course site.
+   *
+   * Pass `waitUntil: "domcontentloaded"` when the test only inspects
+   * server-rendered markup. The default `load` waits on the cross-origin YouTube
+   * iframes embedded by the video player, which is slow and flaky on pages with
+   * several videos.
+   */
+  async goto(
+    route = "",
+    { waitUntil }: { waitUntil?: "load" | "domcontentloaded" } = {}
+  ): Promise<Response | null> {
     const fullRoute = siteUrl(this.siteAlias, route)
-    return this.page.goto(fullRoute)
+    return this.page.goto(fullRoute, { waitUntil })
   }
 
   /**

--- a/tests-e2e/util/CoursePage.ts
+++ b/tests-e2e/util/CoursePage.ts
@@ -32,7 +32,9 @@ class CoursePage {
     route = "",
     {
       waitUntil
-    }: { waitUntil?: NonNullable<Parameters<Page["goto"]>[1]>["waitUntil"] } = {}
+    }: {
+      waitUntil?: NonNullable<Parameters<Page["goto"]>[1]>["waitUntil"]
+    } = {}
   ): Promise<Response | null> {
     const fullRoute = siteUrl(this.siteAlias, route)
     return this.page.goto(fullRoute, { waitUntil })

--- a/tests-e2e/util/CoursePage.ts
+++ b/tests-e2e/util/CoursePage.ts
@@ -30,7 +30,9 @@ class CoursePage {
    */
   async goto(
     route = "",
-    { waitUntil }: { waitUntil?: "load" | "domcontentloaded" } = {}
+    {
+      waitUntil
+    }: { waitUntil?: NonNullable<Parameters<Page["goto"]>[1]>["waitUntil"] } = {}
   ): Promise<Response | null> {
     const fullRoute = siteUrl(this.siteAlias, route)
     return this.page.goto(fullRoute, { waitUntil })

--- a/tests-e2e/util/VideoElement.ts
+++ b/tests-e2e/util/VideoElement.ts
@@ -44,9 +44,9 @@ export class VideoElement {
   /**
    * The "Download video" link, located by attribute rather than by role.
    *
-   * A closed popup is `visibility: hidden`, which takes its contents out of the
-   * accessibility tree, so `downloadVideo()` only matches once the popup has been
-   * opened. Use this when asserting on the rendered href without clicking.
+   * A closed popup is `visibility: hidden`, so its contents sit outside the
+   * accessibility tree and `downloadVideo()` matches only once the popup is open.
+   * Use this to assert on the rendered href without clicking.
    */
   downloadVideoLink(): Locator {
     return this.container.locator('a[aria-label="Download video"]')

--- a/tests-e2e/util/VideoElement.ts
+++ b/tests-e2e/util/VideoElement.ts
@@ -41,6 +41,17 @@ export class VideoElement {
     })
   }
 
+  /**
+   * The "Download video" link, located by attribute rather than by role.
+   *
+   * A closed popup is `visibility: hidden`, which takes its contents out of the
+   * accessibility tree, so `downloadVideo()` only matches once the popup has been
+   * opened. Use this when asserting on the rendered href without clicking.
+   */
+  downloadVideoLink(): Locator {
+    return this.container.locator('a[aria-label="Download video"]')
+  }
+
   downloadTranscriptSubmenuBtn(): Locator {
     return this.container.getByRole("button", {
       name: /Download Transcript/i


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4188

### Description (What does it do?)
The download button under the video player was decided by tab identity alone, never by whether anything was actually downloadable. A video with no `file`, no `archive_url` and no transcripts got a button that opened an empty menu. `video_expandable_tab.html` has no theme overrides, so this covers course-v2, course-v3, www and both offline variants.

- `base-theme/layouts/partials/video_expandable_tab.html`: gate the button and the popup on a single `$showDownloads`, so the two stay 1:1
- New `base-theme/layouts/partials/get_video_download_link.html`: collapses the `file` to `archive_url` fallback that was copy-pasted across `video.html`, `video_v3.html`, `video_embed.html` and the base-offline copy, and fixes it for `file: ''` (previously only `nil` fell back)
- `base-theme/assets/js/video_download_popup.ts`: resolve each popup from its own `.video-tab-toggle-section` instead of by array index
- Tests: 5 Jest, 9 Playwright (v2 and v3), 3 test-course video fixtures

### Netlify
[www](https://ocw-hugo-themes-www-pr-1841--ocw-next.netlify.app/collections/introductory-science-and-math/)
[course-v2](https://ocw-hugo-themes-course-v2-pr-1841--ocw-next.netlify.app/)
[course-v3](https://ocw-hugo-themes-course-v3-pr-1841--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/)

### How can this be tested?

**The fix.** Open the [www collection page](https://ocw-hugo-themes-www-pr-1841--ocw-next.netlify.app/collections/introductory-science-and-math/). It embeds 4 videos that have no file, no archive URL and no transcript, so none of them should show a download button. For contrast, all 4 currently show one on [production](https://ocw.mit.edu/collections/introductory-science-and-math/), and each opens an empty menu.

**Regression.** Open any video lecture on [course-v2](https://ocw-hugo-themes-course-v2-pr-1841--ocw-next.netlify.app/) or [course-v3](https://ocw-hugo-themes-course-v3-pr-1841--ocw-next.netlify.app/courses/o/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/). Every video in that course has an archive URL and a transcript, so the download button should still be there and still work.

**Empty `file` falling back to `archive_url`.** No published content has that shape, so it is only reachable through the new test-course fixtures: