### PR TITLE
docs: document the CSRF_COOKIE_NAME variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ allows CSRF to work between the sites, and `CSRF_COOKIE_NAME` is the name of the
 reads in order to send the `X-CSRFToken` header. In the following examples, we will assume you are running `mit-learn` locally with:
 
 - `CSRF_COOKIE_DOMAIN=.odl.local`
-- `CSRF_COOKIE_NAME=csrftoken`
+- `CSRF_COOKIE_NAME=csrftoken-local-learn`
 - `MIT_LEARN_BASE_URL=http://open.odl.local:8062`
 - `MIT_LEARN_API_BASE_URL=http://api.open.odl.local:8065`
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ To further explain the various environment variables and what they do:
 | `POSTHOG_PROJECT_API_KEY` | `www`, `course` | `api-key` | API key for PostHog |
 | `POSTHOG_UI_HOST` | `www`, `course` | `https://us.posthog.com` | PostHog UI host, used when `POSTHOG_API_HOST` is a reverse proxy. When empty, PostHog falls back to the API host |
 | `CSRF_COOKIE_DOMAIN` | N/A | N/A | The cookie domain to use in Axios when communicating with the `mit-learn` API |
+| `CSRF_COOKIE_NAME` | N/A | `csrftoken` | The name of the CSRF cookie that `mit-learn` sets; read by Axios to send the `X-CSRFToken` header |
 | `MIT_LEARN_BASE_URL` | N/A | `http://learn.odl.local:8062` | The base URL for the frontend of an instance of [`mit-learn`](https://github.com/mitodl/mit-learn) |
 | `MIT_LEARN_API_BASE_URL` | N/A | `http://learn.odl.local:8065` | The base URL for the API gateway (APISIX) of an instance of [`mit-learn`](https://github.com/mitodl/mit-learn) |
 
@@ -246,12 +247,14 @@ at the RC instances and temporarily disable CORS in your browser.
 #### MIT Learn integration
 
 One of the external API's that can be integrated into OCW sites is based on [MIT Learn](https://github.com/mitodl/mit-learn).
-There are three environment variables you can set related to this functionality;
-`CSRF_COOKIE_DOMAIN`, `MIT_LEARN_BASE_URL` and `MIT_LEARN_API_BASE_URL`. With the base URLs, the former is used to construct
+There are four environment variables you can set related to this functionality;
+`CSRF_COOKIE_DOMAIN`, `CSRF_COOKIE_NAME`, `MIT_LEARN_BASE_URL` and `MIT_LEARN_API_BASE_URL`. With the base URLs, the former is used to construct
 URLs to the login / logout pages, and the latter is used to construct calls to the API. The cookie domain setting is what
-allows CSRF to work between the sites. In the following examples, we will assume you are running `mit-learn` locally with:
+allows CSRF to work between the sites, and `CSRF_COOKIE_NAME` is the name of the CSRF cookie that `mit-learn` sets, which Axios
+reads in order to send the `X-CSRFToken` header. In the following examples, we will assume you are running `mit-learn` locally with:
 
 - `CSRF_COOKIE_DOMAIN=.odl.local`
+- `CSRF_COOKIE_NAME=csrftoken`
 - `MIT_LEARN_BASE_URL=http://open.odl.local:8062`
 - `MIT_LEARN_API_BASE_URL=http://api.open.odl.local:8065`
 

--- a/env.ts
+++ b/env.ts
@@ -166,6 +166,10 @@ const envSchema = {
     desc:       "The base URL of the MIT Learn API.",
     devDefault: "https://api.rc.learn.mit.edu"
   }),
+  CSRF_COOKIE_NAME: envalid.str({
+    desc:       "Name of the CSRF cookie set by MIT Learn; read by Axios to send the X-CSRFToken header.",
+    devDefault: "csrftoken"
+  }),
   FEATURE_ENABLE_LEARN_INTEGRATION: envalid.bool({
     desc:       "Enable MIT Learn integration (login, bookmarks, user lists)",
     devDefault: false


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11897

### Description (What does it do?)
Document the existing CSRF_COOKIE_NAME variable that is used to determine the cookie name to use for csrf when communicating with the learn API

### How can this be tested?
This is only a docs change