### PR TITLE
fix: skip caption/transcript partials when the value is not an array

### DIFF
--- a/base-theme/layouts/partials/video_caption_tracks.html
+++ b/base-theme/layouts/partials/video_caption_tracks.html
@@ -14,8 +14,15 @@
 {{- $captionsFile := .captionsFile -}}
 {{- $tracks := slice -}}
 
-{{- if $captionsFile -}}
-  {{/* video_captions_resources is always an array of {file, language, locale?} objects */}}
+{{/*
+  The slice check is load-bearing, do not remove it. When a video has no
+  caption linked, or its linked resource has no uploaded file, older content
+  carries the CMS relation object {"content": ..., "website": ...} here
+  instead of an array. Ranging a map yields its values rather than objects,
+  so `.language` below then aborts the whole site build with
+  "can't evaluate field language in type interface {}".
+*/}}
+{{- if and $captionsFile (reflect.IsSlice $captionsFile) -}}
   {{/* First pass: check whether any English track exists */}}
   {{- $hasEnglish := false -}}
   {{- range $captionsFile -}}

--- a/base-theme/layouts/partials/video_caption_tracks.html
+++ b/base-theme/layouts/partials/video_caption_tracks.html
@@ -6,7 +6,9 @@
 
   Input: dict with:
     - "context" : page context (for resource_url resolution)
-    - "captionsFile" : video_captions_resources, an array of {"file": ..., "language": ..., "locale"?: ...}
+    - "captionsFile" : video_captions_resources, an array of {"file": ..., "language": ..., "locale"?: ...},
+                       or, in already published content, the raw CMS relation
+                       map {"content": ..., "website": ...}, which is skipped
 
   Returns: slice of dicts with keys: "src", "srclang", "label", "isDefault"
 */}}

--- a/base-theme/layouts/partials/video_transcript_links.html
+++ b/base-theme/layouts/partials/video_transcript_links.html
@@ -14,8 +14,15 @@
 {{- $transcriptFile := .transcriptFile -}}
 {{- $links := slice -}}
 
-{{- if $transcriptFile -}}
-  {{/* video_transcript_resources is always an array of {file, language, locale?} objects */}}
+{{/*
+  The slice check is load-bearing, do not remove it. When a video has no
+  transcript linked, or its linked resource has no uploaded file, older
+  content carries the CMS relation object {"content": ..., "website": ...}
+  here instead of an array. Ranging a map yields its values rather than
+  objects, so `.language` below then aborts the whole site build with
+  "can't evaluate field language in type interface {}".
+*/}}
+{{- if and $transcriptFile (reflect.IsSlice $transcriptFile) -}}
   {{/* First pass: check whether any English track exists */}}
   {{- $hasEnglish := false -}}
   {{- range $transcriptFile -}}

--- a/base-theme/layouts/partials/video_transcript_links.html
+++ b/base-theme/layouts/partials/video_transcript_links.html
@@ -6,7 +6,9 @@
 
   Input: dict with:
     - "context" : page context (for resource_url resolution)
-    - "transcriptFile" : video_transcript_resources, an array of {"file": ..., "language": ..., "locale"?: ...}
+    - "transcriptFile" : video_transcript_resources, an array of {"file": ..., "language": ..., "locale"?: ...},
+                         or, in already published content, the raw CMS relation
+                         map {"content": ..., "website": ...}, which is skipped
 
   Returns: slice of dicts with keys: "href", "language", "locale", "label", "isDefault"
 */}}

--- a/test-sites/ocw-ci-test-course/content/resources/ocw_test_course_mit8_01f16_l26v03_360p_mp4.md
+++ b/test-sites/ocw-ci-test-course/content/resources/ocw_test_course_mit8_01f16_l26v03_360p_mp4.md
@@ -15,13 +15,19 @@ resourcetype: Video
 title: ocw_test_course_MIT8_01F16_L26v03_360p.mp4
 uid: abff96f9-6777-4e4e-be27-8a7b85fab93f
 video_files:
+  # Deliberately the unresolved CMS relation shape, not an array. Published
+  # content carries this whenever a video has no caption or transcript linked,
+  # and video_caption_tracks.html / video_transcript_links.html must skip it
+  # rather than range it. Without their slice check, building this site fails
+  # with "can't evaluate field language in type interface {}". Keep this
+  # resource on the relation shape so that failure is caught here.
   video_captions_resources:
-    - file: /courses/ocw-ci-test-course/1pCfBpsMPh5QT56DL7dvvxGr8WGsy0HGP_transcript.webvtt
-      language: en
+    content: ''
+    website: ocw-ci-test-course
   video_thumbnail_file: https://img.youtube.com/vi/ufuYLysOvcg/default.jpg
   video_transcript_resources:
-    - file: /courses/ocw-ci-test-course/1pCfBpsMPh5QT56DL7dvvxGr8WGsy0HGP_transcript.pdf
-      language: en
+    content: ''
+    website: ocw-ci-test-course
 video_metadata:
   video_speakers: ''
   video_tags: ''


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12635

Paired with mitodl/ocw-studio#3123. Either side stops the build failing on its own, and both are worth having: that one keeps the bad shape out of new frontmatter, this one covers content that is already published and would otherwise need a rebuild first.

### Description (What does it do?)
`video_caption_tracks.html` and `video_transcript_links.html` assume their input is always an array of `{file, language}` objects. When a video has no caption or transcript linked, or its linked resource has no uploaded file, published frontmatter carries the CMS relation object `{"content": ..., "website": ...}` instead. Ranging a map yields its values rather than objects, so `.language` aborts the entire site build, not just the affected page:

```
video_caption_tracks.html:22:15: executing "partials/video_caption_tracks.html"
at <.language>: can't evaluate field language in type interface {}
```

- `base-theme/layouts/partials/video_caption_tracks.html`, `base-theme/layouts/partials/video_transcript_links.html`: skip a value that is not an array, and note in each why the check has to stay. These two are the only consumers that iterate the field, so this covers `video.html`, `video_embed.html`, the base-offline copy and `video_v3.html` through them.

### Netlify
[course-v2](https://ocw-hugo-themes-course-v2-pr-1843--ocw-next.netlify.app/)
[course-v3](https://ocw-hugo-themes-course-v3-pr-1843--ocw-next.netlify.app/)

### How can this be tested?

**Regression.** Open any video lecture on course-v2 or course-v3 above. Caption tracks and transcript download links should be unchanged, with English still selected by default and other languages still listed.

**The fix.** It is not reachable from the test course, whose video fixtures all carry the resolved array shape. To exercise it, render either partial with the relation-object shape:

```
{{ $bad := dict "content" (slice) "website" "somesite" }}
{{ $tracks := partial "video_caption_tracks.html" (dict "context" . "captionsFile" $bad) }}
```

Before this change that fails the build with the error above. After it, the partial returns an empty slice and the page renders with no caption tracks. Same for `video_transcript_links.html` with `transcriptFile`.
